### PR TITLE
backend: sort unconfirmed transactions by created time

### DIFF
--- a/backend/accounts/transaction.go
+++ b/backend/accounts/transaction.go
@@ -131,14 +131,17 @@ func (tx *TransactionData) isConfirmed() bool {
 
 // byHeight defines the methods needed to satisify sort.Interface to sort transactions by their
 // height. Special case for unconfirmed transactions (height <=0), which come last. If the height
-// is the same for two txs, they are sorted by the created (first seen) time instead.
+// is the same for two txs, or both txs are unconfirmed they are sorted by the created (first seen)
+// time instead.
 type byHeight []*TransactionData
 
 func (s byHeight) Len() int { return len(s) }
 func (s byHeight) Less(i, j int) bool {
 	// Secondary sort by the time we've first seen the tx in the app.
-	if s[i].Height == s[j].Height && s[i].CreatedTimestamp != nil && s[j].CreatedTimestamp != nil {
-		return s[i].CreatedTimestamp.Before(*s[j].CreatedTimestamp)
+	if s[i].CreatedTimestamp != nil && s[j].CreatedTimestamp != nil {
+		if (s[i].Height == s[j].Height) || (s[i].Height <= 0 && s[j].Height <= 0) {
+			return s[i].CreatedTimestamp.Before(*s[j].CreatedTimestamp)
+		}
 	}
 	if s[j].Height <= 0 {
 		return true

--- a/backend/accounts/transaction_test.go
+++ b/backend/accounts/transaction_test.go
@@ -45,16 +45,32 @@ func TestOrderedTransactions(t *testing.T) {
 			Amount:    coin.NewAmountFromInt64(300),
 		},
 		{
-			Timestamp: nil,
-			Height:    0,
-			Type:      TxTypeSend,
-			Amount:    coin.NewAmountFromInt64(20),
+			Timestamp:        nil,
+			CreatedTimestamp: tt(time.Date(2020, 9, 23, 13, 0, 0, 0, time.UTC)),
+			Height:           0,
+			Type:             TxTypeSend,
+			Amount:           coin.NewAmountFromInt64(10),
 		},
 		{
-			Timestamp: nil,
-			Height:    -1, // unconfirmed parent
-			Type:      TxTypeSend,
-			Amount:    coin.NewAmountFromInt64(20),
+			Timestamp:        nil,
+			CreatedTimestamp: tt(time.Date(2020, 9, 23, 14, 0, 0, 0, time.UTC)),
+			Height:           0,
+			Type:             TxTypeSend,
+			Amount:           coin.NewAmountFromInt64(5),
+		},
+		{
+			Timestamp:        nil,
+			CreatedTimestamp: tt(time.Date(2020, 9, 23, 12, 0, 0, 0, time.UTC)),
+			Height:           -1, // unconfirmed parent
+			Type:             TxTypeSend,
+			Amount:           coin.NewAmountFromInt64(15),
+		},
+		{
+			Timestamp:        nil,
+			CreatedTimestamp: tt(time.Date(2020, 9, 23, 11, 0, 0, 0, time.UTC)),
+			Height:           -1, // unconfirmed parent
+			Type:             TxTypeSend,
+			Amount:           coin.NewAmountFromInt64(20),
 		},
 		{
 			Timestamp: tt(time.Date(2020, 9, 11, 12, 0, 0, 0, time.UTC)),
@@ -79,14 +95,16 @@ func TestOrderedTransactions(t *testing.T) {
 		},
 	}
 	ordered := NewOrderedTransactions(txs)
-	require.Equal(t, coin.NewAmountFromInt64(544), ordered[0].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(564), ordered[1].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(584), ordered[2].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(589), ordered[3].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(590), ordered[4].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(290), ordered[5].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(190), ordered[6].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(200), ordered[7].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(534), ordered[0].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(539), ordered[1].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(549), ordered[2].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(564), ordered[3].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(584), ordered[4].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(589), ordered[5].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(590), ordered[6].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(290), ordered[7].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(190), ordered[8].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(200), ordered[9].Balance)
 
 	timeseries, err := ordered.Timeseries(
 		time.Date(2020, 9, 9, 13, 0, 0, 0, time.UTC),


### PR DESCRIPTION
This commit updates the transaction history sorting to handle multiple unconfirmed transactions. These transactions are now sorted by their created time.