### PR TITLE
frontend/coin-control: add address reuse warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix Wallet Connect issue where account unspecified by the connecting dapp caused a UI crash
 - Fix Wallet Connect issue with required/optionalNamespace and handling all possible namespace definitions
 - Add Satoshi as an option in active currencies
+- Show address re-use warning and group UTXOs with the same address together in coin control.
 
 ## 4.42.0
 - Preselect backup when there's only one backup available

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -324,16 +324,27 @@ func (handlers *Handlers) getUTXOs(*http.Request) (interface{}, error) {
 		return result, errp.New("Interface must be of type btc.Account")
 	}
 
+	addressCounts := make(map[string]int)
+
 	for _, output := range t.SpendableOutputs() {
+		address := output.Address.EncodeForHumans()
+		addressCounts[address]++
+	}
+
+	for _, output := range t.SpendableOutputs() {
+		address := output.Address.EncodeForHumans()
+		addressReused := addressCounts[address] > 1
+
 		result = append(result,
 			map[string]interface{}{
-				"outPoint":   output.OutPoint.String(),
-				"txId":       output.OutPoint.Hash.String(),
-				"txOutput":   output.OutPoint.Index,
-				"amount":     handlers.formatBTCAmountAsJSON(btcutil.Amount(output.TxOut.Value), false),
-				"address":    output.Address.EncodeForHumans(),
-				"scriptType": output.Address.Configuration.ScriptType(),
-				"note":       handlers.account.TxNote(output.OutPoint.Hash.String()),
+				"outPoint":      output.OutPoint.String(),
+				"txId":          output.OutPoint.Hash.String(),
+				"txOutput":      output.OutPoint.Index,
+				"amount":        handlers.formatBTCAmountAsJSON(btcutil.Amount(output.TxOut.Value), false),
+				"address":       address,
+				"scriptType":    output.Address.Configuration.ScriptType(),
+				"note":          handlers.account.TxNote(output.OutPoint.Hash.String()),
+				"addressReused": addressReused,
 			})
 	}
 

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -369,6 +369,7 @@ export type TUTXO = {
   amount: IAmount;
   note: string;
   scriptType: ScriptType;
+  addressReused: boolean;
 };
 
 export const getUTXOs = (code: AccountCode): Promise<TUTXO[]> => {

--- a/frontends/web/src/components/badge/badge.module.css
+++ b/frontends/web/src/components/badge/badge.module.css
@@ -42,3 +42,10 @@
   border-color: var(--color-darkyellow);
   color: var(--color-olive);
 }
+
+/* swiss-red with different opacities */
+.danger {
+  background: rgba(255, 0, 0, 0.2);
+  border-color: rgba(255, 0, 0, 0.33);
+  color: rgba(255, 0, 0, 1);
+}

--- a/frontends/web/src/components/badge/badge.module.css
+++ b/frontends/web/src/components/badge/badge.module.css
@@ -3,7 +3,7 @@
   border: 1px solid;
   display: inline-block;
   font-size: var(--size-small);
-  line-height: 14px;
+  line-height: 1;
   padding: var(--space-eight) 10px;
   white-space: nowrap;
 }

--- a/frontends/web/src/components/badge/badge.tsx
+++ b/frontends/web/src/components/badge/badge.tsx
@@ -17,7 +17,7 @@
 import { ReactElement, ReactNode } from 'react';
 import style from './badge.module.css';
 
-type TBadgeStyles = 'success' | 'warning'; // TODO: not yet implemented 'info' | 'danger'
+type TBadgeStyles = 'success' | 'warning' | 'danger'; // TODO: not yet implemented 'info'
 
 type TProps = {
   children?: ReactNode;

--- a/frontends/web/src/components/forms/radio.module.css
+++ b/frontends/web/src/components/forms/radio.module.css
@@ -1,5 +1,6 @@
 .radio {
     --size-default: 14px;
+    line-height: 1.5;
 }
 
 .radio input {
@@ -11,7 +12,6 @@
     display: inline-flex;
     flex-direction: column;
     font-size: var(--size-default);
-    line-height: 1.5;
     margin-right: var(--space-half);
     padding-left: calc(var(--space-half) + var(--space-quarter));
     position: relative;

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1525,6 +1525,7 @@
     "button": "Review",
     "coincontrol": {
       "address": "Address",
+      "addressReused": "Address re-used",
       "outpoint": "Outpoint",
       "title": "Send from output"
     },
@@ -1790,6 +1791,7 @@
     "walletConnect": "WalletConnect"
   },
   "warning": {
+    "coincontrol": "One or more UTXOs have a reused address. Be aware the receiver will see all UTXOs associated with those addresses.",
     "receivePairing": "Please pair the BitBox to enable secure address verification. Go to 'Manage device' in the sidebar.",
     "sdcard": "Keep the microSD card stored separate from the BitBox, unless you want to manage backups.",
     "sendPairing": "Please pair the BitBox to securely verify transaction details. Go to 'Manage device' in the sidebar."

--- a/frontends/web/src/routes/account/send/utxos.module.css
+++ b/frontends/web/src/routes/account/send/utxos.module.css
@@ -74,7 +74,7 @@
 .transaction {
     display: flex;
     font-size: var(--size-default);
-    line-height: 1.4;
+    line-height: 1.5;
     white-space: nowrap;
 }
 

--- a/frontends/web/src/routes/account/summary/accountssummary.module.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.module.css
@@ -1,6 +1,6 @@
 .accountName {
     display: flex;
-    align-items: center;
+    align-items: baseline;
 }
 
 .accountName p {

--- a/frontends/web/src/routes/buy/components/exchangeselectionradio.module.css
+++ b/frontends/web/src/routes/buy/components/exchangeselectionradio.module.css
@@ -48,7 +48,6 @@
     color: var(--color-default);
     display: inline-block;
     font-weight: 400;
-    line-height: 22px;
     margin: 0;
 }
 .paymentMethodName img {

--- a/frontends/web/src/routes/buy/exchange.module.css
+++ b/frontends/web/src/routes/buy/exchange.module.css
@@ -75,6 +75,7 @@
 }
 
 .radioButtonsContainer {
+    line-height: 1.5;
     min-height: 180px;
 }
 


### PR DESCRIPTION
Add a warning to the coin control modal when a user selects one or more UTXOs from reused addresses. The warning: "One or more UTXOs have a reused address. Be aware  the receiver will see all UTXOs associated with those addresses."

The UTXOs now have red badge when their address was re-used.