### PR TITLE
frontend: bump react-select dep. to latest 5.8.0

### DIFF
--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -19,7 +19,7 @@
         "react-dom": "18.2.0",
         "react-i18next": "11.16.8",
         "react-router-dom": "6.4.3",
-        "react-select": "5.7.4",
+        "react-select": "5.8.0",
         "request-address": "0.0.6"
       },
       "devDependencies": {
@@ -9625,9 +9625,10 @@
       }
     },
     "node_modules/react-select": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.4.tgz",
-      "integrity": "sha512-NhuE56X+p9QDFh4BgeygHFIvJJszO1i1KSkg/JPcIJrbovyRtI+GuOEa4XzFCEpZRAEoEI8u/cAHK+jG/PgUzQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.0.tgz",
+      "integrity": "sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -32,7 +32,7 @@
     "react-dom": "18.2.0",
     "react-i18next": "11.16.8",
     "react-router-dom": "6.4.3",
-    "react-select": "5.7.4",
+    "react-select": "5.8.0",
     "request-address": "0.0.6"
   },
   "eslintConfig": {


### PR DESCRIPTION
no breaking changes, see [release notes.](https://github.com/JedWatson/react-select/releases)

tested on `webdev` chrome.