### PR TITLE
frontend: replace BrowserRouter with HashRouter

### DIFF
--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -233,7 +233,8 @@ public class MainActivity extends AppCompatActivity {
             public void onPageFinished(WebView view, String url) {
                 // The url is not correctly updated when navigating to a new page. This allows to
                 // know the current location and to block external requests on that base.
-                view.evaluateJavascript("window.location.pathname", path -> location = path);
+                // The React router is a hash router - the current app path is behind the '#'.
+                view.evaluateJavascript("window.location.hash.replace(/^#/, '')", path -> location = path);
             }
             @Override
             public WebResourceResponse shouldInterceptRequest(final WebView view, WebResourceRequest request) {

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -122,8 +122,8 @@ public:
         // We treat the onramp page specially because we need to allow onramp
         // widgets to load in an iframe as well as let them open external links
         // in a browser.
-        bool onBuyPage = currentUrl.contains(QRegularExpression("^qrc:/buy/.*$"));
-        bool onBitsurancePage = currentUrl.contains(QRegularExpression("^qrc:/bitsurance/.*$"));
+        bool onBuyPage = currentUrl.contains(QRegularExpression("^qrc:/index\.html\#/buy/.*$"));
+        bool onBitsurancePage = currentUrl.contains(QRegularExpression("^qrc:/index\.html\#/bitsurance/.*$"));
         if (onBuyPage || onBitsurancePage) {
             if (info.firstPartyUrl().toString() == info.requestUrl().toString()) {
                 // A link with target=_blank was clicked.
@@ -136,7 +136,7 @@ public:
 
         // All the requests originated in the wallet-connect section are allowed, as they are needed to
         // load the Dapp logos and it is not easy to filter out non-images requests.
-        bool onWCPage = currentUrl.contains(QRegularExpression("^qrc:/account/[^\/]+/wallet-connect/.*$"));
+        bool onWCPage = currentUrl.contains(QRegularExpression("^qrc:/index\.html\#/account/[^\/]+/wallet-connect/.*$"));
         if (onWCPage) {
           return;
         }

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -67,16 +67,10 @@ export const App = () => {
   }, [t]);
 
   const maybeRoute = useCallback(() => {
-    const currentURL = window.location.pathname;
-    const isIndex = currentURL === '/' || currentURL === '/index.html' || currentURL === '/android_asset/web/index.html';
+    const currentURL = window.location.hash.replace(/^#/, '');
+    const isIndex = currentURL === '' || currentURL === '/';
     const inAccounts = currentURL.startsWith('/account/');
 
-    // QT and Android start their apps in '/index.html' and '/android_asset/web/index.html' respectively
-    // This re-routes them to '/' so we have a simpler uri structure
-    if (isIndex && currentURL !== '/' && (!accounts || accounts.length === 0)) {
-      navigate('/');
-      return;
-    }
     // if no accounts are registered on specified views route to /
     if (accounts.length === 0 && (
       currentURL.startsWith('/account-summary')

--- a/frontends/web/src/index.tsx
+++ b/frontends/web/src/index.tsx
@@ -18,7 +18,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { I18nextProvider } from 'react-i18next';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import { App } from './app';
 import { i18n } from './i18n/i18n';
 import './style/index.css';
@@ -30,9 +30,9 @@ root.render(
   <React.StrictMode>
     <I18nextProvider i18n={i18n}>
       <React.Suspense fallback={null}>
-        <BrowserRouter>
+        <HashRouter>
           <App />
-        </BrowserRouter>
+        </HashRouter>
       </React.Suspense>
     </I18nextProvider>
   </React.StrictMode>


### PR DESCRIPTION
Using the BrowserRouter is needlessly complicated, we don't need the browser to make a new "request" when we route to a different page. Getting this to work is especially difficult in iOS, where the file path to index.html is loaded in the webview, and routing to e.g. `/account-summary' fails because the absolute filepath `/account-summary` does not exist and is outside the app folder sandbox.

Using the hash router instead, where the app path is tracked behind the `#` (e.g. index.html#/account-summary) is more appropriate and easier to handle.