### PR TITLE
frontend: refactor password.jsx into typescript

### DIFF
--- a/frontends/web/src/routes/device/bitbox01/restore.tsx
+++ b/frontends/web/src/routes/device/bitbox01/restore.tsx
@@ -41,7 +41,7 @@ interface State {
     activeDialog: boolean;
     isLoading: boolean;
     understand: boolean;
-    password?: string;
+    password?: string | null;
 }
 
 class Restore extends Component<Props, State> {
@@ -109,7 +109,7 @@ class Restore extends Component<Props, State> {
     this.setState({ understand: e.target.checked });
   };
 
-  private setValidPassword = (password: string) => {
+  private setValidPassword = (password: string | null) => {
     this.setState({ password });
   };
 

--- a/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
@@ -85,7 +85,7 @@ class Initialize extends Component<Props, State> {
     });
   };
 
-  private setValidPassword = (password: string) => {
+  private setValidPassword = (password: string | null) => {
     this.setState({ password });
   };
 

--- a/frontends/web/src/routes/device/bitbox01/unlock.jsx
+++ b/frontends/web/src/routes/device/bitbox01/unlock.jsx
@@ -89,7 +89,6 @@ class Unlock extends Component {
     const { t } = this.props;
     const {
       status,
-      password,
       errorCode,
       errorMessage,
       remainingAttempts,
@@ -135,12 +134,10 @@ class Unlock extends Component {
                         <PasswordSingleInput
                           autoFocus
                           id="password"
-                          type="password"
                           label={t('unlock.input.label')}
                           disabled={status === stateEnum.WAITING}
                           placeholder={t('unlock.input.placeholder')}
-                          onValidPassword={this.handleFormChange}
-                          value={password} />
+                          onValidPassword={this.handleFormChange}/>
                       </div>
                       <div className="buttons">
                         <Button

--- a/frontends/web/src/routes/device/components/skipfortesting.tsx
+++ b/frontends/web/src/routes/device/components/skipfortesting.tsx
@@ -58,11 +58,9 @@ export const SkipForTesting = ({
       <Dialog open={dialog} title={title} onClose={() => setDialog(false)}>
         <form onSubmit={registerTestingDevice}>
           <PasswordSingleInput
-            type="password"
             autoFocus
             label="Test Password"
-            onValidPassword={setTestPIN}
-            value={testPIN} />
+            onValidPassword={(pw) => pw ? setTestPIN(pw) : setTestPIN('')}/>
           <DialogButtons>
             <Button primary type="submit">
               Unlock


### PR DESCRIPTION
Refactor the `password.jsx` file into typescript.

I had to cast to the concrete type a lot of times, I'm not sure if that makes sense since it can throw an error, but how _should_ an error be handled? e.g. `this.setState({ [stateKey]: value } as Pick<TState, keyof TState>, this.validate);`

