### PR TITLE
frontend: bump react dep. version to 18.3.1

### DIFF
--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -15,7 +15,7 @@
         "i18next": "21.6.16",
         "lightweight-charts": "4.1.4",
         "qr-scanner": "1.4.2",
-        "react": "18.2.0",
+        "react": "18.3.1",
         "react-dom": "18.2.0",
         "react-i18next": "11.16.8",
         "react-router-dom": "6.4.3",
@@ -9536,9 +9536,10 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -28,7 +28,7 @@
     "i18next": "21.6.16",
     "lightweight-charts": "4.1.4",
     "qr-scanner": "1.4.2",
-    "react": "18.2.0",
+    "react": "18.3.1",
     "react-dom": "18.2.0",
     "react-i18next": "11.16.8",
     "react-router-dom": "6.4.3",


### PR DESCRIPTION
All other dependencies support at least `^18.0.0` in their peer dependency list:

```
[sus@archlinux web]$ npm ls react
bitboxapp@0.0.0 /home/sus/Work/bitbox/dev/bitbox-wallet-app/frontends/web
├─┬ @testing-library/react@14.3.1
│ └── react@18.2.0 deduped
├─┬ react-dom@18.2.0
│ └── react@18.2.0 deduped
├─┬ react-i18next@11.16.8
│ └── react@18.2.0 deduped
├─┬ react-router-dom@6.4.3
│ ├─┬ react-router@6.4.3
│ │ └── react@18.2.0 deduped
│ └── react@18.2.0 deduped
├─┬ react-select@5.8.0
│ ├─┬ @emotion/react@11.11.4
│ │ ├─┬ @emotion/use-insertion-effect-with-fallbacks@1.0.1
│ │ │ └── react@18.2.0 deduped
│ │ └── react@18.2.0 deduped
│ ├─┬ react-transition-group@4.4.5
│ │ └── react@18.2.0 deduped
│ ├── react@18.2.0 deduped
│ └─┬ use-isomorphic-layout-effect@1.1.2
│   └── react@18.2.0 deduped
└── react@18.2.0

[sus@archlinux web]$ cat node_modules/react-select/package.json | grep peerDependencies -A 5
  "peerDependencies": {
    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
  },
  "files": [
    "dist",
[sus@archlinux web]$ cat node_modules/react-router-dom/package.json | grep peerDependencies -A 5
  "peerDependencies": {
    "react": ">=16.8",
    "react-dom": ">=16.8"
  },
  "files": [
    "dist/",
[sus@archlinux web]$ cat node_modules/react-i18next/package.json | grep peerDependencies -A 5
  "peerDependencies": {
    "i18next": ">= 19.0.0",
    "react": ">= 16.8.0"
  },
  "peerDependenciesMeta": {
    "react-dom": {
      "optional": true
    },
    "react-native": {
      "optional": true
[sus@archlinux web]$ cat node_modules/react-dom/package.json | grep peerDependencies -A 5
  "peerDependencies": {
    "react": "^18.2.0"
  },
  "files": [
    "LICENSE",
    "README.md",
``