### PR TITLE
frontend: prefer arrow functions

### DIFF
--- a/frontends/web/src/api/subscribe.ts
+++ b/frontends/web/src/api/subscribe.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@ export type TSubscriptionCallback<T> = (eventObject: T) => void;
  * can push data through. This should be mostly used within api.
  * Note there is a subscibe-legacy.ts module that supports older events.
  */
-export function subscribeEndpoint<T>(
+export const subscribeEndpoint = <T>(
   endpoint: string,
   cb: TSubscriptionCallback<T>,
-): TUnsubscribe {
+): TUnsubscribe => {
   return apiSubscribe(endpoint, (event: TEvent) => {
     switch (event.action) {
     case 'replace':
@@ -45,7 +45,7 @@ export function subscribeEndpoint<T>(
       throw new Error(`Event: ${event} not supported`);
     }
   });
-}
+};
 
 /**
  * Subscribes the given function to the backend/connected event.

--- a/frontends/web/src/components/dialog/dialog-legacy.tsx
+++ b/frontends/web/src/components/dialog/dialog-legacy.tsx
@@ -212,10 +212,10 @@ interface DialogButtonsProps {
     children: React.ReactNode;
 }
 
-function DialogButtons({ children }: DialogButtonsProps) {
+const DialogButtons = ({ children }: DialogButtonsProps) => {
   return (
     <div className={style.dialogButtons}>{children}</div>
   );
-}
+};
 
 export { DialogLegacy, DialogButtons };

--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -278,10 +278,10 @@ interface DialogButtonsProps {
     children: React.ReactNode;
 }
 
-function DialogButtons({ children }: DialogButtonsProps) {
+const DialogButtons = ({ children }: DialogButtonsProps) => {
   return (
     <div className={style.dialogButtons}>{children}</div>
   );
-}
+};
 
 export { Dialog, DialogButtons };

--- a/frontends/web/src/components/forms/field.tsx
+++ b/frontends/web/src/components/forms/field.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2021-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@
 
 import style from './field.module.css';
 
-export function Field({
+export const Field = ({
   children, ...props
-}: JSX.IntrinsicElements['div']) {
+}: JSX.IntrinsicElements['div']) => {
   return (
     <div className={style.field} {...props}>
       {children}
     </div>
   );
-}
+};

--- a/frontends/web/src/components/forms/label.tsx
+++ b/frontends/web/src/components/forms/label.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2021-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,16 @@
 
 import style from './label.module.css';
 
-export function Label({
+export const Label = ({
   className,
   children,
   id, // TODO: change to htmlFor when mirgated away from preact@8.x
   ...props
-}: JSX.IntrinsicElements['label']) {
+}: JSX.IntrinsicElements['label']) => {
   const classes = [style.label, className].join(' ');
   return (
     <label htmlFor={id} className={classes} {...props}>
       {children}
     </label>
   );
-}
+};

--- a/frontends/web/src/components/forms/radio.tsx
+++ b/frontends/web/src/components/forms/radio.tsx
@@ -23,13 +23,13 @@ interface IRadioProps {
 
 type TRadioProps = IRadioProps & JSX.IntrinsicElements['input']
 
-export function Radio({
+export const Radio = ({
   disabled = false,
   label,
   id,
   children,
   ...props
-}: TRadioProps) {
+}: TRadioProps) => {
   return (
     <span className={style.radio}>
       <input
@@ -44,4 +44,4 @@ export function Radio({
       </label>
     </span>
   );
-}
+};

--- a/frontends/web/src/components/keystoreconnectprompt.tsx
+++ b/frontends/web/src/components/keystoreconnectprompt.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Shift Crypto AG
+ * Copyright 2023-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import { useDarkmode } from '../hooks/darkmode';
 import { SkipForTesting } from '../routes/device/components/skipfortesting';
 import styles from './keystoreconnectprompt.module.css';
 
-export function KeystoreConnectPrompt() {
+export const KeystoreConnectPrompt = () => {
   const { t } = useTranslation();
   const { isDarkMode } = useDarkmode();
 
@@ -105,4 +105,4 @@ export function KeystoreConnectPrompt() {
   default:
     return null;
   }
-}
+};

--- a/frontends/web/src/components/layout/footer.tsx
+++ b/frontends/web/src/components/layout/footer.tsx
@@ -23,7 +23,7 @@ type TProps = {
   children: ReactNode;
 }
 
-export function Footer({ children }: TProps) {
+export const Footer = ({ children }: TProps) => {
   return (
     <footer className={[style.footer, 'flex flex-row flex-items-center flex-end'].join(' ')}>
       {children}
@@ -33,4 +33,4 @@ export function Footer({ children }: TProps) {
       <LanguageSwitch />
     </footer>
   );
-}
+};

--- a/frontends/web/src/components/message/message.tsx
+++ b/frontends/web/src/components/message/message.tsx
@@ -24,12 +24,12 @@ export interface Props {
     children: ReactNode;
 }
 
-export function Message({
+export const Message = ({
   hidden,
   small,
   type = 'message',
   children,
-}: Props) {
+}: Props) => {
   if (hidden) {
     return null;
   }
@@ -38,4 +38,4 @@ export function Message({
       {children}
     </div>
   );
-}
+};

--- a/frontends/web/src/components/password.jsx
+++ b/frontends/web/src/components/password.jsx
@@ -20,7 +20,7 @@ import { alertUser } from './alert/Alert';
 import style from './password.module.css';
 import { withTranslation } from 'react-i18next';
 
-export function PasswordInput (props) {
+export const PasswordInput = (props) => {
   const { seePlaintext, ...rest } = props;
   return (
     <Input
@@ -28,7 +28,7 @@ export function PasswordInput (props) {
       {...rest}
     />
   );
-}
+};
 
 class PasswordSingleInputClass extends Component {
   state = {
@@ -304,7 +304,7 @@ class PasswordRepeatInputClass extends Component {
 
 export const PasswordRepeatInput = withTranslation(null, { withRef: true })(PasswordRepeatInputClass);
 
-function MatchesPattern({ regex, value = '', text }) {
+const MatchesPattern = ({ regex, value = '', text }) => {
   if (!regex || !value.length || regex.test(value)) {
     return null;
   }
@@ -312,11 +312,11 @@ function MatchesPattern({ regex, value = '', text }) {
   return (
     <p style={{ color: 'var(--color-error)' }}>{text}</p>
   );
-}
+};
 
 const excludeKeys = /^(Shift|Alt|Backspace|CapsLock|Tab)$/i;
 
-function hasCaps({ key }) {
+const hasCaps = ({ key }) => {
   // will return null, when we cannot clearly detect if capsLock is active or not
   if (key.length > 1 || key.toUpperCase() === key.toLowerCase() || excludeKeys.test(key)) {
     return null;
@@ -325,4 +325,4 @@ function hasCaps({ key }) {
   // @ts-ignore (event can be undefined and shiftKey exists only on MouseEvent but not Event)
   // eslint-disable-next-line no-restricted-globals
   return key.toUpperCase() === key && key.toLowerCase() !== key && !event.shiftKey;
-}
+};

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -58,8 +58,7 @@ type TProvidedProps = {
     alwaysShowAmounts?: boolean;
 }
 
-
-function Conversion({
+const Conversion = ({
   amount,
   tableRow,
   unstyled,
@@ -68,7 +67,7 @@ function Conversion({
   sign,
   noBtcZeroes,
   alwaysShowAmounts = false
-}: TProvidedProps) {
+}: TProvidedProps) => {
 
   const { defaultCurrency, btcUnit } = useContext(RatesContext);
 
@@ -120,7 +119,7 @@ function Conversion({
       }
     </span>
   );
-}
+};
 
 type TDefaultCurrencyRotator = {
   activeUnit?: ConversionUnit;

--- a/frontends/web/src/components/transactions/note.tsx
+++ b/frontends/web/src/components/transactions/note.tsx
@@ -30,7 +30,7 @@ type Props = {
   note: string;
 }
 
-export function Note({ accountCode, note, internalID }: Props) {
+export const Note = ({ accountCode, note, internalID }: Props) => {
   const { isDarkMode } = useDarkmode();
   const { t } = useTranslation();
   const [newNote, setNewNote] = useState<string>(note);
@@ -90,4 +90,4 @@ export function Note({ accountCode, note, internalID }: Props) {
       </button>
     </form>
   );
-}
+};

--- a/frontends/web/src/hooks/backend.ts
+++ b/frontends/web/src/hooks/backend.ts
@@ -17,7 +17,7 @@
 import { useEffect, useState } from 'react';
 import { TKeystores, subscribeKeystores, getKeystores } from '../api/keystores';
 
-export function useKeystores(): TKeystores | undefined {
+export const useKeystores = (): TKeystores | undefined => {
   const [keystores, setKeystores] = useState<TKeystores>();
   useEffect(() => {
     getKeystores().then(keystores => {
@@ -27,4 +27,4 @@ export function useKeystores(): TKeystores | undefined {
     return subscribeKeystores(setKeystores);
   }, []);
   return keystores;
-}
+};

--- a/frontends/web/src/hooks/default.ts
+++ b/frontends/web/src/hooks/default.ts
@@ -17,6 +17,6 @@
 /**
  * useDefault is a hook to provide a default value to a value that can be undefined.
  */
-export function useDefault<T>(value: T | undefined, defaultValue: T): T {
+export const useDefault = <T>(value: T | undefined, defaultValue: T): T => {
   return value !== undefined ? value : defaultValue;
-}
+};

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,11 +54,11 @@ type Props = {
   devices: TDevices;
 };
 
-export function Account({
+export const Account = ({
   accounts,
   code,
   devices,
-}: Props) {
+}: Props) => {
   const { t } = useTranslation();
 
   const [balance, setBalance] = useState<accountApi.IBalance>();
@@ -185,7 +185,7 @@ export function Account({
     return () => unsubscribe(subscriptions);
   }, [code, onAccountChanged, onStatusChanged, status]);
 
-  function exportAccount() {
+  const exportAccount = () => {
     if (status === undefined || status.fatalError) {
       return;
     }
@@ -196,7 +196,7 @@ export function Account({
         }
       })
       .catch(console.error);
-  }
+  };
 
   useEffect(() => {
     setStateCode(code);
@@ -339,4 +339,4 @@ export function Account({
       />
     </div>
   );
-}
+};

--- a/frontends/web/src/routes/account/add/components/steps.tsx
+++ b/frontends/web/src/routes/account/add/components/steps.tsx
@@ -57,12 +57,12 @@ type TStepProps = {
     hidden?: boolean;
 }
 
-export function Step({
+export const Step = ({
   children,
   hidden = false,
   line,
   status = 'wait',
-}: TStepProps) {
+}: TStepProps) => {
   if (hidden) {
     return null;
   }
@@ -74,4 +74,4 @@ export function Step({
       </div>
     </div>
   );
-}
+};

--- a/frontends/web/src/routes/account/guide.tsx
+++ b/frontends/web/src/routes/account/guide.tsx
@@ -29,13 +29,13 @@ type Props = {
   hasTransactions?: boolean;
 };
 
-export function AccountGuide({
+export const AccountGuide = ({
   account,
   unit,
   hasNoBalance,
   hasIncomingBalance,
   hasTransactions,
-}: Props) {
+}: Props) => {
   const { t } = useTranslation();
   return (
     <Guide title={t('guide.guideTitle.account')}>
@@ -84,4 +84,4 @@ export function AccountGuide({
       }} />
     </Guide>
   );
-}
+};

--- a/frontends/web/src/routes/account/info/guide.tsx
+++ b/frontends/web/src/routes/account/info/guide.tsx
@@ -22,9 +22,9 @@ interface BitcoinBasedAccountInfoGuideProps {
     coinName: string;
 }
 
-export function BitcoinBasedAccountInfoGuide({
+export const BitcoinBasedAccountInfoGuide = ({
   coinName,
-}: BitcoinBasedAccountInfoGuideProps) {
+}: BitcoinBasedAccountInfoGuideProps) => {
   const { t } = useTranslation();
   return (
     <Guide title={t('guide.guideTitle.accountInformation')}>
@@ -37,4 +37,4 @@ export function BitcoinBasedAccountInfoGuide({
       <Entry key="guide.accountInfo.verify" entry={t('guide.accountInfo.verify')} />
     </Guide>
   );
-}
+};

--- a/frontends/web/src/routes/account/receive/components/guide.tsx
+++ b/frontends/web/src/routes/account/receive/components/guide.tsx
@@ -23,10 +23,10 @@ type Props = {
   hasDifferentFormats: boolean;
 };
 
-export function ReceiveGuide({
+export const ReceiveGuide = ({
   hasMultipleAddresses,
   hasDifferentFormats,
-}: Props) {
+}: Props) => {
   const { t } = useTranslation();
   return (
     <Guide title={t('guide.guideTitle.receive')}>
@@ -46,4 +46,4 @@ export function ReceiveGuide({
       )}
     </Guide>
   );
-}
+};

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -46,10 +46,10 @@ export type Balances = {
     [code: string]: accountApi.IBalance;
 };
 
-export function AccountsSummary({
+export const AccountsSummary = ({
   accounts,
   devices,
-}: TProps) {
+}: TProps) => {
   const { t } = useTranslation();
   const summaryReqTimerID = useRef<number>();
   const mounted = useMountedRef();
@@ -249,4 +249,4 @@ export function AccountsSummary({
       </Guide>
     </GuideWrapper>
   );
-}
+};

--- a/frontends/web/src/routes/account/summary/balancerow.tsx
+++ b/frontends/web/src/routes/account/summary/balancerow.tsx
@@ -32,9 +32,9 @@ type TProps = {
   balance?: IBalance;
 };
 
-export function BalanceRow (
+export const BalanceRow = (
   { code, name, coinCode, balance }: TProps
-) {
+) => {
   const { t } = useTranslation();
   const syncStatus = useSubscribe(syncAddressesCount(code));
 
@@ -77,4 +77,4 @@ export function BalanceRow (
       </td>
     </tr>
   );
-}
+};

--- a/frontends/web/src/routes/account/summary/coinbalance.tsx
+++ b/frontends/web/src/routes/account/summary/coinbalance.tsx
@@ -31,11 +31,11 @@ type TAccountCoinMap = {
     [code in accountApi.CoinCode]: accountApi.IAccount[];
 };
 
-export function CoinBalance ({
+export const CoinBalance = ({
   accounts,
   summaryData,
   coinsBalances,
-}: TProps) {
+}: TProps) => {
   const { t } = useTranslation();
 
   const getAccountsPerCoin = () => {
@@ -110,4 +110,4 @@ export function CoinBalance ({
       </div>
     </div>
   );
-}
+};

--- a/frontends/web/src/routes/account/summary/subtotalrow.tsx
+++ b/frontends/web/src/routes/account/summary/subtotalrow.tsx
@@ -27,7 +27,7 @@ type TProps = {
   coinName: string;
 };
 
-export function SubTotalRow ({ coinCode, coinName, balance }: TProps) {
+export const SubTotalRow = ({ coinCode, coinName, balance }: TProps) => {
   const { t } = useTranslation();
   const nameCol = (
     <td data-label={t('accountSummary.total')}>
@@ -64,10 +64,9 @@ export function SubTotalRow ({ coinCode, coinName, balance }: TProps) {
       </td>
     </tr>
   );
-}
+};
 
-
-export function SubTotalCoinRow ({ coinCode, coinName, balance }: TProps) {
+export const SubTotalCoinRow = ({ coinCode, coinName, balance }: TProps) => {
   const { t } = useTranslation();
   const nameCol = (
     <td data-label={t('accountSummary.total')}>
@@ -97,4 +96,4 @@ export function SubTotalCoinRow ({ coinCode, coinName, balance }: TProps) {
       </td>
     </tr>
   );
-}
+};

--- a/frontends/web/src/routes/account/summary/summarybalance.tsx
+++ b/frontends/web/src/routes/account/summary/summarybalance.tsx
@@ -25,7 +25,7 @@ import { Badge } from '../../../components/badge/badge';
 import { USBSuccess } from '../../../components/icon';
 import style from './accountssummary.module.css';
 
-function TotalBalance({ total, fiatUnit }: accountApi.TAccountTotalBalance) {
+const TotalBalance = ({ total, fiatUnit }: accountApi.TAccountTotalBalance) => {
   return (
     <>
       <strong>
@@ -37,7 +37,7 @@ function TotalBalance({ total, fiatUnit }: accountApi.TAccountTotalBalance) {
       </span>
     </>
   );
-}
+};
 
 type TProps = {
   accounts: accountApi.IAccount[],
@@ -53,7 +53,7 @@ type TAccountCoinMap = {
     [code in accountApi.CoinCode]: accountApi.IAccount[];
 };
 
-export function SummaryBalance ({
+export const SummaryBalance = ({
   accounts,
   connected,
   keystoreName,
@@ -61,7 +61,7 @@ export function SummaryBalance ({
   totalBalance,
   balances,
   keystoreDisambiguatorName
-}: TProps) {
+}: TProps) => {
   const { t } = useTranslation();
 
   const getAccountsPerCoin = () => {
@@ -152,4 +152,4 @@ export function SummaryBalance ({
       </div>
     </div>
   );
-}
+};

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -17,18 +17,24 @@
 
 import { AccountCode, CoinCode, ScriptType, IAccount, CoinUnit, TKeystore } from '../../api/account';
 
-export function findAccount(accounts: IAccount[], accountCode: AccountCode): IAccount | undefined {
+export const findAccount = (
+  accounts: IAccount[],
+  accountCode: AccountCode
+): IAccount | undefined => {
   return accounts.find(({ code }) => accountCode === code);
-}
+};
 
-export function getCryptoName(cryptoLabel: string, account?: IAccount): string {
+export const getCryptoName = (
+  cryptoLabel: string,
+  account?: IAccount,
+): string => {
   if (account && isBitcoinOnly(account.coinCode)) {
     return 'Bitcoin';
   }
   return cryptoLabel;
-}
+};
 
-export function isBitcoinOnly(coinCode: CoinCode): boolean {
+export const isBitcoinOnly = (coinCode: CoinCode): boolean => {
   switch (coinCode) {
   case 'btc':
   case 'tbtc':
@@ -36,11 +42,11 @@ export function isBitcoinOnly(coinCode: CoinCode): boolean {
   default:
     return false;
   }
-}
+};
 
 export const isBitcoinCoin = (coin: CoinUnit) => (coin === 'BTC') || (coin === 'TBTC') || (coin === 'sat') || (coin === 'tsat');
 
-export function isBitcoinBased(coinCode: CoinCode): boolean {
+export const isBitcoinBased = (coinCode: CoinCode): boolean => {
   switch (coinCode) {
   case 'btc':
   case 'tbtc':
@@ -50,13 +56,13 @@ export function isBitcoinBased(coinCode: CoinCode): boolean {
   default:
     return false;
   }
-}
+};
 
-export function isEthereumBased(coinCode: CoinCode): boolean {
+export const isEthereumBased = (coinCode: CoinCode): boolean => {
   return coinCode === 'eth' || coinCode === 'goeth' || coinCode === 'sepeth' || coinCode.startsWith('eth-erc20-');
-}
+};
 
-export function getCoinCode(coinCode: CoinCode): CoinCode | undefined {
+export const getCoinCode = (coinCode: CoinCode): CoinCode | undefined => {
   switch (coinCode) {
   case 'btc':
   case 'tbtc':
@@ -69,10 +75,9 @@ export function getCoinCode(coinCode: CoinCode): CoinCode | undefined {
   case 'sepeth':
     return 'eth';
   }
-}
+};
 
-
-export function getScriptName(scriptType: ScriptType): string {
+export const getScriptName = (scriptType: ScriptType): string => {
   switch (scriptType) {
   case 'p2pkh':
     return 'Legacy (P2PKH)';
@@ -83,9 +88,9 @@ export function getScriptName(scriptType: ScriptType): string {
   case 'p2tr':
     return 'Taproot (bech32m, P2TR)';
   }
-}
+};
 
-export function customFeeUnit(coinCode: CoinCode): string {
+export const customFeeUnit = (coinCode: CoinCode): string => {
   if (isBitcoinBased(coinCode)) {
     return 'sat/vB';
   }
@@ -93,7 +98,7 @@ export function customFeeUnit(coinCode: CoinCode): string {
     return 'Gwei';
   }
   return '';
-}
+};
 
 export type TAccountsByKeystore = {
   keystore: TKeystore;
@@ -101,7 +106,7 @@ export type TAccountsByKeystore = {
 };
 
 // Returns the accounts grouped by the keystore fingerprint.
-export function getAccountsByKeystore(accounts: IAccount[]): TAccountsByKeystore[] {
+export const getAccountsByKeystore = (accounts: IAccount[]): TAccountsByKeystore[] => {
   return Object.values(accounts.reduce((acc, account) => {
     const key = account.keystore.rootFingerprint;
     if (!acc[key]) {
@@ -113,9 +118,12 @@ export function getAccountsByKeystore(accounts: IAccount[]): TAccountsByKeystore
     acc[key].accounts.push(account);
     return acc;
   }, {} as Record<string, TAccountsByKeystore>));
-}
+};
 
 // Returns true if more than one keystore has the given name.
-export function isAmbiguiousName(name: string, accounts: TAccountsByKeystore[]): boolean {
+export const isAmbiguiousName = (
+  name: string,
+  accounts: TAccountsByKeystore[],
+): boolean => {
   return accounts.filter(keystore => keystore.keystore.name === name).length > 1;
-}
+};

--- a/frontends/web/src/routes/buy/components/exchangeselectionradio.tsx
+++ b/frontends/web/src/routes/buy/components/exchangeselectionradio.tsx
@@ -74,7 +74,7 @@ const Deal = ({ deal }: { deal: ExchangeDealWithBestDeal }) => {
   );
 };
 
-export function ExchangeSelectionRadio({
+export const ExchangeSelectionRadio = ({
   disabled = false,
   id,
   children,
@@ -84,7 +84,7 @@ export function ExchangeSelectionRadio({
   exchangeName,
   onClickInfoButton,
   ...props
-}: TRadioProps) {
+}: TRadioProps) => {
 
   const handleClick = () => {
     if (!disabled) {
@@ -124,4 +124,4 @@ export function ExchangeSelectionRadio({
     </div>
 
   );
-}
+};

--- a/frontends/web/src/routes/buy/utils.ts
+++ b/frontends/web/src/routes/buy/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,12 @@
 import { FrontendExchangeDealsList, Info } from './types';
 import { IAccount } from '../../api/account';
 import { getExchangeBuySupported } from '../../api/exchanges';
+
 /**
  * Finds the lowest fee among all `supported`
  * exchange providers for a given region.
  */
-export function findLowestFee(providers: FrontendExchangeDealsList) {
+export const findLowestFee = (providers: FrontendExchangeDealsList) => {
   // all payment methods' fees of all
   // supported providers (for a selected region)
   let allFees: number[] = [];
@@ -35,10 +36,12 @@ export function findLowestFee(providers: FrontendExchangeDealsList) {
   });
 
   return Math.min(...allFees);
-}
+};
 
-
-export function findBestDeal(providers: FrontendExchangeDealsList, lowestFee: number): FrontendExchangeDealsList {
+export const findBestDeal = (
+  providers: FrontendExchangeDealsList,
+  lowestFee: number,
+): FrontendExchangeDealsList => {
   // for each provider's payment method
   // mark it as "bestDeal" if the
   // fee is equal to the lowest fee
@@ -52,24 +55,24 @@ export function findBestDeal(providers: FrontendExchangeDealsList, lowestFee: nu
     }))
   }));
   return { exchanges };
-}
+};
 
 /**
  * Gets formatted name for exchange.
  */
-export function getFormattedName(name: Omit<Info, 'region'>) {
+export const getFormattedName = (name: Omit<Info, 'region'>) => {
   switch (name) {
   case 'moonpay':
     return 'MoonPay';
   case 'pocket':
     return 'Pocket';
   }
-}
+};
 
 /**
  * Filters a given accounts list, keeping only the accounts supported by at least one exchange.
  */
-export async function getExchangeSupportedAccounts(accounts: IAccount[]): Promise<IAccount[]> {
+export const getExchangeSupportedAccounts = async (accounts: IAccount[]): Promise<IAccount[]> => {
   const accountsWithFalsyValue = await Promise.all(
     accounts.map(async (account) => {
       const supported = await getExchangeBuySupported(account.code)();
@@ -77,4 +80,4 @@ export async function getExchangeSupportedAccounts(accounts: IAccount[]): Promis
     })
   );
   return accountsWithFalsyValue.filter(result => result) as IAccount[];
-}
+};

--- a/frontends/web/src/routes/device/bitbox02/components/password-entry/password-entry.tsx
+++ b/frontends/web/src/routes/device/bitbox02/components/password-entry/password-entry.tsx
@@ -18,20 +18,18 @@ import { createRef, useEffect } from 'react';
 import PasswordGestureVideo from './assets/password-gestures.webm';
 import styles from './password-entry.module.css';
 
-
-
-function isVideoPlaying(video: HTMLVideoElement): boolean {
+const isVideoPlaying = (video: HTMLVideoElement): boolean => {
   return video.currentTime > 0 && !video.paused && !video.ended && video.readyState > 2;
-}
+};
 
-function replayVideo(ref: HTMLVideoElement): void {
+const replayVideo = (ref: HTMLVideoElement): void => {
   if (ref && !isVideoPlaying(ref)) {
     // prevent: NotAllowedError: play() failed because the user didn't interact with the document first.
     // https://goo.gl/xX8pDD
     ref.muted = true;
     ref.play();
   }
-}
+};
 
 export const PasswordEntry = () => {
   let ref = createRef<HTMLVideoElement>();

--- a/frontends/web/src/utils/env.ts
+++ b/frontends/web/src/utils/env.ts
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,20 +20,20 @@ export const debug = import.meta.env.DEV;
 /**
  * Returns whether the code is running in QtWebEngine.
  */
-export function runningInQtWebEngine() {
+export const runningInQtWebEngine = () => {
   return typeof window.qt !== 'undefined';
-}
+};
 
 /**
  * Returns whether the code is running in Android.
  */
-export function runningInAndroid() {
+export const runningInAndroid = () => {
   return typeof window.android !== 'undefined';
-}
+};
 
 /**
  * Returns whether the code is running on mobile.
  */
-export function runningOnMobile() {
+export const runningOnMobile = () => {
   return runningInAndroid();
-}
+};

--- a/frontends/web/src/utils/event-legacy.ts
+++ b/frontends/web/src/utils/event-legacy.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ const subscriptions: ISubscriptions = {};
 /**
  * This function dispatches the events from the websocket to the observers.
  */
-function handleMessages(payload: TPayload): void {
+const handleMessages = (payload: TPayload): void => {
   if (
     'type' in payload
     && payload.data
@@ -51,12 +51,12 @@ function handleMessages(payload: TPayload): void {
       observer(payload);
     }
   }
-}
+};
 
 /**
  * Subscribes the given observer on events of the given subject and returns a method to unsubscribe.
  */
-export function subscribe(subject: TSubject, observer: Observer): TUnsubscribe {
+export const subscribe = (subject: TSubject, observer: Observer): TUnsubscribe => {
   if (!subscriptions[subject]) {
     subscriptions[subject] = [];
   }
@@ -72,6 +72,6 @@ export function subscribe(subject: TSubject, observer: Observer): TUnsubscribe {
     const index = observers.indexOf(observer);
     observers.splice(index, 1);
   };
-}
+};
 
 apiWebsocket(handleMessages);

--- a/frontends/web/src/utils/event.ts
+++ b/frontends/web/src/utils/event.ts
@@ -40,7 +40,7 @@ const subscriptions: Subscriptions = {};
 /**
  * This function dispatches the events from the websocket to the observers.
  */
-function handleEvent(payload: TPayload): void {
+const handleEvent = (payload: TPayload): void => {
   if (
     'subject' in payload
     && typeof payload.subject === 'string'
@@ -51,7 +51,7 @@ function handleEvent(payload: TPayload): void {
       }
     }
   }
-}
+};
 
 /**
  * This variable keeps track of whether the below method has subscribed to the websocket.
@@ -61,10 +61,10 @@ let subscribed: TUnsubscribe | null = null;
 /**
  * Subscribes the given observer on events of the given subject and returns a method to unsubscribe.
  */
-export function apiSubscribe(
+export const apiSubscribe = (
   subject: TSubject,
   observer: Observer
-): TUnsubscribe {
+): TUnsubscribe => {
   if (!subscribed) {
     subscribed = apiWebsocket(handleEvent);
   }
@@ -84,4 +84,4 @@ export function apiSubscribe(
       console.warn('observers.includes(observer)');
     }
   };
-}
+};

--- a/frontends/web/src/utils/markup.tsx
+++ b/frontends/web/src/utils/markup.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ const captureStrongElement = /^(.*)<strong>(.*)<\/strong>(.*)$/;
     <SimpleMarkup tagName="p" markup="foo <strong>bar</strong> baz" />
  * ```
  */
-export function SimpleMarkup({ tagName, markup, ...props }: TMarkupProps) {
+export const SimpleMarkup = ({ tagName, markup, ...props }: TMarkupProps) => {
   if (typeof markup !== 'string') {
     return null;
   }
@@ -44,7 +44,7 @@ export function SimpleMarkup({ tagName, markup, ...props }: TMarkupProps) {
     return createElement(tagName, props, markup);
   }
   return createElement(tagName, props, simpleMarkupChunks[1], createElement('strong', null, simpleMarkupChunks[2]), simpleMarkupChunks[3]);
-}
+};
 
 type TMultiMarkupProps = {
   withBreaks?: boolean;

--- a/frontends/web/src/utils/request.ts
+++ b/frontends/web/src/utils/request.ts
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,26 +26,26 @@ import { runningInQtWebEngine, runningOnMobile } from './env';
 // is provided in case the file wasn't generated but used directly,
 // for convenience when developing. Both key and defaultValue must be
 // strings and converted into the desired type.
-function extConfig(key: string, defaultValue: string): string {
+const extConfig = (key: string, defaultValue: string): string => {
   if (key.startsWith('{{ ') && key.endsWith(' }}')) {
     return defaultValue;
   }
   return key;
-}
+};
 
 export const apiPort = extConfig('{{ API_PORT }}', '8082');
 export const apiToken = extConfig('{{ API_TOKEN }}', '');
 
-export function isTLS(): boolean {
+export const isTLS = (): boolean => {
   return document.URL.startsWith('https://');
-}
+};
 
-export function apiURL(endpoint: string): string {
+export const apiURL = (endpoint: string): string => {
   return (isTLS() ? 'https://' : 'http://') + 'localhost:' + apiPort + '/api/' + endpoint;
-}
+};
 
-function handleError(endpoint: string) {
-  return function(json: undefined | null | { error?: string }) {
+const handleError = (endpoint: string) => {
+  return (json: undefined | null | { error?: string }) => {
     return new Promise((resolve, reject) => {
       if (json && json.error) {
         if (json.error.indexOf('hidapi: unknown failure') !== -1) {
@@ -64,9 +64,9 @@ function handleError(endpoint: string) {
       resolve(json);
     });
   };
-}
+};
 
-export function apiGet(endpoint: string): Promise<any> {
+export const apiGet = (endpoint: string): Promise<any> => {
   // if apiGet() is invoked immediately this can error with:
   // request.js:64 Uncaught TypeError: Cannot read properties of undefined
   // (reading 'runningInQtWebEngine')
@@ -87,12 +87,12 @@ export function apiGet(endpoint: string): Promise<any> {
   return fetch(apiURL(endpoint), {
     method: 'GET'
   }).then(response => response.json()).then(handleError(endpoint));
-}
+};
 
-export function apiPost(
+export const apiPost = (
   endpoint: string,
   body?: object | number | string | boolean, // any is not safe to use, for example Set and Map are stringified to empty "{}"
-): Promise<any> {
+): Promise<any> => {
   if (runningInQtWebEngine()) {
     return call(JSON.stringify({
       method: 'POST',
@@ -111,4 +111,4 @@ export function apiPost(
     method: 'POST',
     body: JSON.stringify(body)
   }).then(response => response.json()).then(handleError(endpoint));
-}
+};

--- a/frontends/web/src/utils/subscriptions.ts
+++ b/frontends/web/src/utils/subscriptions.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2021-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,9 @@ export type UnsubscribeList = Array<(TUnsubscribe)>;
  * It calls and removes all unsubscribers from the array.
  * This is only useful if you component has more than 1 subscribtion.
  */
-export function unsubscribe(unsubscribeList: UnsubscribeList) {
+export const unsubscribe = (unsubscribeList: UnsubscribeList) => {
   for (const unsubscribeCallback of unsubscribeList) {
     unsubscribeCallback();
   }
   unsubscribeList.splice(0, unsubscribeList.length);
-}
+};

--- a/frontends/web/src/utils/transport-mobile.ts
+++ b/frontends/web/src/utils/transport-mobile.ts
@@ -22,7 +22,7 @@ let queryID: number = 0;
 const queryPromises: TQueryPromiseMap = {};
 const currentListeners: TMsgCallback[] = [];
 
-export function mobileCall(query: string): Promise<unknown> {
+export const mobileCall = (query: string): Promise<unknown> => {
   return new Promise((resolve, reject) => {
     if (runningOnMobile()) {
       if (typeof window.onMobileCallResponse === 'undefined') {
@@ -41,9 +41,9 @@ export function mobileCall(query: string): Promise<unknown> {
       reject();
     }
   });
-}
+};
 
-export function mobileSubscribePushNotifications(msgCallback: TMsgCallback) {
+export const mobileSubscribePushNotifications = (msgCallback: TMsgCallback) => {
   if (typeof window.onMobilePushNotification === 'undefined') {
     window.onMobilePushNotification = (msg: TPayload) => {
       currentListeners.forEach(listener => listener(msg));
@@ -61,4 +61,4 @@ export function mobileSubscribePushNotifications(msgCallback: TMsgCallback) {
       console.warn('currentListeners.includes(msgCallback)');
     }
   };
-}
+};

--- a/frontends/web/src/utils/transport-qt.ts
+++ b/frontends/web/src/utils/transport-qt.ts
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,14 +24,14 @@ let queryID: number = 0;
 const queryPromises: TQueryPromiseMap = {};
 const currentListeners: TMsgCallback[] = [];
 
-async function initTransport() {
+const initTransport = async () => {
   if (!runningInQtWebEngine()) {
     throw new Error('Must be running in Qt');
   }
   if (webChannel) {
     return webChannel;
   }
-  const initWebChannel = function(channel: any) {
+  const initWebChannel = (channel: any) => {
     channel.objects.backend.gotResponse.connect((
       queryID: number,
       response: string,
@@ -49,9 +49,9 @@ async function initTransport() {
     await new Promise(r => setTimeout(r, 1));
   }
   return webChannel;
-}
+};
 
-export function call(query: string): Promise<unknown> {
+export const call = (query: string): Promise<unknown> => {
   return new Promise((resolve, reject) => {
     initTransport().then((channel: any) => {
       queryID++;
@@ -59,9 +59,9 @@ export function call(query: string): Promise<unknown> {
       channel.objects.backend.call(queryID, query);
     });
   });
-}
+};
 
-export function qtSubscribePushNotifications(msgCallback: TMsgCallback) {
+export const qtSubscribePushNotifications = (msgCallback: TMsgCallback) => {
   currentListeners.push(msgCallback);
   return () => {
     if (!currentListeners.includes(msgCallback)) {
@@ -73,4 +73,4 @@ export function qtSubscribePushNotifications(msgCallback: TMsgCallback) {
       console.warn('currentListeners.includes(msgCallback)');
     }
   };
-}
+};

--- a/frontends/web/src/utils/transport-websocket.ts
+++ b/frontends/web/src/utils/transport-websocket.ts
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,28 +22,28 @@ let socket: WebSocket | undefined;
 
 const currentListeners: TMsgCallback[] = [];
 
-export function webSubscribePushNotifications(msgCallback: TMsgCallback): TUnsubscribe {
+export const webSubscribePushNotifications = (msgCallback: TMsgCallback): TUnsubscribe => {
   currentListeners.push(msgCallback);
   if (!socket) {
     socket = new WebSocket((isTLS() ? 'wss://' : 'ws://') + 'localhost:' + apiPort + '/api/events');
 
-    socket.onopen = function() {
+    socket.onopen = () => {
       if (socket) {
         socket.send('Authorization: Basic ' + apiToken);
       }
     };
 
-    socket.onerror = function(event) {
+    socket.onerror = (event) => {
       console.error('websocket error', event);
     };
 
     // Listen for messages
-    socket.onmessage = function(event) {
+    socket.onmessage = (event) => {
       const payload = JSON.parse(event.data);
       currentListeners.forEach(listener => listener(payload));
     };
 
-    socket.onclose = function() {
+    socket.onclose = () => {
       currentListeners.forEach(listener => listener({ subject: 'backend/connected', action: 'replace', object: false }));
     };
   }
@@ -57,4 +57,4 @@ export function webSubscribePushNotifications(msgCallback: TMsgCallback): TUnsub
       console.warn('currentListeners.includes(msgCallback)');
     }
   };
-}
+};

--- a/frontends/web/src/utils/walletconnect-eth-sign-handlers.ts
+++ b/frontends/web/src/utils/walletconnect-eth-sign-handlers.ts
@@ -46,7 +46,10 @@ const fetchAccountNameAndAddress = async (address: string) => {
   return { accountName: name, accountCode: code };
 };
 
-export async function handleWcEthSignRequest(method: string, args: TEthSignHandlerParams) {
+export const handleWcEthSignRequest = async (
+  method: string,
+  args: TEthSignHandlerParams,
+) => {
   switch (method) {
   case EIP155_SIGNING_METHODS.ETH_SIGN:
   case EIP155_SIGNING_METHODS.PERSONAL_SIGN:
@@ -64,14 +67,19 @@ export async function handleWcEthSignRequest(method: string, args: TEthSignHandl
   default:
     console.log(`${method} is unsupported`);
   }
-}
+};
 
 /**
-     * Wallet Connect's ETH_SIGN gives the params as [address, message]
-     * while PERSONAL_SIGN gives them as [message, address]
+ * Wallet Connect's ETH_SIGN gives the params as [address, message]
+ * while PERSONAL_SIGN gives them as [message, address]
 */
-
-async function ethSignHandler({ params, launchSignDialog, topic, id, currentSession }: TEthSignHandlerParams, method: string) {
+const ethSignHandler = async ({
+  params,
+  launchSignDialog,
+  topic,
+  id,
+  currentSession
+}: TEthSignHandlerParams, method: string) => {
   const isPersonalSign = method === EIP155_SIGNING_METHODS.PERSONAL_SIGN;
   const requestParams = params.request.params;
   const accountAddress = isPersonalSign ? requestParams[1] : requestParams[0];
@@ -106,9 +114,15 @@ async function ethSignHandler({ params, launchSignDialog, topic, id, currentSess
       method: t('walletConnect.signingRequest.method.signMessage')
     }
   });
-}
+};
 
-async function ethSignTypedDataHandler({ params, launchSignDialog, topic, id, currentSession }: TEthSignHandlerParams) {
+const ethSignTypedDataHandler = async ({
+  params,
+  launchSignDialog,
+  topic,
+  id,
+  currentSession
+}: TEthSignHandlerParams) => {
   const requestParams = params.request.params;
   const accountAddress = requestParams[0];
   const data = requestParams[1];
@@ -152,9 +166,12 @@ async function ethSignTypedDataHandler({ params, launchSignDialog, topic, id, cu
       method: t('walletConnect.signingRequest.method.signTypedData')
     }
   });
-}
+};
 
-async function ethSignOrSendTransactionHandler(args: TEthSignHandlerParams, method: string) {
+const ethSignOrSendTransactionHandler = async (
+  args: TEthSignHandlerParams,
+  method: string,
+) => {
   const isSendAndSign = method === EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION;
 
   const { params, launchSignDialog, topic, id, currentSession } = args;
@@ -192,5 +209,5 @@ async function ethSignOrSendTransactionHandler(args: TEthSignHandlerParams, meth
       method: formattedMethod,
     }
   });
-}
+};
 

--- a/frontends/web/src/utils/websocket.ts
+++ b/frontends/web/src/utils/websocket.ts
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import { runningInQtWebEngine, runningOnMobile } from './env';
 
 export type { TPayload, TUnsubscribe };
 
-export function apiWebsocket(msgCallback: TMsgCallback): TUnsubscribe {
+export const apiWebsocket = (msgCallback: TMsgCallback): TUnsubscribe => {
   if (runningInQtWebEngine()) {
     return qtSubscribePushNotifications(msgCallback);
   }
@@ -31,4 +31,4 @@ export function apiWebsocket(msgCallback: TMsgCallback): TUnsubscribe {
     return mobileSubscribePushNotifications(msgCallback);
   }
   return webSubscribePushNotifications(msgCallback);
-}
+};


### PR DESCRIPTION
Refactored to use arrow functions to provide a more concise syntax and ensure a consistent style across the codebase. Arrow functions are preferred in this context as they do not bind their own this, making them a better fit for functional components and callbacks.

Traditional function expressions were retained where necessary, such as for methods requiring their own this context, constructor functions, or where hoisting is necessary.

TypeScript's type system helps identify issues related to this binding and potential hoisting problems.