### PR TITLE
chore(deps): update golangci to 1.59.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ catch:
 	@echo "Choose a make target."
 envinit:
 	# Keep golangci-lint version in sync with what's in .github/workflows/ci.yml.
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.55.2
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.59.0
 	go install github.com/vektra/mockery/v2@latest
 	go install github.com/matryer/moq@latest
 	go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
I just found that updating golangci there is a manual change needed in the Makefile to also bump the version.