### PR TITLE
frontend/android: check if webview can go back or close the app

### DIFF
--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -422,7 +422,7 @@ public class MainActivity extends AppCompatActivity {
 
         try {
             String data = readRawText(getAssets().open("web/index.html"));
-            vw.loadDataWithBaseURL(BASE_URL, data, null, null, BASE_URL);
+            vw.loadDataWithBaseURL(BASE_URL, data, null, null, "file:///android_asset/web/index.html");
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -371,7 +371,7 @@ public class MainActivity extends AppCompatActivity {
             public void handleOnBackPressed() {
 
                 if (vw.canGoBack()) {
-                    vw.goBack();
+                    vw.goBackOrForward(-1);
                 } else {
                     // To avoid unexpected behaviour, we prompt users and force the app process
                     // to exit which helps with preserving phone's resources by shutting down

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -422,7 +422,8 @@ public class MainActivity extends AppCompatActivity {
 
         try {
             String data = readRawText(getAssets().open("web/index.html"));
-            vw.loadDataWithBaseURL(BASE_URL, data, null, null, "https://shiftcrypto.ch/index.html");
+            vw.loadDataWithBaseURL(BASE_URL, data, null, null, BASE_URL);
+            vw.clearHistory();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -47,11 +47,11 @@ import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProviders;
 import androidx.activity.OnBackPressedCallback;
 
-import java.io.BufferedReader;
+// import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
+// import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -237,7 +237,7 @@ public class MainActivity extends AppCompatActivity {
                     if (url != null && url.startsWith(BASE_URL)) {
                         // Intercept local requests and serve the response from the Android assets folder.
                         try {
-                            InputStream inputStream = getAssets().open(url.replace(BASE_URL, "web/"));
+                            InputStream inputStream = getAssets().open(url.replace("file:///", "web/"));
                             String mimeType = Util.getMimeType(url);
                             if (mimeType != null) {
                                 return new WebResourceResponse(mimeType, "UTF-8", inputStream);
@@ -420,13 +420,7 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
-        try {
-            String data = readRawText(getAssets().open("web/index.html"));
-            vw.loadDataWithBaseURL(BASE_URL, data, null, null, BASE_URL);
-            vw.clearHistory();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        vw.loadUrl("file:///android_asset/web/index.html");
 
         // We call updateDevice() here in case the app was started while the device was already connected.
         // In that case, handleIntent() is not called with ACTION_USB_DEVICE_ATTACHED.
@@ -438,21 +432,21 @@ public class MainActivity extends AppCompatActivity {
         goService.startServer(getApplicationContext().getFilesDir().getAbsolutePath(), gVM.getGoEnvironment(), gVM.getGoAPI());
     }
 
-    private static String readRawText(InputStream inputStream) throws IOException {
-        if (inputStream == null) {
-            return null;
-        }
+    // private static String readRawText(InputStream inputStream) throws IOException {
+    //     if (inputStream == null) {
+    //         return null;
+    //     }
 
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
-        StringBuilder fileContent = new StringBuilder();
-        String currentLine = bufferedReader.readLine();
-        while (currentLine != null) {
-            fileContent.append(currentLine);
-            fileContent.append("\n");
-            currentLine = bufferedReader.readLine();
-        }
-        return fileContent.toString();
-    }
+    //     BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+    //     StringBuilder fileContent = new StringBuilder();
+    //     String currentLine = bufferedReader.readLine();
+    //     while (currentLine != null) {
+    //         fileContent.append(currentLine);
+    //         fileContent.append("\n");
+    //         currentLine = bufferedReader.readLine();
+    //     }
+    //     return fileContent.toString();
+    // }
 
     @Override
     protected void onNewIntent(Intent intent) {

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -409,7 +409,7 @@ public class MainActivity extends AppCompatActivity {
 
         try {
             String data = readRawText(getAssets().open("web/index.html"));
-            vw.loadDataWithBaseURL(BASE_URL, data, null, null, null);
+            vw.loadDataWithBaseURL(BASE_URL, data, null, null, BASE_URL);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -422,7 +422,7 @@ public class MainActivity extends AppCompatActivity {
 
         try {
             String data = readRawText(getAssets().open("web/index.html"));
-            vw.loadDataWithBaseURL(BASE_URL, data, null, null, "file:///android_asset/web/index.html");
+            vw.loadDataWithBaseURL(BASE_URL, data, null, null, "https://shiftcrypto.ch/index.html");
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -33,6 +33,7 @@ import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
+import android.webkit.WebBackForwardList;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -370,40 +371,52 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void handleOnBackPressed() {
 
-                if (vw.canGoBack()) {
-                    vw.goBackOrForward(-1);
-                } else {
-                    // To avoid unexpected behaviour, we prompt users and force the app process
-                    // to exit which helps with preserving phone's resources by shutting down
-                    // all goroutines.
-                    //
-                    // Without forced app process exit, some goroutines may remain active even after
-                    // the app resumption at which point new copies of goroutines are spun up.
-                    // Note that this is different from users tapping on "home" button or switching
-                    // to another app and then back, in which case no extra goroutines are created.
-                    //
-                    // A proper fix is to make the backend process run in a separate system thread.
-                    // Until such solution is implemented, forced app exit seems most appropriate.
-                    //
-                    // See the following for details about task and activity stacks:
-                    // https://developer.android.com/guide/components/activities/tasks-and-back-stack
-                    new AlertDialog.Builder(MainActivity.this)
-                        .setTitle("Close BitBoxApp")
-                        .setMessage("Do you really want to exit?")
-                        .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int which) {
-                                Util.quit(MainActivity.this);
-                            }
-                        })
-                        .setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int which) {
-                                dialog.dismiss();
-                            }
-                        })
-                        .setIcon(android.R.drawable.ic_dialog_alert)
-                        .show();
-                }
+                WebBackForwardList historyList = vw.copyBackForwardList();
+                int historySize = historyList.getSize();
 
+                // Create and show an alert dialog with the number of entries in the history
+                new AlertDialog.Builder(MainActivity.this)
+                    .setTitle("History Entries")
+                    .setMessage("Number of entries in history: " + historySize)
+                    .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                            if (vw.canGoBack()) {
+                                vw.goBackOrForward(-1);
+                            } else {
+                                // To avoid unexpected behaviour, we prompt users and force the app process
+                                // to exit which helps with preserving phone's resources by shutting down
+                                // all goroutines.
+                                //
+                                // Without forced app process exit, some goroutines may remain active even after
+                                // the app resumption at which point new copies of goroutines are spun up.
+                                // Note that this is different from users tapping on "home" button or switching
+                                // to another app and then back, in which case no extra goroutines are created.
+                                //
+                                // A proper fix is to make the backend process run in a separate system thread.
+                                // Until such solution is implemented, forced app exit seems most appropriate.
+                                //
+                                // See the following for details about task and activity stacks:
+                                // https://developer.android.com/guide/components/activities/tasks-and-back-stack
+                                new AlertDialog.Builder(MainActivity.this)
+                                    .setTitle("Close BitBoxApp")
+                                    .setMessage("Do you really want to exit?")
+                                    .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
+                                        public void onClick(DialogInterface dialog, int which) {
+                                            Util.quit(MainActivity.this);
+                                        }
+                                    })
+                                    .setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
+                                        public void onClick(DialogInterface dialog, int which) {
+                                            dialog.dismiss();
+                                        }
+                                    })
+                                    .setIcon(android.R.drawable.ic_dialog_alert)
+                                    .show();
+                            }
+                        }
+                    })
+                    .setIcon(android.R.drawable.ic_dialog_info)
+                    .show();
             }
         });
 

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -30,7 +30,7 @@ import { syncDeviceList } from './api/devicessync';
 import { syncNewTxs } from './api/transactions';
 import { notifyUser } from './api/system';
 import { ConnectedApp } from './connected';
-import { Alert } from './components/alert/Alert';
+import { Alert, alertUser } from './components/alert/Alert';
 import { Aopp } from './components/aopp/aopp';
 import { Banner } from './components/banner/banner';
 import { Confirm } from './components/confirm/Confirm';
@@ -52,6 +52,12 @@ export const App = () => {
   const devices = useDefault(useSync(getDeviceList, syncDeviceList), {});
 
   const prevDevices = usePrevious(devices);
+
+  useEffect(() => {
+    window.addEventListener('popstate', () => {
+      alertUser(`popstate ${window.location.pathname}`);
+    });
+  }, []);
 
   useEffect(() => {
     return syncNewTxs((meta) => {

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -30,7 +30,7 @@ import { syncDeviceList } from './api/devicessync';
 import { syncNewTxs } from './api/transactions';
 import { notifyUser } from './api/system';
 import { ConnectedApp } from './connected';
-import { Alert, alertUser } from './components/alert/Alert';
+import { Alert/*, alertUser*/ } from './components/alert/Alert';
 import { Aopp } from './components/aopp/aopp';
 import { Banner } from './components/banner/banner';
 import { Confirm } from './components/confirm/Confirm';
@@ -53,11 +53,11 @@ export const App = () => {
 
   const prevDevices = usePrevious(devices);
 
-  useEffect(() => {
-    window.addEventListener('popstate', () => {
-      alertUser(`popstate ${window.location.href}`);
-    });
-  }, []);
+  // useEffect(() => {
+  //   window.addEventListener('popstate', () => {
+  //     alertUser(`popstate ${window.location.href}`);
+  //   });
+  // }, []);
 
   useEffect(() => {
     return syncNewTxs((meta) => {

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -55,7 +55,7 @@ export const App = () => {
 
   useEffect(() => {
     window.addEventListener('popstate', () => {
-      alertUser(`popstate ${window.location.pathname}`);
+      alertUser(`popstate ${window.location.href}`);
     });
   }, []);
 

--- a/frontends/web/src/components/alert/Alert.tsx
+++ b/frontends/web/src/components/alert/Alert.tsx
@@ -43,14 +43,15 @@ const Alert = () => {
   const [message, setMessage] = useState<string>();
   const { t } = useTranslation();
 
-  alertUser = (message: string, options: AlertUserOptions = {}) => {
+  alertUser = (newMessage: string, options: AlertUserOptions = {}) => {
+    const nextMessage = active ? `${message}; \n ${newMessage}` : newMessage;
     const {
       asDialog = true,
     } = options;
     callback = options.callback;
     setActive(true);
     setAsDialog(asDialog);
-    setMessage(message);
+    setMessage(nextMessage);
   };
 
   const handleClose = () => {

--- a/frontends/web/src/index.tsx
+++ b/frontends/web/src/index.tsx
@@ -23,21 +23,20 @@ import { App } from './app';
 import { i18n } from './i18n/i18n';
 import './style/index.css';
 
+// // debug
+// const originalPushState = window.history.pushState;
 
-// debug
-const originalPushState = window.history.pushState;
+// // Create a new proxy object
+// const pushStateProxy = new Proxy(originalPushState, {
+//   apply(target, thisArg, argumentsList) {
+//     // Log the arguments passed to history.pushState
+//     alert(`history.pushState called with arguments: ${JSON.stringify(argumentsList)}`);
+//     return window.Reflect.apply(target, thisArg, argumentsList);
+//   }
+// });
 
-// Create a new proxy object
-const pushStateProxy = new Proxy(originalPushState, {
-  apply(target, thisArg, argumentsList) {
-    // Log the arguments passed to history.pushState
-    alert(`history.pushState called with arguments: ${JSON.stringify(argumentsList)}`);
-    return window.Reflect.apply(target, thisArg, argumentsList);
-  }
-});
-
-// Override the original pushState with the proxy
-window.history.pushState = pushStateProxy;
+// // Override the original pushState with the proxy
+// window.history.pushState = pushStateProxy;
 
 const rootEl = document.getElementById('root') as HTMLDivElement;
 const root = createRoot(rootEl);

--- a/frontends/web/src/index.tsx
+++ b/frontends/web/src/index.tsx
@@ -23,8 +23,25 @@ import { App } from './app';
 import { i18n } from './i18n/i18n';
 import './style/index.css';
 
+
+// debug
+const originalPushState = window.history.pushState;
+
+// Create a new proxy object
+const pushStateProxy = new Proxy(originalPushState, {
+  apply(target, thisArg, argumentsList) {
+    // Log the arguments passed to history.pushState
+    alert(`history.pushState called with arguments: ${JSON.stringify(argumentsList)}`);
+    return window.Reflect.apply(target, thisArg, argumentsList);
+  }
+});
+
+// Override the original pushState with the proxy
+window.history.pushState = pushStateProxy;
+
 const rootEl = document.getElementById('root') as HTMLDivElement;
 const root = createRoot(rootEl);
+
 
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
This should replace native Android back behavior with either going
back in the webview history or closing the app.

In theory the react-router pushes history entries to the webview
navigation history, as soon as the user clicks a Link or navigate
is called. The navigate function can also be called with replace
option so that it does not add to the history.

This is using the native goBack method but it seems that the app
only goes back to account summary. In theory this should behave
the same as native browser back. It is not clear why it jumps to
the beginning.

So this could probably be improved, but seems already useful with
just going back to the account summary.

On the account summary it cannot go back any further so it will
trigger the old do-you-want-to-quit alert.

Replaced deprecated onBackPressed override.