### PR TITLE
qt/windows: fix utf8 encoding of notes etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix Wallet Connect issue with required/optionalNamespace and handling all possible namespace definitions
 - Add Satoshi as an option in active currencies
 - Show address re-use warning and group UTXOs with the same address together in coin control.
+- Fix encoding of transaction notes on Windows
 
 ## 4.42.0
 - Preselect backup when there's only one backup available

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -82,7 +82,7 @@ public:
                 // if the BitBoxApp is launched and also when it is already running, in which case
                 // it is brought to the foreground automatically.
 
-                handleURI(openEvent->url().toString().toLocal8Bit().constData());
+                handleURI(openEvent->url().toString().toUtf8().constData());
             }
         }
 
@@ -103,7 +103,7 @@ public:
     {
         // Log frontend console messages to the Go log.txt.
         QString formattedMsg = QString("msg: %1; line %2; source: %3").arg(message).arg(lineNumber).arg(sourceID);
-        goLog(formattedMsg.toLocal8Bit().constData());
+        goLog(formattedMsg.toUtf8().constData());
     }
 };
 
@@ -127,7 +127,7 @@ public:
         if (onBuyPage || onBitsurancePage) {
             if (info.firstPartyUrl().toString() == info.requestUrl().toString()) {
                 // A link with target=_blank was clicked.
-                systemOpen(info.requestUrl().toString().toLocal8Bit().constData());
+                systemOpen(info.requestUrl().toString().toUtf8().constData());
                 // No need to also load it in our page.
                 info.block(true);
             }
@@ -407,11 +407,11 @@ int main(int argc, char *argv[])
         [&](int instanceId, QByteArray message) {
             QString arg = QString::fromUtf8(message);
             qDebug() << "Received arg from secondary instance:" << arg;
-            handleURI(arg.toLocal8Bit().constData());
+            handleURI(arg.toUtf8().constData());
         });
     // Handle URI which the app was launched with in the primary instance.
     if (a.arguments().size() == 2) {
-        handleURI(a.arguments()[1].toLocal8Bit().constData());
+        handleURI(a.arguments()[1].toUtf8().constData());
     }
 
     return a.exec();

--- a/frontends/qt/webclass.h
+++ b/frontends/qt/webclass.h
@@ -21,7 +21,7 @@ class WebClass : public QObject
     Q_OBJECT
 public slots:
     void call(int queryID, const QString& query) {
-        backendCall(queryID, query.toLocal8Bit().constData());
+        backendCall(queryID, query.toUtf8().constData());
     }
 signals:
     void gotResponse(int queryID, QString response);


### PR DESCRIPTION
When entering chars like 'ü' as a tx note on Windows, the char was encoded as "\xef\xbf\xbd", which is displayed as '�'.

The frontend handled it properly, but when sending the `QString` to Go, the conversion used this function:

https://doc.qt.io/qt-5/qstring.html#toLocal8Bit

in

```
backendCall(queryID, query.toLocal8Bit().constData());
```

which uses whatever local codec is defined.

In Go strings are UTF-8, so using `toUtf8()` instead is appropriate and fixes the issue.

We change all instances of toLocal8bit to toUtf8 for the same reason, fixing possibly other existing bugs on Windows.