### PR TITLE
frontend: bump flag-icons dep. to latest 7.2.3

### DIFF
--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -11,7 +11,7 @@
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/types": "^2.10.4",
         "@walletconnect/web3wallet": "^1.9.3",
-        "flag-icons": "^6.6.6",
+        "flag-icons": "7.2.3",
         "i18next": "21.6.16",
         "lightweight-charts": "4.1.4",
         "qr-scanner": "1.4.2",
@@ -7244,9 +7244,10 @@
       }
     },
     "node_modules/flag-icons": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-6.15.0.tgz",
-      "integrity": "sha512-ARo9Q+aATZEjyjveeec9e+orx+xLWUBdOX9baOKoGqDzMbvZ65ghPhaHbVt5T7ZB+Q4OFsB4Hr+eQnpV8Q+dLA=="
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-7.2.3.tgz",
+      "integrity": "sha512-X2gUdteNuqdNqob2KKTJTS+ZCvyWeLCtDz9Ty8uJP17Y4o82Y+U/Vd4JNrdwTAjagYsRznOn9DZ+E/Q52qbmqg==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "3.2.0",

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -24,7 +24,7 @@
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/types": "^2.10.4",
     "@walletconnect/web3wallet": "^1.9.3",
-    "flag-icons": "^6.6.6",
+    "flag-icons": "7.2.3",
     "i18next": "21.6.16",
     "lightweight-charts": "4.1.4",
     "qr-scanner": "1.4.2",


### PR DESCRIPTION
no breaking changes, simple update.

flag-icons [CHANGELOG.md](https://github.com/lipis/flag-icons/blob/main/CHANGELOG.md)