### PR TITLE
frontend: bump lightweight-charts dep. to latest

### DIFF
--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -13,7 +13,7 @@
         "@walletconnect/web3wallet": "^1.9.3",
         "flag-icons": "^6.6.6",
         "i18next": "21.6.16",
-        "lightweight-charts": "4.1.1",
+        "lightweight-charts": "4.1.4",
         "qr-scanner": "1.4.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -8560,9 +8560,10 @@
       }
     },
     "node_modules/lightweight-charts": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.1.1.tgz",
-      "integrity": "sha512-HYjm66NAIOhoLDNaaQsiwOVWiFHL1yrygZeKd4PgdZESnWyp5dPoTe3pH3t2h4ix+Ix5TwLZaNbWroZqQuj6OA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.1.4.tgz",
+      "integrity": "sha512-jsQOK27a3wiw/Db3Eoo3VX93LGovXA/sOWHVEiEosGOOGtxSSuIWTYVebjRKGK0SWkkUwI8AHQ4j7HZSKm7fxA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "fancy-canvas": "2.1.0"
       }

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -26,7 +26,7 @@
     "@walletconnect/web3wallet": "^1.9.3",
     "flag-icons": "^6.6.6",
     "i18next": "21.6.16",
-    "lightweight-charts": "4.1.1",
+    "lightweight-charts": "4.1.4",
     "qr-scanner": "1.4.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
Bump lightweight-charts dependency to latest version 4.1.4.

No breaking changes, see [release notes.](https://github.com/tradingview/lightweight-charts/blob/0f7343e7934a063238c61a67ca9926248f7f1fbd/website/docs/release-notes.md)

tested on `webdev` chrome.