### PR TITLE
frontend: remove unsafe componnetwillmount fix esc in webdev

### DIFF
--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -166,9 +166,7 @@ class Send extends Component<Props, State> {
         }
       }),
     ];
-  }
 
-  public UNSAFE_componentWillMount() {
     this.registerEvents();
   }
 
@@ -177,16 +175,11 @@ class Send extends Component<Props, State> {
     unsubscribe(this.unsubscribeList);
   }
 
-  private registerEvents = () => {
-    document.addEventListener('keydown', this.handleKeyDown);
-  };
-
-  private unregisterEvents = () => {
-    document.removeEventListener('keydown', this.handleKeyDown);
-  };
+  private registerEvents = () => document.addEventListener('keydown', this.handleKeyDown);
+  private unregisterEvents = () => document.removeEventListener('keydown', this.handleKeyDown);
 
   private handleKeyDown = (e: KeyboardEvent) => {
-    if (e.keyCode === 27 && !this.state.activeCoinControl && !this.state.activeScanQR) {
+    if (e.key === 'Escape' && !this.state.activeCoinControl && !this.state.activeScanQR) {
       route(`/account/${this.props.code}`);
     }
   };


### PR DESCRIPTION
When Strict Mode is on, React will also run one extra setup+cleanup cycle in development. This helps reveal subtle bugs that are hard to catch manually. This also makes the deprecated UNSAFE componentWillMount only run first time.

Send view used UNSAFE_componentWillMount to listen to keydown events that handles ESC button. In webdev pressing ESC button did therefore not go back to the account overview.

Changed to register events on componentDidMount.

Also changed deprecated KeyBoardEvent.keyCode to KeyBoardEvent.key.

See:
- https://react.dev/reference/react/StrictMode
- https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode