### PR TITLE
backend/bitbox02bootloader: allow fixing broken install

### DIFF
--- a/backend/devices/bitbox02bootloader/device.go
+++ b/backend/devices/bitbox02bootloader/device.go
@@ -214,11 +214,11 @@ func (device *Device) UpgradeFirmware() error {
 	}
 	device.log.Infof("upgrading firmware: %s, %s", product, nextFirmware.version)
 
-	binary, err := nextFirmware.binary()
+	signedBinary, err := nextFirmware.signedBinary()
 	if err != nil {
 		return err
 	}
-	return device.Device.UpgradeFirmware(binary)
+	return device.Device.UpgradeFirmware(signedBinary)
 }
 
 // VersionInfo contains version information about the upgrade.

--- a/backend/devices/bitbox02bootloader/firmware.go
+++ b/backend/devices/bitbox02bootloader/firmware.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/BitBoxSwiss/bitbox02-api-go/api/bootloader"
 	bitbox02common "github.com/BitBoxSwiss/bitbox02-api-go/api/common"
 	"github.com/BitBoxSwiss/bitbox02-api-go/util/semver"
 )
@@ -51,6 +52,19 @@ func (fi firmwareInfo) signedBinary() ([]byte, error) {
 		return nil, err
 	}
 	return io.ReadAll(gz)
+}
+
+func (fi firmwareInfo) firmwareHash() ([]byte, error) {
+	signedBinary, err := fi.signedBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	_, _, binary, err := bootloader.ParseSignedFirmware(signedBinary)
+	if err != nil {
+		return nil, err
+	}
+	return bootloader.HashFirmware(fi.monotonicVersion, binary), nil
 }
 
 // The last entry in the slice is the latest firmware update to which one can upgrade.

--- a/backend/devices/bitbox02bootloader/firmware.go
+++ b/backend/devices/bitbox02bootloader/firmware.go
@@ -45,7 +45,7 @@ type firmwareInfo struct {
 	binaryGzip       []byte
 }
 
-func (fi firmwareInfo) binary() ([]byte, error) {
+func (fi firmwareInfo) signedBinary() ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(fi.binaryGzip))
 	if err != nil {
 		return nil, err

--- a/backend/devices/bitbox02bootloader/firmware_test.go
+++ b/backend/devices/bitbox02bootloader/firmware_test.go
@@ -32,11 +32,11 @@ func testHash(t *testing.T, info firmwareInfo, expectedMagic []byte, hashFile st
 	const sigDataLen = 584
 	const magicLen = 4
 
-	fwBinary, err := info.binary()
+	signedBinary, err := info.signedBinary()
 	require.NoError(t, err)
-	require.True(t, len(fwBinary) >= 4+sigDataLen)
-	require.Equal(t, expectedMagic, fwBinary[:magicLen])
-	hash := sha256.Sum256(fwBinary[magicLen+sigDataLen:])
+	require.True(t, len(signedBinary) >= 4+sigDataLen)
+	require.Equal(t, expectedMagic, signedBinary[:magicLen])
+	hash := sha256.Sum256(signedBinary[magicLen+sigDataLen:])
 	expectedHash, err := os.ReadFile(hashFile)
 	require.NoError(t, err)
 	require.Equal(t, string(expectedHash), hex.EncodeToString(hash[:]))
@@ -58,12 +58,12 @@ func TestBundledFirmware(t *testing.T) {
 func TestMontonicVersions(t *testing.T) {
 	for product, binaries := range bundledFirmwares {
 		for _, fwInfo := range binaries {
-			fwBinary, err := fwInfo.binary()
+			signedBinary, err := fwInfo.signedBinary()
 			require.NoError(t, err)
 
 			// TODO: replace magic numbers with parsing functions from the bitbox02-api-go lib,
 			// which first have to be exposed.
-			fwVersion := binary.LittleEndian.Uint32(fwBinary[392:396])
+			fwVersion := binary.LittleEndian.Uint32(signedBinary[392:396])
 
 			require.Equal(t, fwInfo.monotonicVersion, fwVersion, "%s; %s", product, fwInfo.version)
 		}


### PR DESCRIPTION
Problem: a new device ships with the latest firmware monotonic version. User
sees 'Install' because the device is erased (no firmware on it), but during
first install of firmware, unplugs. Upon replug, the device will show 'Invalid
firmware' and boot into bootloader again. Since the monotonic version of the
firmware to be installed is the same as the version stored on the device, and
the device is not erased (half of the firmware is on it), the user sees no
button to upgrade/instll anymore.

This commit fixes this by still showing the upgrade button if the versions are
the same, but the device firmware hash does not match the expected firmware
hash.

Replaces https://github.com/digitalbitbox/bitbox-wallet-app/pull/2700 - @thisconnect suggested to use the firmware hash instead, which is a much nicher solution as it does not show the upgrade button to every user who enters the bootloader, just to the ones where the firmware install is actually broken - thanks @thisconnect :pray: 