### PR TITLE
frontend/send: wipe proposed tx note

### DIFF
--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -173,6 +173,8 @@ class Send extends Component<Props, State> {
   public componentWillUnmount() {
     this.unregisterEvents();
     unsubscribe(this.unsubscribeList);
+    // Wipe proposed tx note.
+    accountApi.proposeTxNote(this.getAccount()!.code, '');
   }
 
   private registerEvents = () => document.addEventListener('keydown', this.handleKeyDown);


### PR DESCRIPTION
Bug: enter send screen, modify note, exit send screen, re-enter send screen. Now the note field is empty but the previously proposed tx note will be used to label the new transaction.

Fix: wipe the proposed tx note when leaving the send screen.