### PR TITLE
frontend: modularise `send` screen

### DIFF
--- a/frontends/web/src/components/forms/input.module.css
+++ b/frontends/web/src/components/forms/input.module.css
@@ -62,7 +62,7 @@
 }
 
 .errorText {
-    color: var(--color-softred);
+    color: var(--color-softred) !important;
 }
 
 .errorText > span > span {

--- a/frontends/web/src/routes/account/send/components/dialogs/confirm-wait-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/dialogs/confirm-wait-dialog.tsx
@@ -1,0 +1,169 @@
+import { useTranslation } from 'react-i18next';
+import { WaitDialog } from '../../../../../components/wait-dialog/wait-dialog';
+import { TSignProgress } from '../../types';
+import { CoinCode, ConversionUnit, FeeTargetCode, Fiat, IAmount } from '../../../../../api/account';
+import { Amount } from '../../../../../components/amount/amount';
+import { customFeeUnit } from '../../../utils';
+import style from '../../send.module.css';
+
+type TransactionStatus = {
+  isConfirming: boolean;
+  signConfirm: boolean;
+  signProgress?: TSignProgress;
+}
+
+type TransactionDetails = {
+  proposedAmount?: IAmount;
+  proposedFee?: IAmount;
+  proposedTotal?: IAmount;
+  feeTarget?: FeeTargetCode;
+  customFee: string;
+  recipientAddress: string;
+  fiatUnit: Fiat;
+}
+
+type TProps = {
+  paired?: boolean;
+  baseCurrencyUnit: ConversionUnit;
+  note: string;
+  hasSelectedUTXOs: boolean;
+  selectedUTXOs: string[];
+  coinCode: CoinCode;
+  transactionStatus: TransactionStatus;
+  transactionDetails: TransactionDetails;
+
+}
+export const ConfirmingWaitDialog = ({
+  paired,
+  baseCurrencyUnit,
+  note,
+  hasSelectedUTXOs,
+  selectedUTXOs,
+  coinCode,
+  transactionStatus,
+  transactionDetails
+}: TProps) => {
+  const { t } = useTranslation();
+  const { isConfirming, signConfirm, signProgress } = transactionStatus;
+  const {
+    proposedFee,
+    proposedAmount,
+    proposedTotal,
+    customFee,
+    feeTarget,
+    recipientAddress,
+    fiatUnit
+  } = transactionDetails;
+
+  if (!isConfirming) {
+    return null;
+  }
+
+  const confirmPrequel = (signProgress && signProgress.steps > 1) ? (
+    <span>
+      {
+        t('send.signprogress.description', {
+          steps: signProgress.steps.toString(),
+        })
+      }
+      <br />
+      {t('send.signprogress.label')}: {signProgress.step}/{signProgress.steps}
+    </span>
+  ) : undefined;
+
+  return (
+    <WaitDialog
+      title={t('send.confirm.title')}
+      prequel={confirmPrequel}
+      paired={paired}
+      touchConfirm={signConfirm}
+      includeDefault>
+      <div className={style.confirmItem}>
+        <label>{t('send.address.label')}</label>
+        <p>{recipientAddress || 'N/A'}</p>
+      </div>
+      <div className={style.confirmItem}>
+        <label>{t('send.amount.label')}</label>
+        <p>
+          <span key="proposedAmount">
+            {(proposedAmount &&
+              <Amount amount={proposedAmount.amount} unit={proposedAmount.unit}/>) || 'N/A'}
+            {' '}
+            <small>{(proposedAmount && proposedAmount.unit) || 'N/A'}</small>
+          </span>
+          {
+            proposedAmount && proposedAmount.conversions && (
+              <span>
+                <span className="text-gray"> / </span>
+                <Amount amount={proposedAmount.conversions[fiatUnit]} unit={baseCurrencyUnit}/>
+                {' '}<small>{baseCurrencyUnit}</small>
+              </span>)
+          }
+        </p>
+      </div>
+      {note ? (
+        <div className={style.confirmItem}>
+          <label>{t('note.title')}</label>
+          <p>{note}</p>
+        </div>
+      ) : null}
+      <div className={style.confirmItem}>
+        <label>{t('send.fee.label')}{feeTarget ? ' (' + t(`send.feeTarget.label.${feeTarget}`) + ')' : ''}</label>
+        <p>
+          <span key="amount">
+            {(proposedFee &&
+              <Amount amount={proposedFee.amount} unit={proposedFee.unit}/>) || 'N/A'}
+            {' '}
+            <small>{(proposedFee && proposedFee.unit) || 'N/A'}</small>
+          </span>
+          {proposedFee && proposedFee.conversions && (
+            <span key="conversation">
+              <span className="text-gray"> / </span>
+              <Amount amount={proposedFee.conversions[fiatUnit]} unit={baseCurrencyUnit}/>
+              {' '}<small>{baseCurrencyUnit}</small>
+            </span>
+          )}
+          {customFee ? (
+            <span key="customFee">
+              <br/>
+              <small>({customFee} {customFeeUnit(coinCode)})</small>
+            </span>
+          ) : null}
+        </p>
+      </div>
+      {
+        hasSelectedUTXOs && (
+          <div className={[style.confirmItem].join(' ')}>
+            <label>{t('send.confirm.selected-coins')}</label>
+            {
+              selectedUTXOs.map((uxto, i) => (
+                <p className={style.confirmationValue} key={`selectedCoin-${i}`}>{uxto}</p>
+              ))
+            }
+          </div>
+        )
+      }
+      <div className={[style.confirmItem, style.total].join(' ')}>
+        <label>{t('send.confirm.total')}</label>
+        <p>
+          <span>
+            <strong>
+              {(proposedTotal &&
+              <Amount amount={proposedTotal.amount} unit={proposedTotal.unit}/>) || 'N/A'}
+            </strong>
+            {' '}
+            <small>{(proposedTotal && proposedTotal.unit) || 'N/A'}</small>
+          </span>
+          {(proposedTotal && proposedTotal.conversions) && (
+            <span>
+              <span className="text-gray"> / </span>
+              <strong><Amount amount={proposedTotal.conversions[fiatUnit]} unit={baseCurrencyUnit}/></strong>
+              {' '}<small>{baseCurrencyUnit}</small>
+            </span>
+          )}
+        </p>
+      </div>
+    </WaitDialog>
+  )
+  ;
+};

--- a/frontends/web/src/routes/account/send/components/dialogs/message-wait-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/dialogs/message-wait-dialog.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next';
+import { Cancel, Checked } from '../../../../../components/icon/icon';
+import { WaitDialog } from '../../../../../components/wait-dialog/wait-dialog';
+
+type TProps = {
+    isShown: boolean;
+    messageType: 'sent' | 'abort';
+}
+export const MessageWaitDialog = ({ isShown, messageType }: TProps) => {
+  const { t } = useTranslation();
+
+  if (!isShown) {
+    return null;
+  }
+
+  const icons = {
+    'sent': <Checked style={{ height: 18, marginRight: '1rem' }} />,
+    'abort': <Cancel alt="Abort" style={{ height: 18, marginRight: '1rem' }} />
+  };
+
+  const messages = {
+    'sent': t('send.success'),
+    'abort': t('send.abort')
+  };
+
+  return (
+    <WaitDialog>
+      <div className="flex flex-row flex-center flex-items-center">
+        {icons[messageType]}
+        {messages[messageType]}
+      </div>
+    </WaitDialog>
+  );
+};

--- a/frontends/web/src/routes/account/send/components/dialogs/scan-qr-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/dialogs/scan-qr-dialog.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from 'react-i18next';
+import { Dialog } from '../../../../../components/dialog/dialog';
+import { Button } from '../../../../../components/forms';
+import { Spinner } from '../../../../../components/spinner/Spinner';
+import style from '../../send.module.css';
+
+type TProps = {
+    activeScanQR: boolean;
+    toggleScanQR: () => void;
+    videoLoading: boolean;
+    onLoadedVideo: () => void;
+}
+
+const DialogScanQR = ({ activeScanQR, toggleScanQR, videoLoading, onLoadedVideo }: TProps) => {
+  const { t } = useTranslation();
+  return (
+    <Dialog
+      open={activeScanQR}
+      title={t('send.scanQR')}
+      onClose={toggleScanQR}>
+      {videoLoading && <Spinner guideExists />}
+      <video
+        id="video"
+        width={400}
+        height={300 /* fix height to avoid ugly resize effect after open */}
+        className={style.qrVideo}
+        onLoadedData={onLoadedVideo} />
+      <div className={['buttons', 'flex', 'flex-row', 'flex-between'].join(' ')}>
+        <Button
+          secondary
+          onClick={toggleScanQR}>
+          {t('button.back')}
+        </Button>
+      </div>
+    </Dialog>
+  );
+};
+
+export default DialogScanQR;

--- a/frontends/web/src/routes/account/send/components/inputs/buttons-group.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/buttons-group.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next';
+import { Button, ButtonLink } from '../../../../../components/forms';
+
+type TProps = {
+    onSendButtonClick: () => void;
+    isSendButtonDisabled?: boolean;
+    accountCode: string;
+}
+
+export const ButtonsGroup = ({ onSendButtonClick, isSendButtonDisabled, accountCode }: TProps) => {
+  const { t } = useTranslation();
+  return (
+    <>
+      <Button
+        primary
+        onClick={onSendButtonClick}
+        disabled={isSendButtonDisabled}>
+        {t('send.button')}
+      </Button>
+      <ButtonLink
+        transparent
+        to={`/account/${accountCode}`}>
+        {t('button.back')}
+      </ButtonLink>
+    </>
+  );
+};

--- a/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
@@ -1,0 +1,49 @@
+import { SyntheticEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Checkbox, Input } from '../../../../../components/forms';
+import { IAmount, IBalance } from '../../../../../api/account';
+import style from '../../send.module.css';
+
+type TProps = {
+    balance?: IBalance
+    onInputChange: (e: SyntheticEvent) => void;
+    sendAll: boolean;
+    amountError?: string;
+    proposedAmount?: IAmount;
+    amount: string;
+    hasSelectedUTXOs: boolean;
+}
+
+export const CoinInput = ({
+  balance,
+  onInputChange,
+  sendAll,
+  amountError,
+  proposedAmount,
+  amount,
+  hasSelectedUTXOs
+}: TProps) => {
+  const { t } = useTranslation();
+  return (
+    <Input
+      type="number"
+      step="any"
+      min="0"
+      label={balance ? balance.available.unit : t('send.amount.label')}
+      id="amount"
+      onInput={onInputChange}
+      disabled={sendAll}
+      error={amountError}
+      value={sendAll ? (proposedAmount ? proposedAmount.amount : '') : amount}
+      placeholder={t('send.amount.placeholder')}
+      labelSection={
+        <Checkbox
+          label={t(hasSelectedUTXOs ? 'send.maximumSelectedCoins' : 'send.maximum')}
+          id="sendAll"
+          onChange={onInputChange}
+          checked={sendAll}
+          className={style.maxAmount} />
+      }
+    />
+  );
+};

--- a/frontends/web/src/routes/account/send/components/inputs/fiat-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/fiat-input.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'react-i18next';
+import { ConversionUnit } from '../../../../../api/account';
+import { Input } from '../../../../../components/forms';
+
+type TProps = {
+    label: ConversionUnit;
+    onFiatChange: (event: Event) => void;
+    disabled: boolean;
+    error?: string;
+    fiatAmount: string;
+}
+
+export const FiatInput = ({ label, onFiatChange, disabled, error, fiatAmount }: TProps) => {
+  const { t } = useTranslation();
+  return (
+    <Input
+      type="number"
+      step="any"
+      min="0"
+      label={label}
+      id="fiatAmount"
+      onInput={onFiatChange}
+      disabled={disabled}
+      error={error}
+      value={fiatAmount}
+      placeholder={t('send.amount.placeholder')}
+    />
+  );
+};

--- a/frontends/web/src/routes/account/send/components/inputs/note-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/note-input.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next';
+import { Input } from '../../../../../components/forms';
+import style from '../../send.module.css';
+
+type TProps = {
+    onNoteChange: (event: Event) => void;
+    note: string;
+}
+
+export const NoteInput = ({ onNoteChange, note }: TProps) => {
+  const { t } = useTranslation();
+  return (
+    <Input
+      label={t('note.title')}
+      labelSection={
+        <span className={style.labelDescription}>
+          {t('note.input.description')}
+        </span>
+      }
+      id="note"
+      onInput={onNoteChange}
+      value={note}
+      placeholder={t('note.input.placeholder')}
+    />
+  );
+};

--- a/frontends/web/src/routes/account/send/components/inputs/receiver-address-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/receiver-address-input.tsx
@@ -1,0 +1,61 @@
+import { SyntheticEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Input } from '../../../../../components/forms';
+import qrcodeIconDark from '../../../../../assets/icons/qrcode-dark.png';
+import qrcodeIconLight from '../../../../../assets/icons/qrcode-light.png';
+
+import style from '../../send.module.css';
+
+type TToggleScanQRButtonProps = {
+    onClick: () => void;
+}
+
+type TReceiverAddressInputProps = {
+    onClickScanQRButton: () => void;
+    hasCamera: boolean;
+    debug: boolean;
+    onClickSendToSelfButton: (e: SyntheticEvent) => void;
+    onInputChange: (e: SyntheticEvent) => void;
+    addressError?: string;
+    recipientAddress: string;
+}
+
+const ScanQRButton = ({ onClick }: TToggleScanQRButtonProps) => {
+  return (
+    <button onClick={onClick} className={style.qrButton}>
+      <img className="show-in-lightmode" src={qrcodeIconDark} />
+      <img className="show-in-darkmode" src={qrcodeIconLight} />
+    </button>);
+};
+
+export const ReceiverAddressInput = ({
+  onClickScanQRButton,
+  hasCamera,
+  debug,
+  onInputChange,
+  onClickSendToSelfButton,
+  addressError,
+  recipientAddress
+}: TReceiverAddressInputProps) => {
+  const { t } = useTranslation();
+  return (
+    <Input
+      label={t('send.address.label')}
+      placeholder={t('send.address.placeholder')}
+      id="recipientAddress"
+      error={addressError}
+      onInput={onInputChange}
+      value={recipientAddress}
+      className={hasCamera ? style.inputWithIcon : ''}
+      labelSection={debug ? (
+        <span id="sendToSelf" className={style.action} onClick={onClickSendToSelfButton}>
+        Send to self
+        </span>
+      ) : undefined}
+      autoFocus>
+      { hasCamera && (
+        <ScanQRButton onClick={onClickScanQRButton} />
+      )}
+    </Input>
+  );
+};

--- a/frontends/web/src/routes/account/send/feetargets.module.css
+++ b/frontends/web/src/routes/account/send/feetargets.module.css
@@ -117,5 +117,5 @@ select.priority {
     padding-right: var(--space-half);
     position: absolute;
     right: 0;
-    width: 56px;
+    width: auto;
 }

--- a/frontends/web/src/routes/account/send/send-guide.tsx
+++ b/frontends/web/src/routes/account/send/send-guide.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'react-i18next';
+import { isBitcoinBased, isBitcoinOnly } from '../utils';
+import { Entry } from '../../../components/guide/entry';
+import { Guide } from '../../../components/guide/guide';
+import { CoinCode } from '../../../api/account';
+
+type TProps = {
+    coinCode: CoinCode
+}
+
+export default function SendGuide({ coinCode }: TProps) {
+  const { t } = useTranslation();
+  return (
+    <Guide>
+      <Entry key="guide.send.whyFee" entry={t('guide.send.whyFee')} />
+      { isBitcoinBased(coinCode) && (
+        <Entry key="guide.send.priority" entry={t('guide.send.priority')} />
+      )}
+      { isBitcoinBased(coinCode) && (
+        <Entry key="guide.send.fee" entry={t('guide.send.fee')} />
+      )}
+      { isBitcoinOnly(coinCode) && (
+        <Entry key="guide.send.change" entry={t('guide.send.change')} />
+      )}
+      <Entry key="guide.send.revert" entry={t('guide.send.revert')} />
+      <Entry key="guide.send.plugout" entry={t('guide.send.plugout')} />
+    </Guide>
+  );
+}

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -26,7 +26,7 @@ import { getDeviceInfo } from '../../../api/bitbox01';
 import { alertUser } from '../../../components/alert/Alert';
 import A from '../../../components/anchor/anchor';
 import { Balance } from '../../../components/balance/balance';
-import { Button, ButtonLink, Input } from '../../../components/forms';
+import { Button, ButtonLink } from '../../../components/forms';
 import { Column, ColumnButtons, Grid, GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';
 import { store as fiat } from '../../../components/rates/rates';
 import { Status } from '../../../components/status/status';
@@ -46,6 +46,7 @@ import DialogScanQR from './components/dialogs/scan-qr-dialog';
 import { ReceiverAddressInput } from './components/inputs/receiver-address-input';
 import { CoinInput } from './components/inputs/coin-input';
 import { FiatInput } from './components/inputs/fiat-input';
+import { NoteInput } from './components/inputs/note-input';
 
 interface SendProps {
     accounts: accountApi.IAccount[];
@@ -705,17 +706,10 @@ class Send extends Component<Props, State> {
                       error={feeError} />
                   </Column>
                   <Column>
-                    <Input
-                      label={t('note.title')}
-                      labelSection={
-                        <span className={style.labelDescription}>
-                          {t('note.input.description')}
-                        </span>
-                      }
-                      id="note"
-                      onInput={this.handleNoteInput}
-                      value={note}
-                      placeholder={t('note.input.placeholder')} />
+                    <NoteInput
+                      note={note}
+                      onNoteChange={this.handleNoteInput}
+                    />
                     <ColumnButtons
                       className="m-top-default m-bottom-xlarge"
                       inline>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -45,6 +45,7 @@ import style from './send.module.css';
 import DialogScanQR from './components/dialogs/scan-qr-dialog';
 import { ReceiverAddressInput } from './components/inputs/receiver-address-input';
 import { CoinInput } from './components/inputs/coin-input';
+import { FiatInput } from './components/inputs/fiat-input';
 
 interface SendProps {
     accounts: accountApi.IAccount[];
@@ -680,17 +681,13 @@ class Send extends Component<Props, State> {
                     />
                   </Column>
                   <Column>
-                    <Input
-                      type="number"
-                      step="any"
-                      min="0"
-                      label={baseCurrencyUnit}
-                      id="fiatAmount"
-                      onInput={this.handleFiatInput}
+                    <FiatInput
+                      onFiatChange={this.handleFiatInput}
                       disabled={sendAll}
                       error={amountError}
-                      value={fiatAmount}
-                      placeholder={t('send.amount.placeholder')} />
+                      fiatAmount={fiatAmount}
+                      label={baseCurrencyUnit}
+                    />
                   </Column>
                 </Grid>
                 <Grid>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -26,7 +26,7 @@ import { getDeviceInfo } from '../../../api/bitbox01';
 import { alertUser } from '../../../components/alert/Alert';
 import A from '../../../components/anchor/anchor';
 import { Balance } from '../../../components/balance/balance';
-import { Button, ButtonLink, Checkbox, Input } from '../../../components/forms';
+import { Button, ButtonLink, Input } from '../../../components/forms';
 import { Column, ColumnButtons, Grid, GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';
 import { store as fiat } from '../../../components/rates/rates';
 import { Status } from '../../../components/status/status';
@@ -44,6 +44,7 @@ import { MessageWaitDialog } from './components/dialogs/message-wait-dialog';
 import style from './send.module.css';
 import DialogScanQR from './components/dialogs/scan-qr-dialog';
 import { ReceiverAddressInput } from './components/inputs/receiver-address-input';
+import { CoinInput } from './components/inputs/coin-input';
 
 interface SendProps {
     accounts: accountApi.IAccount[];
@@ -668,25 +669,15 @@ class Send extends Component<Props, State> {
                 </Grid>
                 <Grid>
                   <Column>
-                    <Input
-                      type="number"
-                      step="any"
-                      min="0"
-                      label={balance ? balance.available.unit : t('send.amount.label')}
-                      id="amount"
-                      onInput={this.handleFormChange}
-                      disabled={sendAll}
-                      error={amountError}
-                      value={sendAll ? (proposedAmount ? proposedAmount.amount : '') : amount}
-                      placeholder={t('send.amount.placeholder')}
-                      labelSection={
-                        <Checkbox
-                          label={t(this.hasSelectedUTXOs() ? 'send.maximumSelectedCoins' : 'send.maximum')}
-                          id="sendAll"
-                          onChange={this.handleFormChange}
-                          checked={sendAll}
-                          className={style.maxAmount} />
-                      } />
+                    <CoinInput
+                      balance={balance}
+                      onInputChange={this.handleFormChange}
+                      sendAll={sendAll}
+                      amountError={amountError}
+                      proposedAmount={proposedAmount}
+                      amount={amount}
+                      hasSelectedUTXOs={this.hasSelectedUTXOs()}
+                    />
                   </Column>
                   <Column>
                     <Input

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -20,9 +20,9 @@ import { BrowserQRCodeReader } from '@zxing/library';
 import * as accountApi from '../../../api/account';
 import { syncdone } from '../../../api/accountsync';
 import { BtcUnit, parseExternalBtcAmount } from '../../../api/coins';
+import { View, ViewContent } from '../../../components/view/view';
 import { TDevices } from '../../../api/devices';
 import { getDeviceInfo } from '../../../api/bitbox01';
-import { Checked, Cancel } from '../../../components/icon/icon';
 import qrcodeIconDark from '../../../assets/icons/qrcode-dark.png';
 import qrcodeIconLight from '../../../assets/icons/qrcode-light.png';
 import { alertUser } from '../../../components/alert/Alert';
@@ -34,19 +34,19 @@ import { Column, ColumnButtons, Grid, GuideWrapper, GuidedContent, Header, Main 
 import { store as fiat } from '../../../components/rates/rates';
 import { Spinner } from '../../../components/spinner/Spinner';
 import { Status } from '../../../components/status/status';
-import { WaitDialog } from '../../../components/wait-dialog/wait-dialog';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { debug } from '../../../utils/env';
 import { apiGet, apiPost } from '../../../utils/request';
 import { apiWebsocket } from '../../../utils/websocket';
 import { isBitcoinBased, findAccount } from '../utils';
 import { FeeTargets } from './feetargets';
-import style from './send.module.css';
 import { TSelectedUTXOs, UTXOs } from './utxos';
 import { route } from '../../../utils/route';
 import { UnsubscribeList, unsubscribe } from '../../../utils/subscriptions';
 import { ConfirmingWaitDialog } from './components/dialogs/confirm-wait-dialog';
-import { View, ViewContent } from '../../../components/view/view';
+import { MessageWaitDialog } from './components/dialogs/message-wait-dialog';
+import style from './send.module.css';
+
 
 interface SendProps {
     accounts: accountApi.IAccount[];
@@ -771,24 +771,8 @@ class Send extends Component<Props, State> {
                 transactionDetails={waitDialogTransactionDetails}
                 transactionStatus={waitDialogTransactionStatus}
               />
-              {
-                isSent && (
-                  <WaitDialog>
-                    <div className="flex flex-row flex-center flex-items-center">
-                      <Checked style={{ height: 18, marginRight: '1rem' }} />{t('send.success')}
-                    </div>
-                  </WaitDialog>
-                )
-              }
-              {
-                isAborted && (
-                  <WaitDialog>
-                    <div className="flex flex-row flex-center flex-items-center">
-                      <Cancel alt="Abort" style={{ height: 18, marginRight: '1rem' }} />{t('send.abort')}
-                    </div>
-                  </WaitDialog>
-                )
-              }
+              <MessageWaitDialog isShown={isSent} messageType={'sent'} />
+              <MessageWaitDialog isShown={isAborted} messageType={'abort'} />
               <Dialog
                 open={activeScanQR}
                 title={t('send.scanQR')}

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -22,7 +22,6 @@ import { syncdone } from '../../../api/accountsync';
 import { BtcUnit, parseExternalBtcAmount } from '../../../api/coins';
 import { View, ViewContent } from '../../../components/view/view';
 import { TDevices } from '../../../api/devices';
-import { getDeviceInfo } from '../../../api/bitbox01';
 import { alertUser } from '../../../components/alert/Alert';
 import A from '../../../components/anchor/anchor';
 import { Balance } from '../../../components/balance/balance';
@@ -47,7 +46,7 @@ import { CoinInput } from './components/inputs/coin-input';
 import { FiatInput } from './components/inputs/fiat-input';
 import { NoteInput } from './components/inputs/note-input';
 import { ButtonsGroup } from './components/inputs/buttons-group';
-import { getPairingStatusBB01, getTransactionStatusUpdate, txProposalErrorHandling } from './services';
+import { convertToFiatService, getPairingStatusBB01, getTransactionStatusUpdate, txProposalErrorHandling } from './services';
 
 interface SendProps {
     accounts: accountApi.IAccount[];
@@ -375,20 +374,10 @@ class Send extends Component<Props, State> {
     this.convertFromFiat(value);
   };
 
-  private convertToFiat = (value?: string | boolean) => {
-    if (value) {
-      const coinCode = this.getAccount()!.coinCode;
-      apiGet(`coins/convert-to-plain-fiat?from=${coinCode}&to=${this.state.fiatUnit}&amount=${value}`)
-        .then(data => {
-          if (data.success) {
-            this.setState({ fiatAmount: data.fiatAmount });
-          } else {
-            this.setState({ amountError: this.props.t('send.error.invalidAmount') });
-          }
-        });
-    } else {
-      this.setState({ fiatAmount: '' });
-    }
+  private convertToFiat = async (value?: string | boolean) => {
+    const coinCode = this.getAccount()!.coinCode;
+    const { fiatAmount, amountError } = await convertToFiatService(coinCode, this.state.fiatUnit, value);
+    this.setState({ fiatAmount: fiatAmount || '', amountError });
   };
 
   private convertFromFiat = (value: string) => {

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -23,8 +23,6 @@ import { BtcUnit, parseExternalBtcAmount } from '../../../api/coins';
 import { View, ViewContent } from '../../../components/view/view';
 import { TDevices } from '../../../api/devices';
 import { getDeviceInfo } from '../../../api/bitbox01';
-import qrcodeIconDark from '../../../assets/icons/qrcode-dark.png';
-import qrcodeIconLight from '../../../assets/icons/qrcode-light.png';
 import { alertUser } from '../../../components/alert/Alert';
 import A from '../../../components/anchor/anchor';
 import { Balance } from '../../../components/balance/balance';
@@ -45,7 +43,7 @@ import { ConfirmingWaitDialog } from './components/dialogs/confirm-wait-dialog';
 import { MessageWaitDialog } from './components/dialogs/message-wait-dialog';
 import style from './send.module.css';
 import DialogScanQR from './components/dialogs/scan-qr-dialog';
-
+import { ReceiverAddressInput } from './components/inputs/receiver-address-input';
 
 interface SendProps {
     accounts: accountApi.IAccount[];
@@ -657,27 +655,15 @@ class Send extends Component<Props, State> {
                 </div>
                 <Grid col="1">
                   <Column>
-                    <Input
-                      label={t('send.address.label')}
-                      placeholder={t('send.address.placeholder')}
-                      id="recipientAddress"
-                      error={addressError}
-                      onInput={this.handleFormChange}
-                      value={recipientAddress}
-                      className={hasCamera ? style.inputWithIcon : ''}
-                      labelSection={debug ? (
-                        <span id="sendToSelf" className={style.action} onClick={this.sendToSelf}>
-                        Send to self
-                        </span>
-                      ) : undefined}
-                      autoFocus>
-                      { hasCamera && (
-                        <button onClick={this.toggleScanQR} className={style.qrButton}>
-                          <img className="show-in-lightmode" src={qrcodeIconDark} />
-                          <img className="show-in-darkmode" src={qrcodeIconLight} />
-                        </button>
-                      )}
-                    </Input>
+                    <ReceiverAddressInput
+                      onClickScanQRButton={this.toggleScanQR}
+                      hasCamera={hasCamera}
+                      debug={debug}
+                      onInputChange={this.handleFormChange}
+                      onClickSendToSelfButton={this.sendToSelf}
+                      addressError={addressError}
+                      recipientAddress={recipientAddress}
+                    />
                   </Column>
                 </Grid>
                 <Grid>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -46,7 +46,7 @@ import { CoinInput } from './components/inputs/coin-input';
 import { FiatInput } from './components/inputs/fiat-input';
 import { NoteInput } from './components/inputs/note-input';
 import { ButtonsGroup } from './components/inputs/buttons-group';
-import { convertToFiatService, getPairingStatusBB01, getTransactionStatusUpdate, txProposalErrorHandling } from './services';
+import { convertFromFiatService, convertToFiatService, getPairingStatusBB01, getTransactionStatusUpdate, txProposalErrorHandling } from './services';
 
 interface SendProps {
     accounts: accountApi.IAccount[];
@@ -380,21 +380,10 @@ class Send extends Component<Props, State> {
     this.setState({ fiatAmount: fiatAmount || '', amountError });
   };
 
-  private convertFromFiat = (value: string) => {
-    if (value) {
-      const coinCode = this.getAccount()!.coinCode;
-      apiGet(`coins/convert-from-fiat?from=${this.state.fiatUnit}&to=${coinCode}&amount=${value}`)
-        .then(data => {
-          if (data.success) {
-            this.setState({ amount: data.amount });
-            this.validateAndDisplayFee(false);
-          } else {
-            this.setState({ amountError: this.props.t('send.error.invalidAmount') });
-          }
-        });
-    } else {
-      this.setState({ amount: '' });
-    }
+  private convertFromFiat = async (value: string) => {
+    const coinCode = this.getAccount()!.coinCode;
+    const { amount, amountError } = await convertFromFiatService(coinCode, this.state.fiatUnit, value);
+    this.setState({ amount: amount || '', amountError });
   };
 
   private sendToSelf = (event: React.SyntheticEvent) => {

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -26,7 +26,6 @@ import { getDeviceInfo } from '../../../api/bitbox01';
 import { alertUser } from '../../../components/alert/Alert';
 import A from '../../../components/anchor/anchor';
 import { Balance } from '../../../components/balance/balance';
-import { Button, ButtonLink } from '../../../components/forms';
 import { Column, ColumnButtons, Grid, GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';
 import { store as fiat } from '../../../components/rates/rates';
 import { Status } from '../../../components/status/status';
@@ -47,6 +46,7 @@ import { ReceiverAddressInput } from './components/inputs/receiver-address-input
 import { CoinInput } from './components/inputs/coin-input';
 import { FiatInput } from './components/inputs/fiat-input';
 import { NoteInput } from './components/inputs/note-input';
+import { ButtonsGroup } from './components/inputs/buttons-group';
 
 interface SendProps {
     accounts: accountApi.IAccount[];
@@ -713,17 +713,11 @@ class Send extends Component<Props, State> {
                     <ColumnButtons
                       className="m-top-default m-bottom-xlarge"
                       inline>
-                      <Button
-                        primary
-                        onClick={this.send}
-                        disabled={this.sendDisabled() || !valid || isUpdatingProposal}>
-                        {t('send.button')}
-                      </Button>
-                      <ButtonLink
-                        transparent
-                        to={`/account/${code}`}>
-                        {t('button.back')}
-                      </ButtonLink>
+                      <ButtonsGroup
+                        onSendButtonClick={this.send}
+                        accountCode={code}
+                        isSendButtonDisabled={this.sendDisabled() || !valid || isUpdatingProposal}
+                      />
                     </ColumnButtons>
                   </Column>
                 </Grid>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -28,11 +28,9 @@ import qrcodeIconLight from '../../../assets/icons/qrcode-light.png';
 import { alertUser } from '../../../components/alert/Alert';
 import A from '../../../components/anchor/anchor';
 import { Balance } from '../../../components/balance/balance';
-import { Dialog } from '../../../components/dialog/dialog';
 import { Button, ButtonLink, Checkbox, Input } from '../../../components/forms';
 import { Column, ColumnButtons, Grid, GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';
 import { store as fiat } from '../../../components/rates/rates';
-import { Spinner } from '../../../components/spinner/Spinner';
 import { Status } from '../../../components/status/status';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { debug } from '../../../utils/env';
@@ -46,6 +44,7 @@ import { UnsubscribeList, unsubscribe } from '../../../utils/subscriptions';
 import { ConfirmingWaitDialog } from './components/dialogs/confirm-wait-dialog';
 import { MessageWaitDialog } from './components/dialogs/message-wait-dialog';
 import style from './send.module.css';
+import DialogScanQR from './components/dialogs/scan-qr-dialog';
 
 
 interface SendProps {
@@ -773,25 +772,12 @@ class Send extends Component<Props, State> {
               />
               <MessageWaitDialog isShown={isSent} messageType={'sent'} />
               <MessageWaitDialog isShown={isAborted} messageType={'abort'} />
-              <Dialog
-                open={activeScanQR}
-                title={t('send.scanQR')}
-                onClose={this.toggleScanQR}>
-                {videoLoading && <Spinner guideExists />}
-                <video
-                  id="video"
-                  width={400}
-                  height={300 /* fix height to avoid ugly resize effect after open */}
-                  className={style.qrVideo}
-                  onLoadedData={this.handleVideoLoad} />
-                <div className={['buttons', 'flex', 'flex-row', 'flex-between'].join(' ')}>
-                  <Button
-                    secondary
-                    onClick={this.toggleScanQR}>
-                    {t('button.back')}
-                  </Button>
-                </div>
-              </Dialog>
+              <DialogScanQR
+                activeScanQR={activeScanQR}
+                onLoadedVideo={this.handleVideoLoad}
+                toggleScanQR={this.toggleScanQR}
+                videoLoading={videoLoading}
+              />
             </View>
           </Main>
         </GuidedContent>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -47,6 +47,7 @@ import { FiatInput } from './components/inputs/fiat-input';
 import { NoteInput } from './components/inputs/note-input';
 import { ButtonsGroup } from './components/inputs/buttons-group';
 import { convertFromFiatService, convertToFiatService, getPairingStatusBB01, getSelfSendAddress, getTransactionStatusUpdate, txProposalErrorHandling } from './services';
+import SendGuide from './send-guide';
 
 interface SendProps {
     accounts: accountApi.IAccount[];
@@ -690,6 +691,7 @@ class Send extends Component<Props, State> {
             </View>
           </Main>
         </GuidedContent>
+        <SendGuide coinCode={account.coinCode} />
       </GuideWrapper>
 
     );

--- a/frontends/web/src/routes/account/send/services.ts
+++ b/frontends/web/src/routes/account/send/services.ts
@@ -18,6 +18,18 @@ export const convertToFiatService = async (coinCode: string, fiatUnit: Fiat, val
   return { fiatAmount: data.fiatAmount as string };
 };
 
+export const convertFromFiatService = async (coinCode: string, fiatUnit: Fiat, value?: string | boolean) => {
+  const { t } = i18n;
+  const data = value ? await apiGet(`coins/convert-from-fiat?from=${fiatUnit}&to=${coinCode}&amount=${value}`) : null;
+  if (!data) {
+    return { amount: '' };
+  }
+  if (!data.success) {
+    return { amountError: t('send.error.invalidAmount') };
+  }
+  return { amount: data.amount as string };
+};
+
 export const getPairingStatusBB01 = async (deviceID: string, mobileChannel: boolean, account?: IAccount) => {
   try {
     const { pairing } = await getDeviceInfo(deviceID);

--- a/frontends/web/src/routes/account/send/services.ts
+++ b/frontends/web/src/routes/account/send/services.ts
@@ -1,6 +1,21 @@
 import { i18n } from '../../../i18n/i18n';
 import { alertUser } from '../../../components/alert/Alert';
 import { TPayload } from '../../../utils/websocket';
+import { getDeviceInfo } from '../../../api/bitbox01';
+import { isBitcoinBased } from '../utils';
+import { IAccount } from '../../../api/account';
+
+export const getPairingStatusBB01 = async (deviceID: string, mobileChannel: boolean, account?: IAccount) => {
+  try {
+    const { pairing } = await getDeviceInfo(deviceID);
+    const paired = mobileChannel && pairing;
+    const noMobileChannelError = pairing && !mobileChannel && account && isBitcoinBased(account.coinCode);
+    return { paired, noMobileChannelError };
+  } catch (error) {
+    console.error(error);
+    return {};
+  }
+};
 
 export const getTransactionStatusUpdate = (payload: TPayload) => {
   let statusUpdate = {};

--- a/frontends/web/src/routes/account/send/services.ts
+++ b/frontends/web/src/routes/account/send/services.ts
@@ -1,5 +1,24 @@
-import { alertUser } from '../../../components/alert/Alert';
 import { i18n } from '../../../i18n/i18n';
+import { alertUser } from '../../../components/alert/Alert';
+import { TPayload } from '../../../utils/websocket';
+
+export const getTransactionStatusUpdate = (payload: TPayload) => {
+  let statusUpdate = {};
+  if ('type' in payload) {
+    const { data, meta, type } = payload;
+    if (type === 'device') {
+      switch (data) {
+      case 'signProgress':
+        statusUpdate = { signProgress: meta, signConfirm: false };
+        break;
+      case 'signConfirm':
+        statusUpdate = { signConfirm: true };
+        break;
+      }
+    }
+  }
+  return statusUpdate;
+};
 
 export const txProposalErrorHandling = (errorCode: string, registerEvents: () => void, unregisterEvents: () => void) => {
   const { t } = i18n;

--- a/frontends/web/src/routes/account/send/services.ts
+++ b/frontends/web/src/routes/account/send/services.ts
@@ -3,7 +3,20 @@ import { alertUser } from '../../../components/alert/Alert';
 import { TPayload } from '../../../utils/websocket';
 import { getDeviceInfo } from '../../../api/bitbox01';
 import { isBitcoinBased } from '../utils';
-import { IAccount } from '../../../api/account';
+import { Fiat, IAccount } from '../../../api/account';
+import { apiGet } from '../../../utils/request';
+
+export const convertToFiatService = async (coinCode: string, fiatUnit: Fiat, value?: string | boolean) => {
+  const { t } = i18n;
+  const data = value ? await apiGet(`coins/convert-to-plain-fiat?from=${coinCode}&to=${fiatUnit}&amount=${value}`) : null;
+  if (!data) {
+    return { fiatAmount: '' };
+  }
+  if (!data.success) {
+    return { amountError: t('send.error.invalidAmount') };
+  }
+  return { fiatAmount: data.fiatAmount as string };
+};
 
 export const getPairingStatusBB01 = async (deviceID: string, mobileChannel: boolean, account?: IAccount) => {
   try {

--- a/frontends/web/src/routes/account/send/services.ts
+++ b/frontends/web/src/routes/account/send/services.ts
@@ -1,0 +1,28 @@
+import { alertUser } from '../../../components/alert/Alert';
+import { i18n } from '../../../i18n/i18n';
+
+export const txProposalErrorHandling = (errorCode: string, registerEvents: () => void, unregisterEvents: () => void) => {
+  const { t } = i18n;
+  let errorHandling = {};
+  let transactionDetails = {};
+  switch (errorCode) {
+  case 'invalidAddress':
+    errorHandling = { addressError: t('send.error.invalidAddress') };
+    break;
+  case 'invalidAmount':
+  case 'insufficientFunds':
+    errorHandling = { amountError: t(`send.error.${errorCode}`) };
+    transactionDetails = { proposedFee: undefined };
+    break;
+  case 'feeTooLow':
+  case 'feesNotAvailable':
+    errorHandling = { feeError: t(`send.error.${errorCode}`) };
+    break;
+  default:
+    if (errorCode) {
+      unregisterEvents();
+      alertUser(errorCode, { callback: registerEvents });
+    }
+  }
+  return { errorHandling, transactionDetails };
+};

--- a/frontends/web/src/routes/account/send/services.ts
+++ b/frontends/web/src/routes/account/send/services.ts
@@ -3,7 +3,7 @@ import { alertUser } from '../../../components/alert/Alert';
 import { TPayload } from '../../../utils/websocket';
 import { getDeviceInfo } from '../../../api/bitbox01';
 import { isBitcoinBased } from '../utils';
-import { Fiat, IAccount } from '../../../api/account';
+import { Fiat, IAccount, getReceiveAddressList } from '../../../api/account';
 import { apiGet } from '../../../utils/request';
 
 export const convertToFiatService = async (coinCode: string, fiatUnit: Fiat, value?: string | boolean) => {
@@ -39,6 +39,19 @@ export const getPairingStatusBB01 = async (deviceID: string, mobileChannel: bool
   } catch (error) {
     console.error(error);
     return {};
+  }
+};
+
+export const getSelfSendAddress = async (accountCode: string): Promise<string | null> => {
+  try {
+    const receiveAddresses = await getReceiveAddressList(accountCode)();
+    if (receiveAddresses && receiveAddresses.length > 0 && receiveAddresses[0].addresses.length > 1) {
+      return receiveAddresses[0].addresses[0].address;
+    }
+    return null;
+  } catch (error) {
+    console.error(error);
+    return null;
   }
 };
 

--- a/frontends/web/src/routes/account/send/types.ts
+++ b/frontends/web/src/routes/account/send/types.ts
@@ -1,0 +1,5 @@
+export type TSignProgress = {
+    steps: number;
+    step: number;
+  }
+


### PR DESCRIPTION
An effort to modularise `send.tsx` ("inspired" from #2171). Doing so by:
1. breaking it down into several components,
2. created helper function / services.
3. using the `View` component (and the `GuidedWrapper`, `GuidedContent`,etc).


 Please refer to each commit as each commit contains the changes per created component / helper function :) 

In short, here are the changes:

1. created ConfirmWaitDialog component ->  #2193
1. using GuidedContent and View for send screen -> #2193 
2. created and used MessageWaitDialog for send screen -> #2199 
3. created ScanQRDialog component for send screen -> #2206 
4. created ReceiverAddressInput component for send screen -> #2213 
5. created CoinInput component for send screen -> #2221 
6. created FiatInput component for send screen -> #2321 
7. created NoteInput component for send screen -> #2345 
8. created ButtonsGroup component for send screen -> #2353 
9. extracted txProposal error handling into a function -> #2421 
10. extracted getTransactionStatusUpdate as a standalone fn
11. extracted update pairing status fn for bb01 into a fn
12. extracted convertToFiat into a fn
13. extracted convertFromFiat into a fn
14. extracted getSelfSendAddress into a fn
15. created guide component for send screen ->  #2193