### PR TITLE
backend/account: migrate legacy notes upfront

### DIFF
--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -71,12 +71,7 @@ type BaseAccount struct {
 	offline error
 
 	// notes handles transaction notes.
-	//
-	// It is a slice for migration purposes: from v4.27.0 to v4.28.0, the account identifiers
-	// changed. The slice contains all possible instances of where notes are stored. The first
-	// element is the newest, and other elements are notes stored under legacy names. After
-	// `Initialize()`, this will always have at least one element.
-	notes []*notes.Notes
+	notes *notes.Notes
 
 	proposedTxNote   string
 	proposedTxNoteMu sync.Mutex
@@ -151,10 +146,28 @@ func (account *BaseAccount) Initialize(accountIdentifier string) error {
 	if err != nil {
 		return err
 	}
-	account.notes = []*notes.Notes{txNotes}
+	account.notes = txNotes
 
-	// Append legacy notes (notes stored in files based on obsolete account identifiers). Account
-	// identifiers changed from v4.27.0 to v4.28.0.
+	if err := account.migrateLegacyNotes(); err != nil {
+		return err
+	}
+
+	// An account syncdone event is generated when new rates are available. This allows the frontend
+	// to reload the relevant data.
+	if account.config.RateUpdater != nil {
+		account.config.RateUpdater.Observe(func(e observable.Event) {
+			if e.Subject == rates.RatesEventSubject {
+				account.config.OnEvent(types.EventSyncDone)
+			}
+		})
+	}
+
+	return nil
+}
+
+// Migrate legacy notes (notes stored in files based on obsolete account identifiers). Account
+// identifiers changed from v4.27.0 to v4.28.0.
+func (account *BaseAccount) migrateLegacyNotes() error {
 	if len(account.Config().Config.SigningConfigurations) == 0 {
 		return nil
 	}
@@ -199,18 +212,11 @@ func (account *BaseAccount) Initialize(accountIdentifier string) error {
 		if err != nil {
 			return err
 		}
-		account.notes = append(account.notes, legacyNotes)
+		if err := account.notes.MergeLegacy(legacyNotes); err != nil {
+			return err
+		}
+		_ = os.Remove(notesFile)
 	}
-
-	// An account syncdone event is generated when new rates are available. This allows the frontend to reload the relevant data.
-	if account.config.RateUpdater != nil {
-		account.config.RateUpdater.Observe(func(e observable.Event) {
-			if e.Subject == rates.RatesEventSubject {
-				account.config.OnEvent(types.EventSyncDone)
-			}
-		})
-	}
-
 	return nil
 }
 
@@ -235,15 +241,8 @@ func (account *BaseAccount) GetAndClearProposedTxNote() string {
 
 // SetTxNote implements accounts.Account.
 func (account *BaseAccount) SetTxNote(txID string, note string) error {
-	// The notes slice is guaranteed to have at least one element by BaseAccount.Initialize.
-	if err := account.notes[0].SetTxNote(txID, note); err != nil {
+	if err := account.notes.SetTxNote(txID, note); err != nil {
 		return err
-	}
-	// Delete the notes in legacy files. Don't really care if it fails.
-	for i, notes := range account.notes[1:] {
-		if err := notes.SetTxNote(txID, ""); err != nil {
-			account.log.WithError(err).Errorf("Can't delete a note from a legacy file idx=%d", i)
-		}
 	}
 	// Prompt refresh.
 	account.config.OnEvent(types.EventStatusChanged)
@@ -252,14 +251,7 @@ func (account *BaseAccount) SetTxNote(txID string, note string) error {
 
 // TxNote fetches a note for a transcation. Returns the empty string if no note was found.
 func (account *BaseAccount) TxNote(txID string) string {
-	// Take the first note we can find. The first slice element is the regular location of notes,
-	// the other elements lookup notes in legacy locations, so they are not lost when upgrading.
-	for _, notes := range account.notes {
-		if note := notes.TxNote(txID); note != "" {
-			return note
-		}
-	}
-	return ""
+	return account.notes.TxNote(txID)
 }
 
 // ExportCSV implements accounts.Account.

--- a/backend/accounts/notes/notes.go
+++ b/backend/accounts/notes/notes.go
@@ -57,6 +57,7 @@ func write(data *notesData, filename string) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = file.Close() }()
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(data); err != nil {

--- a/backend/accounts/notes/notes.go
+++ b/backend/accounts/notes/notes.go
@@ -26,8 +26,8 @@ import (
 // maxNoteLen is the maximum length per note.
 const maxNoteLen = 1024
 
-// NotesData is the notes JSON data serialized to disk.
-type notesData struct {
+// Data is the notes JSON data serialized to disk.
+type Data struct {
 	// More fields to be added when we can label more stuff, e.g. receive addresses, utxos, etc.
 
 	// a map of transaction ID to transaction note.
@@ -36,23 +36,23 @@ type notesData struct {
 
 // read deserializes the json files into notes. If the file does not exist yet, no error is
 // returned, and the struct is retruned with default values.
-func read(filename string) (*notesData, error) {
+func read(filename string) (*Data, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &notesData{}, nil
+			return &Data{}, nil
 		}
 		return nil, errp.WithStack(err)
 	}
 	defer file.Close() //nolint:errcheck
-	var notes notesData
+	var notes Data
 	if err := json.NewDecoder(file).Decode(&notes); err != nil {
 		return nil, errp.WithStack(err)
 	}
 	return &notes, nil
 }
 
-func write(data *notesData, filename string) error {
+func write(data *Data, filename string) error {
 	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func write(data *notesData, filename string) error {
 // Notes is a high level helper for notes, allowing you to read and set notes for transactions.
 type Notes struct {
 	filename string
-	data     *notesData
+	data     *Data
 	dataMu   sync.RWMutex
 }
 
@@ -116,4 +116,30 @@ func (notes *Notes) TxNote(txID string) string {
 	defer notes.dataMu.RUnlock()
 
 	return notes.data.TransactionNotes[txID]
+}
+
+// Data retrieves all stored notes. You must not modify the returned object.
+func (notes *Notes) Data() *Data {
+	notes.dataMu.RLock()
+	defer notes.dataMu.RUnlock()
+	return notes.data
+}
+
+// MergeLegacy merges the notes from an older/legacy notes file. Current/new notes take priority in
+// case of conflict.
+func (notes *Notes) MergeLegacy(legacy *Notes) error {
+	notes.dataMu.Lock()
+	defer notes.dataMu.Unlock()
+
+	if notes.data.TransactionNotes == nil {
+		notes.data.TransactionNotes = map[string]string{}
+	}
+
+	legacyData := legacy.Data()
+	for txID, note := range legacyData.TransactionNotes {
+		if _, ok := notes.data.TransactionNotes[txID]; !ok {
+			notes.data.TransactionNotes[txID] = note
+		}
+	}
+	return write(notes.data, notes.filename)
 }


### PR DESCRIPTION
In the past we had different account IDs, and the notes where stored in different files. To deal with this, we used a list of notes objects per account to be able to fetch notes from all files.

This commit changes this to migrate/merge legacy note files so we only have one notes file per account. This is conceptually easier and simplifies the upcoming notes export feature.

This also fixes a bug where the rates updater event is not propagated for accounts with account number > 0 - Initialize() returned early with `return nil` in that case.