### PR TITLE
frontend: add eslint rule restrict-template-expressions

### DIFF
--- a/frontends/web/.eslintrc.json
+++ b/frontends/web/.eslintrc.json
@@ -59,6 +59,7 @@
       "files": ["**/*.ts?(x)"],
       "rules": {
         "@typescript-eslint/restrict-template-expressions": ["error", {
+          "allowNumber": true,
           "allowAny": false,
           "allowBoolean": false,
           "allowNullish": false

--- a/frontends/web/.eslintrc.json
+++ b/frontends/web/.eslintrc.json
@@ -57,7 +57,16 @@
   "overrides": [
     {
       "files": ["**/*.ts?(x)"],
-      "rules": { }
+      "rules": {
+        "@typescript-eslint/restrict-template-expressions": ["error", {
+          "allowAny": false,
+          "allowBoolean": false,
+          "allowNullish": false
+        }]
+      },
+      "parserOptions": {
+        "project": ["./tsconfig.json"]
+      }
     },
     {
       "files": ["**/*.test.ts?(x)"],

--- a/frontends/web/src/api/subscribe.ts
+++ b/frontends/web/src/api/subscribe.ts
@@ -42,7 +42,7 @@ export const subscribeEndpoint = <T>(
         .catch(console.error);
       break;
     default:
-      throw new Error(`Event: ${event} not supported`);
+      throw new Error(`Event: ${JSON.stringify(event)} not supported`);
     }
   });
 };

--- a/frontends/web/src/components/forms/select.tsx
+++ b/frontends/web/src/components/forms/select.tsx
@@ -41,7 +41,7 @@ export const Select = ({
       <select id={id} {...props}>
         {options.map(({ value, text, disabled = false }) => (
           <option
-            key={`${value}`}
+            key={String(value)}
             value={value}
             disabled={disabled}
           >

--- a/frontends/web/src/components/icon/logo.module.css
+++ b/frontends/web/src/components/icon/logo.module.css
@@ -9,16 +9,8 @@
     width: 100% !important;
 }
 
-.swissOpenSource.large {
-    max-width: 280px !important;
-}
-
 @media (max-width: 768px) {
     .swissOpenSource {
         max-width: 180px !important;
-    }
-
-    .swissOpenSource.large {
-        max-width: 210px !important;
     }
 }

--- a/frontends/web/src/components/icon/logo.tsx
+++ b/frontends/web/src/components/icon/logo.tsx
@@ -56,23 +56,22 @@ import PAXG_GREY from './assets/paxg-white.svg';
 import ShiftLogo from './assets/shift-cryptosecurity-logo.svg';
 import style from './logo.module.css';
 
-interface GenericProps {
-    [property: string]: any;
-}
 
-export const BitBox = (props: GenericProps) => <img {...props} draggable={false} src={BitBoxLogo} alt="BitBox" className={style.logo} />;
-export const BitBox02 = (props: GenericProps) => <img {...props} draggable={false} src={BitBox02Logo} alt="BitBox02" className={style.logo} />;
-export const BitBox02Inverted = (props: GenericProps) => <img {...props} draggable={false} src={BitBox02InvertedLogo} alt="BitBox02" className={style.logo} />;
-export const AppLogo = (props: GenericProps) => <img {...props} draggable={false} src={AppLogoImg} alt="BitBox" className={style.logo} />;
-export const AppLogoInverted = (props: GenericProps) => <img {...props} draggable={false} src={AppLogoInvertedImg} alt="BitBox" className={style.logo} />;
-export const BitBoxSwiss = (props: GenericProps) => <img {...props} draggable={false} src={BitBoxSwissLogo} alt="BitBox" className={style.logo} />;
-export const BitBoxSwissInverted = (props: GenericProps) => <img {...props} draggable={false} src={BitBoxSwissInvertedLogo} alt="BitBox" className={style.logo} />;
-export const Shift = (props: GenericProps) => <img {...props} draggable={false} src={ShiftLogo} alt="Shift Crypto" className={style.logo} />;
-export const SwissMadeOpenSource = ({ large: boolean, className, ...props }: GenericProps) => <img {...props} draggable={false} src={SwissOpenSourceLight} alt="Swiss Made Open Source" className={`${style.swissOpenSource} ${props.large ? style.large : ''} ${className ? className : ''}`} />;
-export const SwissMadeOpenSourceDark = ({ large: boolean, className, ...props }: GenericProps) => <img {...props} draggable={false} src={SwissOpenSourceDark} alt="Swiss Made Open Source" className={`${style.swissOpenSource} ${props.large ? style.large : ''} ${className ? className : ''}`} />;
+type ImgProps = JSX.IntrinsicElements['img'];
+
+export const BitBox = (props: ImgProps) => <img {...props} draggable={false} src={BitBoxLogo} alt="BitBox" className={style.logo} />;
+export const BitBox02 = (props: ImgProps) => <img {...props} draggable={false} src={BitBox02Logo} alt="BitBox02" className={style.logo} />;
+export const BitBox02Inverted = (props: ImgProps) => <img {...props} draggable={false} src={BitBox02InvertedLogo} alt="BitBox02" className={style.logo} />;
+export const AppLogo = (props: ImgProps) => <img {...props} draggable={false} src={AppLogoImg} alt="BitBox" className={style.logo} />;
+export const AppLogoInverted = (props: ImgProps) => <img {...props} draggable={false} src={AppLogoInvertedImg} alt="BitBox" className={style.logo} />;
+export const BitBoxSwiss = (props: ImgProps) => <img {...props} draggable={false} src={BitBoxSwissLogo} alt="BitBox" className={style.logo} />;
+export const BitBoxSwissInverted = (props: ImgProps) => <img {...props} draggable={false} src={BitBoxSwissInvertedLogo} alt="BitBox" className={style.logo} />;
+export const Shift = (props: ImgProps) => <img {...props} draggable={false} src={ShiftLogo} alt="Shift Crypto" className={style.logo} />;
+export const SwissMadeOpenSource = ({ className, ...props }: ImgProps) => <img {...props} draggable={false} src={SwissOpenSourceLight} alt="Swiss Made Open Source" className={`${style.swissOpenSource} ${className ? className : ''}`} />;
+export const SwissMadeOpenSourceDark = ({ className, ...props }: ImgProps) => <img {...props} draggable={false} src={SwissOpenSourceDark} alt="Swiss Made Open Source" className={`${style.swissOpenSource} ${className ? className : ''}`} />;
 
 type LogoMap = {
-    [key in CoinCode]: string[];
+  [key in CoinCode]: string[];
 }
 
 const logoMap: LogoMap = {
@@ -96,12 +95,12 @@ const logoMap: LogoMap = {
   'eth-erc20-paxg': [PAXG, PAXG_GREY],
 };
 
-interface Props {
-    active?: boolean;
-    alt?: string;
-    className?: string;
-    coinCode: CoinCode;
-    stacked?: boolean;
+type LogoProps = {
+  active?: boolean;
+  alt?: string;
+  className?: string;
+  coinCode: CoinCode;
+  stacked?: boolean;
 }
 
 export const Logo = ({
@@ -109,7 +108,7 @@ export const Logo = ({
   active,
   stacked,
   ...rest
-}: Props) => {
+}: LogoProps) => {
   if (!logoMap[coinCode]) {
     console.error('logo undefined for ', coinCode);
     return null;

--- a/frontends/web/src/contexts/WCWeb3WalletProvider.tsx
+++ b/frontends/web/src/contexts/WCWeb3WalletProvider.tsx
@@ -23,8 +23,8 @@ import { useLoad } from '@/hooks/api';
 import { getConfig, setConfig } from '@/utils/config';
 
 type TProps = {
-    children: ReactNode;
-  }
+  children: ReactNode;
+}
 
 export const WCWeb3WalletProvider = ({ children }: TProps) => {
   const { t } = useTranslation();
@@ -83,13 +83,13 @@ export const WCWeb3WalletProvider = ({ children }: TProps) => {
       }
       await web3wallet?.core.pairing.pair({ uri });
       setConfig({ frontend: { hasUsedWalletConnect: true } });
-    } catch (e: any) {
-      console.error(`Wallet connect attempt to pair error ${e}`);
-      if (e.message.includes('Pairing already exists')) {
+    } catch (error: any) {
+      console.error('Wallet connect attempt to pair error', error);
+      if (error?.message?.includes('Pairing already exists')) {
         throw new Error(t('walletConnect.useNewUri'));
       }
       //unexpected error, display native error message
-      throw new Error(e.message);
+      throw new Error(error.message);
     }
   };
 

--- a/frontends/web/src/i18n/i18n.test.tsx
+++ b/frontends/web/src/i18n/i18n.test.tsx
@@ -39,7 +39,7 @@ describe('i18n', () => {
       { nativeLocale: 'fr', newLang: 'en', userLang: 'en' },
     ];
     table.forEach((test) => {
-      it(`sets userLanguage to ${test.userLang} if native-locale is ${test.nativeLocale}`, async () => {
+      it(`sets userLanguage to ${test.userLang || 'null'} if native-locale is ${test.nativeLocale}`, async () => {
         (apiGet as Mock).mockImplementation(endpoint => {
           switch (endpoint) {
           case 'config': { return Promise.resolve({}); }

--- a/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
@@ -54,14 +54,16 @@ export const BuyReceiveCTA = ({
   const isMobile = useMediaQuery('(max-width: 768px)');
 
   const onExchangeCTA = () => navigate(code ? `/exchange/info/${code}` : '/exchange/info');
-  const onWalletConnect = () => navigate(`/account/${code}/wallet-connect/dashboard`);
+  const onWalletConnect = () => code && navigate(`/account/${code}/wallet-connect/dashboard`);
   const onReceiveCTA = () => {
     if (balanceList) {
       if (balanceList.length > 1) {
         navigate('/accounts/select-receive');
         return;
       }
-      navigate(`/account/${code}/receive`);
+      if (code) {
+        navigate(`/account/${code}/receive`);
+      }
     }
   };
 

--- a/frontends/web/src/routes/account/info/info.tsx
+++ b/frontends/web/src/routes/account/info/info.tsx
@@ -28,8 +28,8 @@ import { Status } from '@/components/status/status';
 import style from './info.module.css';
 
 type TProps = {
-    accounts: IAccount[];
-    code: AccountCode;
+  accounts: IAccount[];
+  code: AccountCode;
 };
 
 export const Info = ({
@@ -57,6 +57,8 @@ export const Info = ({
     setViewXPub((viewXPub + 1) % numberOfXPubs);
   };
 
+  const xpubType = xpubTypes[(viewXPub + 1) % numberOfXPubs];
+
   return (
     <div className="contentWithGuide">
       <div className="container">
@@ -75,10 +77,13 @@ export const Info = ({
                     current: `${viewXPub + 1}`,
                     numberOfXPubs: numberOfXPubs.toString(),
                     scriptType: config.bitcoinSimple.scriptType.toUpperCase(),
-                  })}<br />
-                  <button className={style.nextButton} onClick={showNextXPub}>
-                    {t(`accountInfo.xpubTypeChangeBtn.${xpubTypes[(viewXPub + 1) % numberOfXPubs]}`)}
-                  </button>
+                  })}
+                  <br />
+                  {xpubType && (
+                    <button className={style.nextButton} onClick={showNextXPub}>
+                      {t(`accountInfo.xpubTypeChangeBtn.${xpubType}`)}
+                    </button>
+                  )}
                 </p>
               ) : null}
               { (config.bitcoinSimple?.scriptType === 'p2tr') ? (

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -26,22 +26,21 @@ import { customFeeUnit, getCoinCode, isEthereumBased } from '@/routes/account/ut
 import style from './feetargets.module.css';
 
 type Props = {
-    accountCode: accountApi.AccountCode;
-    coinCode: accountApi.CoinCode;
-    disabled: boolean;
-    fiatUnit: accountApi.ConversionUnit;
-    proposedFee?: accountApi.IAmount;
-    customFee: string;
-    showCalculatingFeeLabel?: boolean;
-    onFeeTargetChange: (code: accountApi.FeeTargetCode) => void;
-    onCustomFee: (customFee: string) => void;
-    error?: string;
+  accountCode: accountApi.AccountCode;
+  coinCode: accountApi.CoinCode;
+  disabled: boolean;
+  fiatUnit: accountApi.ConversionUnit;
+  proposedFee?: accountApi.IAmount;
+  customFee: string;
+  showCalculatingFeeLabel?: boolean;
+  onFeeTargetChange: (code: accountApi.FeeTargetCode) => void;
+  onCustomFee: (customFee: string) => void;
+  error?: string;
 }
 
-
 type TOptions = {
-    value: accountApi.FeeTargetCode;
-    text: string;
+  value: accountApi.FeeTargetCode;
+  text: string;
 }
 
 export const FeeTargets = ({
@@ -113,7 +112,8 @@ export const FeeTargets = ({
       return '';
     }
     const { amount, unit, conversions } = proposedFee;
-    return `${amount} ${unit} ${conversions ? ` = ${conversions[fiatUnit]} ${fiatUnit}` : ''}`;
+    const conversion = (conversions && conversions[fiatUnit]) ? ` = ${conversions[fiatUnit]} ${fiatUnit}` : '';
+    return `${amount} ${unit} ${conversion}`;
   };
 
   if (options === null) {

--- a/frontends/web/src/routes/account/walletconnect/components/incoming-pairing/incoming-pairing.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/incoming-pairing/incoming-pairing.tsx
@@ -96,9 +96,8 @@ export const WCIncomingPairing = ({
 
       onApprove();
     } catch (e: any) {
-      console.error(`Wallet connect approve pairing error ${e}`);
+      console.error('Wallet connect approve pairing error', e);
 
-      console.error(e);
       if (e.message.includes('Non conforming namespaces')) {
         alertUser(t('walletConnect.invalidPairingChain',
           {

--- a/frontends/web/src/routes/device/bitbox01/restore.tsx
+++ b/frontends/web/src/routes/device/bitbox01/restore.tsx
@@ -98,9 +98,11 @@ class Restore extends Component<Props, State> {
           route('/', true);
         }
       } else {
-        alertUser(this.props.t(`backup.restore.error.e${code}`, {
-          defaultValue: errorMessage,
-        }));
+        if (typeof code === 'string') {
+          alertUser(this.props.t(`backup.restore.error.e${code}`, {
+            defaultValue: errorMessage,
+          }));
+        }
       }
     });
   };

--- a/frontends/web/src/routes/device/bitbox01/settings/components/mobile-pairing.tsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/mobile-pairing.tsx
@@ -29,20 +29,20 @@ import { apiPost } from '../../../../../utils/request';
 import { A } from '../../../../../components/anchor/anchor';
 import style from '../../bitbox01.module.css';
 
-interface PairingProps {
-    deviceID: string;
-    deviceLocked: boolean;
-    paired: boolean;
-    hasMobileChannel: boolean;
-    onPairingEnabled: () => void;
+type PairingProps = {
+  deviceID: string;
+  deviceLocked: boolean;
+  paired: boolean;
+  hasMobileChannel: boolean;
+  onPairingEnabled: () => void;
 }
 
 type Props = PairingProps & TranslateProps;
 
-interface State {
-    channel: string | null;
-    status: string | boolean;
-    showQRCode: boolean;
+type State = {
+  channel: string | null;
+  status: string | false;
+  showQRCode: boolean;
 }
 
 class MobilePairing extends Component<Props, State> {
@@ -206,14 +206,14 @@ class MobilePairing extends Component<Props, State> {
       );
     } else if (status === 'connectOnly') {
       content = (<QRCode tapToCopy={false} data={JSON.stringify({ channel, connectOnly: true })} />);
-    } else {
+    } else if (status) {
       content = (<p className="m-top-none">{t(`pairing.${status}.text`)}</p>);
     }
     return (
       <div>
         <SettingsButton
           onClick={hasMobileChannel && !paired ? this.reconnectUnpaired : this.startPairing}
-          optionalText={t(`deviceSettings.pairing.status.${paired}`)}>
+          optionalText={t(`deviceSettings.pairing.status.${paired ? 'true' : 'false' }`)}>
           { deviceLocked ? (
             hasMobileChannel ? t('pairing.reconnectOnly.button') : t('pairing.connectOnly.button')
           ) : (

--- a/frontends/web/src/routes/device/bitbox01/setup/goal.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/goal.jsx
@@ -49,7 +49,7 @@ class Goal extends Component {
                 </div>
               </div>
               <div className="text-center m-top-large">
-                {getDarkmode() ? <SwissMadeOpenSourceDark large /> : <SwissMadeOpenSource large />}
+                {getDarkmode() ? <SwissMadeOpenSourceDark /> : <SwissMadeOpenSource />}
               </div>
             </div>
           </div>

--- a/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
@@ -105,13 +105,15 @@ class Initialize extends Component<Props, State> {
       formSubmissionState = <Message type="info">{t('initialize.creating')}</Message>;
       break;
     case stateEnum.ERROR:
-      formSubmissionState = (
-        <Message type="error">
-          {t(`initialize.error.e${errorCode}`, {
-            defaultValue: errorMessage,
-          })}
-        </Message>
-      );
+      if (errorCode !== null) {
+        formSubmissionState = (
+          <Message type="error">
+            {t(`initialize.error.e${errorCode}`, {
+              defaultValue: errorMessage,
+            })}
+          </Message>
+        );
+      }
     }
 
     const content = showInfo ? (
@@ -170,7 +172,7 @@ class Initialize extends Component<Props, State> {
               {formSubmissionState}
               {content}
               <div className="text-center m-top-large">
-                {getDarkmode() ? <SwissMadeOpenSourceDark large /> : <SwissMadeOpenSource large />}
+                {getDarkmode() ? <SwissMadeOpenSourceDark /> : <SwissMadeOpenSource />}
               </div>
             </div>
           </div>

--- a/frontends/web/src/routes/device/bitbox01/setup/security-information.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/security-information.tsx
@@ -25,16 +25,16 @@ import { SimpleMarkup } from '../../../../utils/markup';
 import { getDarkmode } from '../../../../components/darkmode/darkmode';
 import style from '../bitbox01.module.css';
 
-interface SecurityInformationProps {
-    goBack: () => void;
-    goal: string | null;
-    children: ReactNode;
+type SecurityInformationProps = {
+  goBack: () => void;
+  goal: string | null;
+  children: ReactNode;
 }
 
 type Props = SecurityInformationProps & TranslateProps;
 
-interface State {
-    showInfo: boolean;
+type State = {
+  showInfo: boolean;
 }
 
 class SecurityInformation extends Component<Props, State> {
@@ -63,7 +63,9 @@ class SecurityInformation extends Component<Props, State> {
           </Header>
           <div className="innerContainer">
             <div className="content padded narrow isVerticallyCentered">
-              <h1 className={[style.title, 'text-center'].join(' ')}>{t(`securityInformation.${goal}.title`)}</h1>
+              <h1 className={[style.title, 'text-center'].join(' ')}>
+                {goal && t(`securityInformation.${goal}.title`)}
+              </h1>
               {
                 goal === 'create' ? (
                   <div className="box large">
@@ -110,7 +112,7 @@ class SecurityInformation extends Component<Props, State> {
                 )
               }
               <div className="text-center m-top-large">
-                {getDarkmode() ? <SwissMadeOpenSourceDark large /> : <SwissMadeOpenSource large />}
+                {getDarkmode() ? <SwissMadeOpenSourceDark /> : <SwissMadeOpenSource />}
               </div>
             </div>
           </div>

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
@@ -250,7 +250,7 @@ class SeedCreateNew extends Component {
               }
               {content}
               <div className="text-center m-top-large">
-                {getDarkmode() ? <SwissMadeOpenSourceDark large /> : <SwissMadeOpenSource large />}
+                {getDarkmode() ? <SwissMadeOpenSourceDark /> : <SwissMadeOpenSource />}
               </div>
             </div>
           </div>

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
@@ -147,7 +147,7 @@ class SeedRestore extends Component {
                 )
               }
               <div className="text-center m-top-large">
-                {getDarkmode() ? <SwissMadeOpenSourceDark large /> : <SwissMadeOpenSource large />}
+                {getDarkmode() ? <SwissMadeOpenSourceDark /> : <SwissMadeOpenSource />}
               </div>
             </div>
           </div>

--- a/frontends/web/src/routes/device/bitbox01/setup/success.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/success.jsx
@@ -66,7 +66,7 @@ class Success extends Component {
                 </div>
               </div>
               <div className="text-center m-top-large">
-                {getDarkmode() ? <SwissMadeOpenSourceDark large /> : <SwissMadeOpenSource large />}
+                {getDarkmode() ? <SwissMadeOpenSourceDark /> : <SwissMadeOpenSource />}
               </div>
             </div>
           </div>

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -64,9 +64,11 @@ export const Passphrase = ({ deviceID }: TProps) => {
       const result = await setMnemonicPassphraseEnabled(deviceID, enabled);
       if (!result.success) {
         navigate(-1);
-        alertUser(t(`passphrase.error.e${result.code}`, {
-          defaultValue: result.message || t('genericError'),
-        }));
+        if (result.code) {
+          alertUser(t(`passphrase.error.e${result.code}`, {
+            defaultValue: result.message || t('genericError'),
+          }));
+        }
         return null;
       }
       setIsEnabled(enabled);

--- a/frontends/web/src/routes/device/bitbox02/setup/name.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/name.tsx
@@ -105,7 +105,7 @@ export const DeviceNameErrorMessage = ({ error, invalidChars }: TDeviceNameError
   }
   return (
     <span hidden={!error} className={style.errorMessage}>
-      {t(`bitbox02Wizard.stepCreate.error.${error}`, {
+      {error && t(`bitbox02Wizard.stepCreate.error.${error}`, {
         invalidChars
       })}
       {' '}

--- a/frontends/web/src/routes/settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -28,7 +28,8 @@ export const DefaultCurrencyDropdownSetting = () => {
   const { formattedCurrencies, currenciesWithDisplayName } = useLocalizedFormattedCurrencies(i18n.language);
   const { addToActiveCurrencies, updateDefaultCurrency, defaultCurrency, activeCurrencies } = useContext(RatesContext);
   const valueLabel = currenciesWithDisplayName.find(fiat => fiat.currency === defaultCurrency)?.displayName;
-  const defaultValueLabel = valueLabel ? `${currencyName.of(defaultCurrency)} (${defaultCurrency})` : defaultCurrency;
+  const currencyNameOfDefaultCurrency = currencyName.of(defaultCurrency) || '';
+  const defaultValueLabel = valueLabel ? `${currencyNameOfDefaultCurrency} (${defaultCurrency})` : defaultCurrency;
 
   return (
     <SettingsItem

--- a/frontends/web/src/routes/settings/components/appearance/languageDropdownSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/languageDropdownSetting.tsx
@@ -38,7 +38,7 @@ export const LanguageDropdownSetting = () => {
       settingName={<div className={styles.container}>{globe}{t('newSettings.appearance.language.title')}</div>}
       secondaryText={t('newSettings.appearance.language.description')}
       collapseOnSmall
-      title={`Detected native locale: ${nativeLocale}`}
+      title={nativeLocale && `Detected native locale: ${nativeLocale}`}
       extraComponent={
         <Dropdown
           className={settingsDropdownStyles.select}

--- a/frontends/web/src/routes/settings/components/device-settings/attestation-check-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/attestation-check-setting.tsx
@@ -44,7 +44,7 @@ const AttestationCheckSetting = ({ deviceID }: TProps) => {
       settingName={t('deviceSettings.hardware.attestation.label')}
       secondaryText={t('deviceSettings.deviceInformation.attestation.description')}
       extraComponent={icon}
-      displayedValue={t(`deviceSettings.hardware.attestation.${attestation}`)}
+      displayedValue={t(`deviceSettings.hardware.attestation.${attestation ? 'true' : 'false'}`)}
       hideDisplayedValueOnSmall
     />
   );


### PR DESCRIPTION
So that we do not accidentally pass undefined, null, booleans or just any type in tempalte literals, see:

    `all these should error ${false} ${undefined} ${[]} ${null}`

This is a eslint rule, so only make weblint will check.