### PR TITLE
frontend: bump @walletconnect versions to latest

### DIFF
--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -8,9 +8,9 @@
       "name": "bitboxapp",
       "version": "0.0.0",
       "dependencies": {
-        "@walletconnect/jsonrpc-types": "^1.0.3",
-        "@walletconnect/types": "^2.10.4",
-        "@walletconnect/web3wallet": "^1.9.3",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/types": "2.13.1",
+        "@walletconnect/web3wallet": "1.12.1",
         "flag-icons": "7.2.3",
         "i18next": "23.11.5",
         "lightweight-charts": "4.1.4",
@@ -4847,6 +4847,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.13.1.tgz",
       "integrity": "sha512-h0MSYKJu9i1VEs5koCTT7c5YeQ1Kj0ncTFiMqANbDnB1r3mBulXn+FKtZ2fCmf1j7KDpgluuUzpSs+sQfPcv4Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-provider": "1.0.14",
@@ -4865,6 +4866,15 @@
         "isomorphic-unfetch": "3.1.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "3.1.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/uint8arrays": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
+      "integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
       }
     },
     "node_modules/@walletconnect/environment": {
@@ -4888,6 +4898,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.2.tgz",
       "integrity": "sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
@@ -4898,6 +4909,7 @@
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.14.tgz",
       "integrity": "sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/safe-json": "^1.0.2",
@@ -4908,6 +4920,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.4.tgz",
       "integrity": "sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==",
+      "license": "MIT",
       "dependencies": {
         "events": "^3.3.0",
         "keyvaluestorage-interface": "^1.0.0"
@@ -4965,6 +4978,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.10.tgz",
       "integrity": "sha512-tqrdd4zU9VBNqUaXXQASaexklv6A54yEyQQEXYOCr+Jz8Ket0dmPBDyg19LVSNUN2cipAghQc45/KVmfFJ0cYw==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-types": "^1.0.2"
       }
@@ -4994,6 +5008,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.13.1.tgz",
       "integrity": "sha512-e+dcqcLsedB4ZjnePFM5Cy8oxu0dyz5iZfhfKH/MOrQV/hyhZ+hJwh4MmkO2QyEu2PERKs9o2Uc6x8RZdi0UAQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/core": "2.13.1",
         "@walletconnect/events": "1.0.1",
@@ -5018,6 +5033,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.13.1.tgz",
       "integrity": "sha512-CIrdt66d38xdunGCy5peOOP17EQkCEGKweXc3+Gn/RWeSiRU35I7wjC/Bp4iWcgAQ6iBTZv4jGGST5XyrOp+Pg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -5031,6 +5047,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.13.1.tgz",
       "integrity": "sha512-EcooXXlqy5hk9hy/nK2wBF/qxe7HjH0K8ZHzjKkXRkwAE5pCvy0IGXIXWmUR9sw8LFJEqZyd8rZdWLKNUe8hqA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -5048,10 +5065,20 @@
         "uint8arrays": "3.1.0"
       }
     },
+    "node_modules/@walletconnect/utils/node_modules/uint8arrays": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
+      "integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/@walletconnect/web3wallet": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/web3wallet/-/web3wallet-1.12.1.tgz",
       "integrity": "sha512-34h7UkWjZvZdtCc/t6tZCSBPjDzJbfG1+OPkJ6FiD1KJP+a0wSwuI7l4LliGgvAdsXfrM+sn3ZEWVWy62zeRDA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/auth-client": "2.1.2",
         "@walletconnect/core": "2.13.1",

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -21,9 +21,9 @@
     "vitest": "^1.4.0"
   },
   "dependencies": {
-    "@walletconnect/jsonrpc-types": "^1.0.3",
-    "@walletconnect/types": "^2.10.4",
-    "@walletconnect/web3wallet": "^1.9.3",
+    "@walletconnect/jsonrpc-types": "1.0.4",
+    "@walletconnect/types": "2.13.1",
+    "@walletconnect/web3wallet": "1.12.1",
     "flag-icons": "7.2.3",
     "i18next": "23.11.5",
     "lightweight-charts": "4.1.4",


### PR DESCRIPTION
Bump all @walletconnect dependencies to the newest versions:
@walletconnect/jsonrpc-types@1.0.4
@walletconnect/types@2.13.1
@walletconnect/web3wallet@1.12.1

Since the dependencies are transitive they should be updated together. There is no easy way to check for any breaking changes because there is not really something like a changelog (?).

- tested with `webdev` real BB02M keystore and Wallet Connect to Uniswap, connection was established without any issues.