### PR TITLE
frontend: bump @testing-library/jest-dom version

### DIFF
--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -24,7 +24,7 @@
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-        "@testing-library/jest-dom": "^6.4.2",
+        "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^14.2.1",
         "@testing-library/user-event": "^14.5.2",
         "@types/node": "^20.12.7",
@@ -3984,12 +3984,13 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.5.tgz",
-      "integrity": "sha512-AguB9yvTXmCnySBP1lWjfNNUwpbElsaQ567lt2VdGqAdHtpieLgjmcVyv1q7PMIvLbgpDdkWV5Ydv3FEejyp2A==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.6.tgz",
+      "integrity": "sha512-8qpnGVincVDLEcQXWaHOf6zmlbwTKc6Us6PPu4CRnPXCzo2OGBS5cwgMMOWdxDpEz1mkbvXHpEy99M5Yvt682w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@adobe/css-tools": "^4.3.2",
+        "@adobe/css-tools": "^4.4.0",
         "@babel/runtime": "^7.9.2",
         "aria-query": "^5.0.0",
         "chalk": "^3.0.0",

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.2",
     "@types/node": "^20.12.7",


### PR DESCRIPTION
Bump the version of the @testing-library/jest-dom to the latest version 6.4.6.

There should be no breaking changes (since only minor version was updated), see the CHANGELOG:
https://github.com/testing-library/jest-dom/releases

Tested by running `act` locally since this is for testing this should be sufficient.