### PR TITLE
feat: added trivy repository mode scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,24 @@ env:
   GITHUB_BUILD_DIR: ${{github.workspace}}
 
 jobs:
+  trivy:
+    name: trivy
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@0.22.0
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
   test-lint:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
Hi,
I've added a Trivy action scanner (in repository mode), to scan for security vulnerabilities. The results would be sent to the security tab (can be changed). I'm using it for all my repositories and recommend it.
If you like the idea, You can ask me anything. A example run can be seen on my fork [here](https://github.com/baizon/bitbox-wallet-app/actions/runs/9444306412/job/26009589307).
For more information see: https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#usage
