### PR TITLE
frontend/conversions: show BTC as active currency in sats mode

### DIFF
--- a/backend/coins/coin/conversions.go
+++ b/backend/coins/coin/conversions.go
@@ -55,9 +55,14 @@ func Conversions(amount Amount, coin Coin, isFee bool, ratesUpdater *ratesPkg.Ra
 	rates := ratesUpdater.LatestPrice()
 	if rates != nil {
 		unit := coin.Unit(isFee)
-
+		formatUnit := coin.GetFormatUnit(isFee)
+		formatBtcasBtc := (formatUnit == "tsat" || formatUnit == "sat") && (coin.Code() == "tbtc" || coin.Code() == "btc")
 		conversions = map[string]string{}
 		for key, value := range rates[unit] {
+			// Avoid formatting BTC as sats for BTC accounts with sats mode enabled
+			if key == ratesPkg.BTC.String() && formatBtcasBtc {
+				formatBtcAsSats = false
+			}
 			convertedAmount := new(big.Rat).Mul(new(big.Rat).SetFloat64(coin.ToUnit(amount, isFee)), new(big.Rat).SetFloat64(value))
 			conversions[key] = FormatAsCurrency(convertedAmount, key == ratesPkg.BTC.String(), formatBtcAsSats)
 		}

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -76,7 +76,8 @@ function Conversion({
   let isAvailable = false;
 
   let activeUnit: ConversionUnit = defaultCurrency;
-  if (defaultCurrency === 'BTC' && btcUnit === 'sat') {
+  // for BTC accounts where the amount unit is sat/tsat we don't want to use sat as activeUnit for redundancy
+  if (defaultCurrency === 'BTC' && btcUnit === 'sat' && (amount && amount.unit !== 'tsat' && amount.unit !== 'sat')) {
     activeUnit = 'sat';
   }
 

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -530,8 +530,9 @@ class Send extends Component<Props, State> {
     if (!account) {
       return null;
     }
-
-    const baseCurrencyUnit: accountApi.ConversionUnit = fiatUnit === 'BTC' && btcUnit === 'sat' ? 'sat' : fiatUnit;
+    // for BTC accounts with sat mode enabled use BTC as baseCurrencyUnit
+    const isNotBtcAccount = account.coinCode !== 'tbtc' && account.coinCode !== 'btc';
+    const baseCurrencyUnit: accountApi.ConversionUnit = fiatUnit === 'BTC' && btcUnit === 'sat' && isNotBtcAccount ? 'sat' : fiatUnit;
     return (
       <GuideWrapper>
         <GuidedContent>


### PR DESCRIPTION
In BTC accounts with sats mode enabled, displaying two amounts in sats is redundant. This commit addresses this by ensuring that when sats mode is enabled for BTC accounts, the active currency is displayed as BTC. BTC is now displayed in this setting as the active currency on the send page and during the transaction review process.