### PR TITLE
frontend: update 'My portfolio' with lightning account

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -440,6 +440,18 @@ export const connectKeystore = (code: AccountCode): Promise<{ success: boolean; 
   return apiPost(`account/${code}/connect-keystore`);
 };
 
+export type TResponseKeystoreName = {
+  success: true,
+  keystoreName: string;
+} | {
+  success: false;
+}
+
+export const getKeystoreName = (rootFingerprint: string): Promise<TResponseKeystoreName> => {
+  return apiGet(`keystore-name?rootFingerprint=${rootFingerprint}`);
+};
+
+
 export type TSignMessage = { success: false, aborted?: boolean; errorMessage?: string; } | { success: true; signature: string; }
 
 export type TSignWalletConnectTx = {

--- a/frontends/web/src/routes/account/summary/chart.module.css
+++ b/frontends/web/src/routes/account/summary/chart.module.css
@@ -30,6 +30,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  flex-grow: 1;
 }
 
 .filters {

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -26,12 +26,14 @@ import { Filters } from './filters';
 import { getDarkmode } from '@/components/darkmode/darkmode';
 import { DefaultCurrencyRotator } from '@/components/rates/rates';
 import { AppContext } from '@/contexts/AppContext';
+import { TChartFiltersProps } from './types';
 import styles from './chart.module.css';
 
 type TProps = {
   data?: TSummary;
   noDataPlaceholder?: JSX.Element;
   hideAmounts?: boolean;
+  hideChartDetails: boolean;
 };
 
 const defaultData: Readonly<TSummary> = {
@@ -88,7 +90,8 @@ const renderDate = (
 export const Chart = ({
   data = defaultData,
   noDataPlaceholder,
-  hideAmounts = false
+  hideAmounts = false,
+  hideChartDetails = false
 }: TProps) => {
   const height: number = 300;
   const mobileHeight: number = 150;
@@ -489,7 +492,7 @@ export const Chart = ({
   const disableFilters = !hasData || chartDataMissing;
   const disableWeeklyFilters = !hasHourlyData || chartDataMissing;
   const showMobileTotalValue = toolTipVisible && !!toolTipValue && isMobile;
-  const chartFiltersProps = {
+  const chartFiltersProps: TChartFiltersProps = {
     display: chartDisplay,
     disableFilters,
     disableWeeklyFilters,
@@ -516,50 +519,56 @@ export const Chart = ({
               {chartTotal !== null && <DefaultCurrencyRotator tableRow={false} />}
             </span>
           </div>
-          {!showMobileTotalValue ? (
-            <PercentageDiff
-              hasDifference={!!hasDifference}
-              difference={difference}
-              title={diffSince}
-            />
-          ) :
-            <span className={styles.diffValue}>
-              {renderDate(toolTipTime * 1000, i18n.language, source)}
-            </span>
-          }
+          {!hideChartDetails && (
+            <>
+              {!showMobileTotalValue ? (
+                <PercentageDiff
+                  hasDifference={!!hasDifference}
+                  difference={difference}
+                  title={diffSince}
+                />
+              ) :
+                <span className={styles.diffValue}>
+                  {renderDate(toolTipTime * 1000, i18n.language, source)}
+                </span>
+              }
+            </>
+          )}
         </div>
-        {!isMobile && <Filters {...chartFiltersProps} />}
+        {!isMobile && !hideChartDetails && <Filters {...chartFiltersProps} />}
       </header>
-      <div className={styles.chartCanvas} style={{ minHeight: chartHeight }}>
-        {chartDataMissing ? (
-          <div className={styles.chartUpdatingMessage} style={{ height: chartHeight }}>
-            {t('chart.dataMissing')}
-          </div>
-        ) : hasData ? !chartIsUpToDate && (
-          <div className={styles.chartUpdatingMessage}>
-            {t('chart.dataOldTimestamp', { time: new Date(lastTimestamp).toLocaleString(i18n.language), })}
-          </div>
-        ) : noDataPlaceholder}
-        <div ref={ref} className={styles.invisible}></div>
-        <span
-          ref={refToolTip}
-          className={styles.tooltip}
-          style={{ left: toolTipLeft, top: toolTipTop }}
-          hidden={!toolTipVisible || isMobile}>
-          {toolTipValue !== undefined ? (
-            <span>
-              <h2 className={styles.toolTipValue}>
-                <Amount amount={toolTipValue} unit={chartFiat} />
-                <span className={styles.toolTipUnit}>{chartFiat}</span>
-              </h2>
-              <span className={styles.toolTipTime}>
-                {renderDate(toolTipTime * 1000, i18n.language, source)}
+      {hideChartDetails || (
+        <div className={styles.chartCanvas} style={{ minHeight: chartHeight }}>
+          {chartDataMissing ? (
+            <div className={styles.chartUpdatingMessage} style={{ height: chartHeight }}>
+              {t('chart.dataMissing')}
+            </div>
+          ) : hasData ? !chartIsUpToDate && (
+            <div className={styles.chartUpdatingMessage}>
+              {t('chart.dataOldTimestamp', { time: new Date(lastTimestamp).toLocaleString(i18n.language), })}
+            </div>
+          ) : noDataPlaceholder}
+          <div ref={ref} className={styles.invisible}></div>
+          <span
+            ref={refToolTip}
+            className={styles.tooltip}
+            style={{ left: toolTipLeft, top: toolTipTop }}
+            hidden={!toolTipVisible || isMobile}>
+            {toolTipValue !== undefined ? (
+              <span>
+                <h2 className={styles.toolTipValue}>
+                  <Amount amount={toolTipValue} unit={chartFiat} />
+                  <span className={styles.toolTipUnit}>{chartFiat}</span>
+                </h2>
+                <span className={styles.toolTipTime}>
+                  {renderDate(toolTipTime * 1000, i18n.language, source)}
+                </span>
               </span>
-            </span>
-          ) : null}
-        </span>
-      </div>
-      {isMobile && <Filters {...chartFiltersProps} />}
+            ) : null}
+          </span>
+        </div>
+      )}
+      {isMobile && !hideChartDetails && <Filters {...chartFiltersProps} />}
     </section>
   );
 };


### PR DESCRIPTION
This commit adds functionality to display Lightning account
in 'My portfolio' in cases where it is active but not associated
with a connected or remembered wallet, or when all mainnet
accounts in the connected wallet are disabled.

The total coins table is updated to include the Lightning account
Hide chart, percentage change, and filters in my portfolio if
only the lightning account is displayed.