### PR TITLE
.github/workflows/ci.yml: fix typo in docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   # "docker login ghcr.io -u <github-username>" using the
   # newly generated token as password.
   # Once logged in, tag an new image:
-  #   docker tag bitboxswiss/bitbox-wallet-app:VERSION \
+  #   docker tag shiftcrypto/bitbox-wallet-app:VERSION \
   #     ghcr.io/bitboxswiss/bitbox-wallet-app-ci:VERSION
   # and push as usual:
   #   docker push ghcr.io/bitboxswiss/bitbox-wallet-app-ci:VERSION


### PR DESCRIPTION
Accidentally renamed in 0dd9660def9896eca922895285d432651924d2ab, but the docker hub org name is shiftcrypto and not bitboxswiss.