### PR TITLE
frontend: add device password recommendation 

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -287,8 +287,12 @@
     },
     "stepPassword": {
       "e104": "Setting password was canceled.",
-      "title": "Set BitBox02 password",
-      "useControls": "Use the controls on your BitBox02 to set a password."
+      "recommendLength": {
+        "link": "Learn more",
+        "text": "about how to choose a good device password."
+      },
+      "title": "Set BitBox02 device password",
+      "useControls": "Use the controls on your BitBox02 to set a device password."
     },
     "stepUninitialized": {
       "create": "I want to create a new wallet on my BitBox02.",

--- a/frontends/web/src/routes/device/bitbox02/setup/password.module.css
+++ b/frontends/web/src/routes/device/bitbox02/setup/password.module.css
@@ -1,0 +1,5 @@
+.textIcon {
+    height: 1.2em;
+    margin-right: 0.5em;
+    vertical-align: text-bottom;
+  }

--- a/frontends/web/src/routes/device/bitbox02/setup/password.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/password.tsx
@@ -15,16 +15,29 @@
  */
 
 import { useTranslation } from 'react-i18next';
+import { i18n } from '../../../../i18n/i18n';
 import { View, ViewContent, ViewHeader } from '../../../../components/view/view';
 import { Backup } from '../../../../api/backup';
 import { PasswordEntry } from '../components/password-entry/password-entry';
 import { Status } from '../../../../components/status/status';
 import { MultilineMarkup } from '../../../../utils/markup';
 import { convertDateToLocaleString } from '../../../../utils/date';
+import { A } from '../../../../components/anchor/anchor';
+import { Info } from '../../../../components/icon';
+import style from './password.module.css';
 
 type Props = {
   errorText: string | undefined;
 }
+
+const getSupportLink = () => {
+  switch (i18n.resolvedLanguage) {
+  case 'de':
+    return 'https://bitbox.swiss/redirects/device-password-recommendation-de/';
+  default:
+    return 'https://bitbox.swiss/redirects/device-password-recommendation-en/';
+  }
+};
 
 export const SetPassword = ({ errorText }: Props) => {
   const { t } = useTranslation();
@@ -45,6 +58,12 @@ export const SetPassword = ({ errorText }: Props) => {
       </ViewHeader>
       <ViewContent>
         <PasswordEntry />
+        <br />
+        <p className="text-small text-gray">
+          <Info className={style.textIcon} />
+          <A href={getSupportLink()}>{t('bitbox02Wizard.stepPassword.recommendLength.link')}</A>&nbsp;
+          {t('bitbox02Wizard.stepPassword.recommendLength.text')}
+        </p>
       </ViewContent>
     </View>
   );
@@ -83,6 +102,12 @@ export const SetPasswordWithBackup = ({
       <ViewContent>
         <p>{t('bitbox02Wizard.stepPassword.useControls')}</p>
         <PasswordEntry />
+        <br />
+        <p className="text-small text-gray">
+          <Info className={style.textIcon} />
+          <A href={getSupportLink()}>{t('bitbox02Wizard.stepPassword.recommendLength.link')}</A>&nbsp;
+          {t('bitbox02Wizard.stepPassword.recommendLength.text')}
+        </p>
       </ViewContent>
     </View>
   );


### PR DESCRIPTION
Adds a small note below the password demo video which links to the knowledge base entry on how to choose a good device password.

Some users are confused when it comes to the device password and may choose overly long device password. The knowledge base entry provides valuable context and enables the user to make an informed decision.

To avoid confusion with BIP-39 passphrases, "password" has been rephrased to "device password".

**Preview:**

<img width="1285" alt="Screenshot 2024-04-29 at 13 38 07" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/79049748/ff5bdfcf-8e35-4d94-aceb-4a91690b14eb">

<img width="1285" alt="Screenshot 2024-04-29 at 13 38 21" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/79049748/fd03bd2c-f398-4f8f-a943-c3e1a945f102">

