### PR TITLE
backend/lightning: don't expose mnemonic words for lightning

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -1529,8 +1529,29 @@ func (handlers *Handlers) postExportLog(r *http.Request) interface{} {
 	return result{Success: true}
 }
 
+type lightningAccountConfigWithoutMnemonic struct {
+	RootFingerprint jsonp.HexBytes     `json:"rootFingerprint"`
+	Code            accountsTypes.Code `json:"code"`
+	Number          uint16             `json:"num"`
+}
+
+type lightningConfigWithoutMnemonic struct {
+	Accounts []*lightningAccountConfigWithoutMnemonic `json:"accounts"`
+}
+
 func (handlers *Handlers) getLightningConfigHandler(_ *http.Request) interface{} {
-	return handlers.backend.Config().LightningConfig()
+	lightningAccounts := handlers.backend.Config().LightningConfig().Accounts
+	accounts := make([]*lightningAccountConfigWithoutMnemonic, len(lightningAccounts))
+	for i, account := range lightningAccounts {
+		accounts[i] = &lightningAccountConfigWithoutMnemonic{
+			RootFingerprint: account.RootFingerprint,
+			Code:            account.Code,
+			Number:          account.Number,
+		}
+	}
+	return lightningConfigWithoutMnemonic{
+		Accounts: accounts,
+	}
 }
 
 func (handlers *Handlers) postLightningConfigHandler(r *http.Request) (interface{}, error) {

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -27,7 +27,6 @@ export interface ILightningResponse<T> {
 }
 
 export type TLightningAccountConfig = {
-  mnemonic: string;
   rootFingerprint: string;
   code: AccountCode;
   num: number;


### PR DESCRIPTION
This commit ensures the mnemonic words created
for lightning wallet are not exposed to frontend.