### PR TITLE
frontend: remove keydown blocking in spinner component

### DIFF
--- a/frontends/web/src/components/spinner/Spinner.tsx
+++ b/frontends/web/src/components/spinner/Spinner.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AppContext } from '../../contexts/AppContext';
 import { MenuDark } from '../icon';
@@ -31,16 +31,6 @@ const Spinner = ({ text, guideExists }: TProps) => {
   const { t } = useTranslation();
 
   const { toggleGuide, toggleSidebar } = useContext(AppContext);
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    e.preventDefault();
-    (document.activeElement as HTMLInputElement).blur();
-  };
-
-  useEffect(() => {
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, []);
 
   return (
     <div className={style.spinnerContainer}>


### PR DESCRIPTION
 The Spinner component has some logic that aggressively suppresses
keydown events, it prevents the default bubbling of the event and
removes focus from the active element.

This was done to prevent the user from accidentally navigating or
changing a form that was covered by the Spinner.

The logic was introduced to Spinner and WaitDialog in:
- d7a9fec80254740dc905974374206b100e896ecc
- a0077119ccc607b728dff95f023f2c337bd751a9

Listening to global document and preventing the event is a bit a
hack and at some point this broke on macOS. It still works on
Linux and is the reason for a regression. The bug is that users
can not enter a device name during setup and the input element
looses focus when typing.

Regression was introduced in a change that conditionally shows
the Spinner in the Waiting view. As the setup wizard itself is
now an overlay, the Spinner can be rendered below and is not
visible but still suppresses global keydown event.
- ee2d529a1a26187e9cf2cfafd4c0fa284939d687

To prevent such issues this commit removes the logic in Spinner.
This should be fine in cases where the Spinner does not cover
any elements (account overview, buy info). Spinner is also
used to cover iframes until onload event occurs, this should
be ok as the spinner only appears quickly.

WaitDialog should not be rendered below an overlay, but also
the keydown event suppression does not work on macOS. Keeping as
is for now.

This commit only fixes the regression, but there are a few changes
that could improve blocking the UI in the future:
- having a global "block" or "isBlocking" state in app context
- moving away from form covering dialogs to just display the
  data instead of the form for example in Send view
