### PR TITLE
frontend simpler coinbalance

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -70,11 +70,11 @@ export const getAccounts = (): Promise<IAccount[]> => {
 };
 
 export type TAccountsBalanceByCoin = {
-    [key: string]: IAmount;
+    [key in CoinCode]: IAmount;
 };
 
 export type TAccountsBalance = {
-  [rootFingerprint: string]: TAccountsBalanceByCoin;
+  [rootFingerprint in TKeystore['rootFingerprint']]: TAccountsBalanceByCoin;
 };
 
 export const getAccountsBalance = (): Promise<TAccountsBalance> => {
@@ -87,7 +87,7 @@ export type TAccountTotalBalance = {
 };
 
 export type TAccountsTotalBalance = {
-    [key: string]: TAccountTotalBalance;
+  [rootFingerprint in TKeystore['rootFingerprint']]: TAccountTotalBalance;
 };
 
 export type TAccountsTotalBalanceResponse = {
@@ -104,7 +104,7 @@ export const getAccountsTotalBalance = (): Promise<TAccountsTotalBalanceResponse
 };
 
 export type TCoinsTotalBalance = {
-  [key: string]: IAmount;
+  [key in CoinCode]: IAmount;
 };
 
 export const getCoinsTotalBalance = (): Promise<TCoinsTotalBalance> => {

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -214,7 +214,6 @@ export function AccountsSummary({
               } />
             {accountsByKeystore.length > 1 && (
               <CoinBalance
-                accounts={accounts}
                 summaryData={summaryData}
                 coinsBalances={coinsTotalBalance}
               />

--- a/frontends/web/src/routes/account/summary/coinbalance.tsx
+++ b/frontends/web/src/routes/account/summary/coinbalance.tsx
@@ -16,39 +16,46 @@
 
 import { useTranslation } from 'react-i18next';
 import * as accountApi from '../../../api/account';
-import { SubTotalCoinRow } from './subtotalrow';
 import { Amount } from '../../../components/amount/amount';
 import { Skeleton } from '../../../components/skeleton/skeleton';
+import { SubTotalCoinRow } from './subtotalrow';
+import { getCoinOrTokenName } from '../utils';
 import style from './accountssummary.module.css';
 
 type TProps = {
-  accounts: accountApi.IAccount[],
-  summaryData?: accountApi.ISummary,
-  coinsBalances?: accountApi.TCoinsTotalBalance,
+  summaryData?: accountApi.ISummary;
+  coinsBalances?: accountApi.TCoinsTotalBalance;
 }
 
-type TAccountCoinMap = {
-    [code in accountApi.CoinCode]: accountApi.IAccount[];
-};
-
 export function CoinBalance ({
-  accounts,
   summaryData,
   coinsBalances,
 }: TProps) {
   const { t } = useTranslation();
 
-  const getAccountsPerCoin = () => {
-    return accounts.reduce((accountPerCoin, account) => {
-      accountPerCoin[account.coinCode]
-        ? accountPerCoin[account.coinCode].push(account)
-        : accountPerCoin[account.coinCode] = [account];
-      return accountPerCoin;
-    }, {} as TAccountCoinMap);
-  };
+  if (!coinsBalances) {
+    return null;
+  }
 
-  const accountsPerCoin = getAccountsPerCoin();
-  const coins = Object.keys(accountsPerCoin) as accountApi.CoinCode[];
+  const coinsOrdered = [
+    'btc',
+    'tbtc',
+    'ltc',
+    'tltc',
+    'eth',
+    'goeth',
+    'sepeth',
+    'eth-erc20-usdt',
+    'eth-erc20-usdc',
+    'eth-erc20-link',
+    'eth-erc20-bat',
+    'eth-erc20-mkr',
+    'eth-erc20-zrx',
+    'eth-erc20-wbtc',
+    'eth-erc20-paxg',
+    'eth-erc20-dai0x6b17',
+  ] as accountApi.CoinCode[];
+  const activeCoinCodeList = coinsOrdered.filter(coin => coin in coinsBalances);
 
   return (
     <div>
@@ -70,21 +77,14 @@ export function CoinBalance ({
             </tr>
           </thead>
           <tbody>
-            { accounts.length > 0 ? (
-              coins.map(coinCode => {
-                if (accountsPerCoin[coinCode]?.length >= 1) {
-                  const account = accountsPerCoin[coinCode][0];
-                  return (
-                    <SubTotalCoinRow
-                      key={account.coinCode}
-                      coinCode={account.coinCode}
-                      coinName={account.coinName}
-                      balance={coinsBalances && coinsBalances[coinCode]}
-                    />
-                  );
-                }
-                return null;
-              })) : null}
+            {activeCoinCodeList.map((coinCode) => (
+              <SubTotalCoinRow
+                key={coinCode}
+                coinCode={coinCode}
+                coinName={getCoinOrTokenName(coinCode)}
+                balance={coinsBalances && coinsBalances[coinCode]}
+              />
+            ))}
           </tbody>
           <tfoot>
             <tr>

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -71,6 +71,46 @@ export function getCoinCode(coinCode: CoinCode): CoinCode | undefined {
   }
 }
 
+export const getCoinOrTokenName = (coinCode: CoinCode): string => {
+  switch (getCryptoName(coinCode)) {
+  case 'btc':
+    return 'Bitcoin';
+  case 'tbtc':
+    return 'Bitcoin Testnet';
+  case 'ltc':
+    return 'Litecoin';
+  case 'tltc':
+    return 'Litecoin Testnet';
+  case 'eth':
+    return 'Ethereum';
+  case 'goeth':
+    return 'Ethereum Goerli';
+  case 'sepeth':
+    return 'Ethereum Sepolia';
+  case 'eth-erc20-usdt':
+    return 'Tether USD';
+  case 'eth-erc20-usdc':
+    return 'USD Coin';
+  case 'eth-erc20-link':
+    return 'LINK';
+  case 'eth-erc20-bat':
+    return 'Basic Attention Token';
+  case 'eth-erc20-mkr':
+    return 'Maker';
+  case 'eth-erc20-zrx':
+    return '0x';
+  case 'eth-erc20-wbtc':
+    return 'Wrapped Bitcoin';
+  case 'eth-erc20-paxg':
+    return 'Pax Gold';
+  case 'eth-erc20-dai0x6b17':
+    return 'Dai';
+  default:
+    console.warn(`unknown coin or token ${coinCode}`);
+    return coinCode;
+  }
+};
+
 
 export function getScriptName(scriptType: ScriptType): string {
   switch (scriptType) {


### PR DESCRIPTION
Coin balance needs a list of coinCodes and some way to display the
coin name.

Before this change it first constructed a map that contains accounts
per coin, as the name of the coin is only included in IAccount
interface.

Using a dedicated utils function to derive the coin name from coin
codes simplifies CoinBalance component.

Also cleanup and type keys of various maps in 2nd commit

Before the key was just of type string, but in these cases
we have proper types.