### PR TITLE
frontend: make reusable pill button & pill button group

### DIFF
--- a/frontends/web/src/components/pillbuttongroup/pillbuttongroup.module.css
+++ b/frontends/web/src/components/pillbuttongroup/pillbuttongroup.module.css
@@ -1,0 +1,54 @@
+.pillbuttongroup {
+	align-items: baseline;
+	display: flex;
+	flex-wrap: wrap;
+	flex-grow: 1;
+}
+
+.pillbuttongroup button {
+	appearance: none;
+	background: var(--background-secondary);
+	border: 2px solid var(--background-secondary);
+	border-radius: 2rem;
+	color: var(--color-default);
+	font-size: var(--size-default);
+	line-height: 1.75;
+	margin-bottom: var(--spacing-half);
+	margin-left: var(--spacing-half);
+	padding: 0 calc(var(--spacing-default) * .75);
+}
+
+.pillbuttongroup button:first-child {
+	margin-left: 0;
+}
+
+.pillbuttongroup button:hover:not([disabled]) {
+	cursor: pointer;
+}
+
+.pillbuttongroup button:hover:is([disabled]) {
+	cursor: not-allowed;
+}
+
+.pillbuttongroup button:focus {
+	border: 2px solid var(--color-blue);
+	outline: none;
+}
+
+.pillbuttongroup button.active {
+	background: var(--color-blue);
+	border-color: var(--color-blue);
+	color: var(--color-alt);
+}
+
+.pillbuttongroup button[disabled] {
+	background: var(--background-quaternary);
+	border-color: var(--background-quaternary);
+	color: var(--color-alt);
+}
+
+:global(.dark-mode) .pillbuttongroup button[disabled] {
+	background: var(--background-secondary);
+	border-color: var(--background-secondary);
+	color: var(--color-disabled);
+}

--- a/frontends/web/src/components/pillbuttongroup/pillbuttongroup.tsx
+++ b/frontends/web/src/components/pillbuttongroup/pillbuttongroup.tsx
@@ -1,0 +1,52 @@
+
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode } from 'react';
+import styles from './pillbuttongroup.module.css';
+
+type TPillTabProps = {
+  children: ReactNode;
+  className?: string;
+}
+
+type TPillTabButtonProps = {
+    active: boolean;
+    children: ReactNode;
+    disabled?: boolean;
+    onClick: () => void;
+}
+
+export const PillButtonGroup = ({ className = '', children }: TPillTabProps) => {
+  return <div className={`${styles.pillbuttongroup} ${className}`}>{children}</div>;
+};
+
+export const PillButton = ({
+  active,
+  children,
+  onClick,
+  disabled = false,
+}: TPillTabButtonProps) => {
+  return (
+    <button
+      className={active ? styles.active : ''}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};

--- a/frontends/web/src/routes/account/summary/chart.module.css
+++ b/frontends/web/src/routes/account/summary/chart.module.css
@@ -33,16 +33,11 @@
 }
 
 .filters {
-  align-items: baseline;
-  display: flex;
-  flex-wrap: wrap;
-  flex-grow: 1;
   justify-content: flex-end;
   margin: var(--spacing-half) 0 0 0;
 }
 
 @media (max-width: 640px){
-
   .chart{
     margin-bottom: var(--spacing-default);
   }
@@ -55,7 +50,7 @@
     align-items: center;
   }
 
-  .filters{
+  .filters {
     justify-content: center;
     margin-top: var(--spacing-default);
   }
@@ -67,54 +62,6 @@
     padding-right: var(--space-half);
   }
 }
-
-.filters button {
-  appearance: none;
-  background: var(--background-secondary);
-  border: 2px solid var(--background-secondary);
-  border-radius: 2rem;
-  color: var(--color-default);
-  font-size: var(--size-default);
-  line-height: 1.75;
-  margin-bottom: var(--spacing-half);
-  margin-left: var(--spacing-half);
-  padding: 0 calc(var(--spacing-default) * .75);
-}
-
-.filters button:first-child {
-  margin-left: 0;
-}
-
-.filters button:hover:not([disabled]) {
-  cursor: pointer;
-}
-
-.filters button:hover:is([disabled]) {
-  cursor: not-allowed;
-}
-
-.filters button:focus {
-  border: 2px solid var(--color-blue);
-  outline: none;
-}
-
-.filters button.filterActive {
-  background: var(--color-blue);
-  border-color: var(--color-blue);
-  color: var(--color-alt);
-}
-
-.filters button[disabled] {
-  background: var(--background-quaternary);
-  border-color: var(--background-quaternary);
-  color: var(--color-alt);
-}
-:global(.dark-mode) .filters button[disabled] {
-  background: var(--background-secondary);
-  border-color: var(--background-secondary);
-  color: var(--color-disabled);
-}
-
 
 .totalValue {
   font-size: 2rem;
@@ -140,7 +87,6 @@
     overflow: hidden;
   }
 }
-  
 
 .tooltip {
   background: var(--background-secondary);

--- a/frontends/web/src/routes/account/summary/filters.tsx
+++ b/frontends/web/src/routes/account/summary/filters.tsx
@@ -16,6 +16,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { TChartFiltersProps } from './types';
+import { PillButton, PillButtonGroup } from '../../../components/pillbuttongroup/pillbuttongroup';
 import styles from './chart.module.css';
 
 export const Filters = ({
@@ -29,31 +30,35 @@ export const Filters = ({
 }: TChartFiltersProps) => {
   const { t } = useTranslation();
   return (
-    <div className={styles.filters}>
-      <button
-        className={display === 'week' ? styles.filterActive : undefined}
+    <PillButtonGroup className={styles.filters}>
+      <PillButton
+        active={display === 'week'}
         disabled={disableFilters || disableWeeklyFilters}
-        onClick={onDisplayWeek}>
+        onClick={onDisplayWeek}
+      >
         {t('chart.filter.week')}
-      </button>
-      <button
-        className={display === 'month' ? styles.filterActive : undefined}
+      </PillButton>
+      <PillButton
+        active={display === 'month'}
         disabled={disableFilters}
-        onClick={onDisplayMonth}>
+        onClick={onDisplayMonth}
+      >
         {t('chart.filter.month')}
-      </button>
-      <button
-        className={display === 'year' ? styles.filterActive : undefined}
+      </PillButton>
+      <PillButton
+        active={display === 'year'}
         disabled={disableFilters}
-        onClick={onDisplayYear}>
+        onClick={onDisplayYear}
+      >
         {t('chart.filter.year')}
-      </button>
-      <button
-        className={display === 'all' ? styles.filterActive : undefined}
+      </PillButton>
+      <PillButton
+        active={display === 'all'}
         disabled={disableFilters}
-        onClick={onDisplayAll}>
+        onClick={onDisplayAll}
+      >
         {t('chart.filter.all')}
-      </button>
-    </div>
+      </PillButton>
+    </PillButtonGroup>
   );
 };


### PR DESCRIPTION
Right now, we're only using such components in `filters.tsx`. However, this will change in the future as other components may incorporate these pill buttons for filtering / tabbing-like functionality.

I didn't make a new variant in the button component because we wanna keep the styling on the parent container of the buttons (`PillButtonGroup`) as we want them to look & behave the same (size-wise, etc) on every components we want to have them in. So instead, I made a `PillButtonGroup` and `PillButton` components to be used together.  