### PR TITLE
frontend: set data source to hourly on mount if display is week

### DIFF
--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -93,6 +93,9 @@ class Chart extends Component<Props, State> {
   };
 
   public componentDidMount() {
+    if (this.state.source !== 'hourly' && this.context.chartDisplay === 'week') {
+      this.setState({ source: 'hourly' });
+    }
     this.createChart();
   }
 


### PR DESCRIPTION
Our chart uses `daily` as its `source` default state value, which isn't always useful. Instead, we need to make sure to set this `source` state to the appropriate value according to the stored `chartDisplay` in the context, since the `source` state is used to populate chart data,etc.

Other than as a best practice, this fixes an edge case bug. Such as wrong data & percentage difference displayed when user does the following:
1. picks USD as default currency,
2. navigate to a different page,
3.  and going back to account summary.

The above only happens when "USD" is picked because of the following line:

```js
    if (this.props.data.chartFiat !== prev.data.chartFiat) {
      this.reinitializeChart();
    }
```

This means, if other `chartFiat` is picked, it'll reinitializeChart() very quickly (thus unnoticable), and will use the already correct `source` state.

Bug fix preview:

[Before]:

https://github.com/BitBoxSwiss/bitbox-wallet-app/assets/28676406/cbf20a78-0355-4d11-ad8c-88ef3517a5bc


[After]:

https://github.com/BitBoxSwiss/bitbox-wallet-app/assets/28676406/962f6e2a-369b-41c8-bc31-4d1b1ab199c6

