### PR TITLE
frontend: refactor transaction.tsx

### DIFF
--- a/frontends/web/src/components/transactions/components/address-or-txid.tsx
+++ b/frontends/web/src/components/transactions/components/address-or-txid.tsx
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CopyableInput } from '@/components/copy/Copy';
+import transactionStyle from '@/components/transactions/transactions.module.css';
+import parentStyle from '@/components/transactions/transaction.module.css';
+
+type TPropsTxAddress = {
+  label: string;
+  addresses: string[];
+}
+
+export const TxAddress = ({
+  label,
+  addresses,
+}: TPropsTxAddress) => {
+  return (
+    <div className={transactionStyle.activity}>
+      <span className={parentStyle.label}>
+        {label}
+      </span>
+      <span className={parentStyle.address}>
+        {addresses[0]}
+        {addresses.length > 1 && (
+          <span className={parentStyle.badge}>
+                    (+{addresses.length - 1})
+          </span>
+        )}
+      </span>
+    </div>
+  );
+};
+
+type TPropsTxDetailCopyableValues = {
+  label: string;
+  values: string[];
+}
+
+export const TxDetailCopyableValues = ({
+  label,
+  values,
+}: TPropsTxDetailCopyableValues) => {
+  return (
+    <div className={`${parentStyle.detail} ${parentStyle.addresses}`}>
+      <label>{label}</label>
+      <div className={parentStyle.detailAddresses}>
+        {values.map((addrOrTxID) => (
+          <CopyableInput
+            key={addrOrTxID}
+            alignRight
+            borderLess
+            flexibleHeight
+            className={parentStyle.detailAddress}
+            value={addrOrTxID}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontends/web/src/components/transactions/components/arrow.tsx
+++ b/frontends/web/src/components/transactions/components/arrow.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,21 @@
  * limitations under the License.
  */
 
-export const convertDateToLocaleString = (
-  date: string,
-  language: string
-) => {
-  return new Date(date).toLocaleString(language, {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-};
+import type { ITransaction } from '@/api/account';
+import { Warning } from '@/components/icon/icon';
+import { ArrowIn, ArrowOut, ArrowSelf } from './icons';
 
-export const parseTimeShort = (time: string, lang: string) => {
-  const options: Intl.DateTimeFormatOptions = {
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric',
-  };
-  return new Date(Date.parse(time)).toLocaleString(lang, options);
+type TProps = Pick<ITransaction, 'status' | 'type'>;
+
+export const Arrow = ({ status, type }: TProps) => {
+  if (status === 'failed') {
+    return <Warning style={{ maxWidth: '18px' }} />;
+  }
+  if (type === 'receive') {
+    return <ArrowIn />;
+  }
+  if (type === 'send') {
+    return <ArrowOut />;
+  }
+  return <ArrowSelf />;
 };

--- a/frontends/web/src/components/transactions/components/date.tsx
+++ b/frontends/web/src/components/transactions/components/date.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { parseTimeShort } from '@/utils/date';
+import { TxDetail } from './detail';
+import transactionsStyle from '@/components/transactions/transactions.module.css';
+import parentStyle from '@/components/transactions/transaction.module.css';
+
+type TProps = {
+  time: string | null;
+}
+
+export const TxDate = ({ time }: TProps) => {
+  const { i18n, t } = useTranslation();
+  const shortDate = time ? parseTimeShort(time, i18n.language) : '---';
+  return (
+    <div className={transactionsStyle.date}>
+      <span className={parentStyle.columnLabel}>
+        {t('transaction.details.date')}:
+      </span>
+      <span className={parentStyle.date}>{shortDate}</span>
+    </div>
+  );
+};
+
+export const TxDateDetail = ({ time }: TProps) => {
+  const { i18n, t } = useTranslation();
+  const shortDate = time ? parseTimeShort(time, i18n.language) : '---';
+  return (
+    <TxDetail
+      label={t('transaction.details.date')}>
+      {shortDate}
+    </TxDetail>
+  );
+};

--- a/frontends/web/src/components/transactions/components/detail.tsx
+++ b/frontends/web/src/components/transactions/components/detail.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import parentStyle from '@/components/transactions/transaction.module.css';
+
+type TProps = React.PropsWithChildren<{
+  label: string;
+}>;
+
+export const TxDetail = ({
+  label,
+  children,
+}: TProps) => {
+  return (
+    <div className={parentStyle.detail}>
+      <label>{label}</label>
+      <p>{children}</p>
+    </div>
+  );
+};

--- a/frontends/web/src/components/transactions/components/details.tsx
+++ b/frontends/web/src/components/transactions/components/details.tsx
@@ -1,0 +1,198 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ITransaction, IAmount, getTransaction } from '@/api/account';
+import { A } from '@/components/anchor/anchor';
+import { Dialog } from '@/components/dialog/dialog';
+import { FiatConversion } from '@/components/rates/rates';
+import { Amount } from '@/components/amount/amount';
+import { Note } from '@/components/transactions/note';
+import { TxDetail } from './detail';
+import { Arrow } from './arrow';
+import { TxDateDetail } from './date';
+import { TxStatusDetail } from './status';
+import { TxDetailCopyableValues } from './address-or-txid';
+import parentStyle from '@/components/transactions/transaction.module.css';
+
+type TProps = {
+  open: boolean;
+  onClose: () => void;
+  accountCode: string;
+  internalID: string;
+  note: string;
+  status: ITransaction['status'];
+  type: ITransaction['type'];
+  numConfirmations: number;
+  numConfirmationsComplete: number;
+  time: string | null;
+  amount: IAmount;
+  sign: string;
+  typeClassName: string;
+  explorerURL: string;
+}
+
+export const TxDetailsDialog = ({
+  open,
+  onClose,
+  accountCode,
+  internalID,
+  note,
+  status,
+  type,
+  numConfirmations,
+  numConfirmationsComplete,
+  time,
+  amount,
+  sign,
+  typeClassName,
+  explorerURL,
+}: TProps) => {
+  const { t } = useTranslation();
+
+  const [transactionInfo, setTransactionInfo] = useState<ITransaction | null>(null);
+
+  useEffect(() => {
+    if (!transactionInfo && open) {
+      getTransaction(accountCode, internalID).then(transaction => {
+        if (!transaction) {
+          console.error(`Unable to retrieve transaction ${internalID}`);
+        }
+        setTransactionInfo(transaction);
+      }).catch(console.error);
+    }
+  }, [accountCode, internalID, open, transactionInfo]);
+
+  // Amount and Confirmations info are displayed using props data
+  // instead of transactionInfo because they are live updated.
+  return (
+    <Dialog
+      open={open && !!transactionInfo}
+      title={t('transaction.details.title')}
+      onClose={onClose}
+      slim
+      medium>
+      {transactionInfo && (
+        <>
+          <Note
+            accountCode={accountCode}
+            internalID={internalID}
+            note={note}
+          />
+          <TxDetail label={t('transaction.details.type')}>
+            <Arrow
+              status={status}
+              type={type}
+            />
+          </TxDetail>
+          <TxDetail label={t('transaction.confirmation')}>{numConfirmations}</TxDetail>
+          <TxStatusDetail
+            status={status}
+            numConfirmations={numConfirmations}
+            numConfirmationsComplete={numConfirmationsComplete}
+          />
+          <TxDateDetail time={time} />
+          <TxDetail label={t('transaction.details.fiat')}>
+            <span className={`${parentStyle.fiat} ${typeClassName}`}>
+              <FiatConversion amount={amount} sign={sign} noAction />
+            </span>
+          </TxDetail>
+          <TxDetail label={t('transaction.details.fiatAtTime')}>
+            <span className={`${parentStyle.fiat} ${typeClassName}`}>
+              {transactionInfo.amountAtTime ?
+                <FiatConversion amount={transactionInfo.amountAtTime} sign={sign} noAction />
+                :
+                <FiatConversion noAction />
+              }
+            </span>
+          </TxDetail>
+          <TxDetail label={t('transaction.details.amount')}>
+            <span className={`${parentStyle.amount} ${typeClassName}`}>
+              {sign}
+              <Amount amount={amount.amount} unit={amount.unit} />
+            </span>
+            {' '}
+            <span className={`${parentStyle.currencyUnit} ${typeClassName}`}>{transactionInfo.amount.unit}</span>
+          </TxDetail>
+          {
+            transactionInfo.fee && transactionInfo.fee.amount ? (
+              <TxDetail label={t('transaction.fee')}>
+                <Amount amount={transactionInfo.fee.amount} unit={transactionInfo.fee.unit} />
+                {' '}
+                <span className={parentStyle.currencyUnit}>{transactionInfo.fee.unit}</span>
+              </TxDetail>
+            ) : (
+              <TxDetail label={t('transaction.fee')}>---</TxDetail>
+            )
+          }
+          <TxDetailCopyableValues
+            label={t('transaction.details.address')}
+            values={transactionInfo.addresses}
+          />
+          {
+            transactionInfo.gas ? (
+              <TxDetail label={t('transaction.gas')}>{transactionInfo.gas}</TxDetail>
+            ) : null
+          }
+          {
+            transactionInfo.nonce ? (
+              <TxDetail label="Nonce">{transactionInfo.nonce}</TxDetail>
+            ) : null
+          }
+          {
+            transactionInfo.weight ? (
+              <TxDetail label={t('transaction.weight')}>
+                {transactionInfo.weight}
+                {' '}
+                <span className={parentStyle.currencyUnit}>WU</span>
+              </TxDetail>
+            ) : null
+          }
+          {
+            transactionInfo.vsize ? (
+              <TxDetail label={t('transaction.vsize')}>
+                {transactionInfo.vsize}
+                {' '}
+                <span className={parentStyle.currencyUnit}>b</span>
+              </TxDetail>
+            ) : null
+          }
+          {
+            transactionInfo.size ? (
+              <TxDetail label={t('transaction.size')}>
+                {transactionInfo.size}
+                {' '}
+                <span className={parentStyle.currencyUnit}>b</span>
+              </TxDetail>
+            ) : null
+          }
+          <TxDetailCopyableValues
+            label={t('transaction.explorer')}
+            values={[transactionInfo.txID]}
+          />
+          <div className={`${parentStyle.detail} flex-center`}>
+            <A
+              href={explorerURL + transactionInfo.txID}
+              title={`${t('transaction.explorerTitle')}\n${explorerURL}${transactionInfo.txID}`}>
+              {t('transaction.explorerTitle')}
+            </A>
+          </div>
+        </>
+      )}
+    </Dialog>
+  );
+};

--- a/frontends/web/src/components/transactions/components/show-details-button.tsx
+++ b/frontends/web/src/components/transactions/components/show-details-button.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ExpandIcon } from '@/components/icon/icon';
+import transactionStyle from '@/components/transactions/transactions.module.css';
+import parentStyle from '@/components/transactions/transaction.module.css';
+
+type TProps = {
+  onClick: () => void;
+  expand: boolean;
+  hideOnMedium?: boolean;
+}
+
+export const ShowDetailsButton = ({
+  onClick,
+  expand,
+  hideOnMedium,
+}: TProps) => {
+  return (
+    <div className={`${transactionStyle.action} ${hideOnMedium ? transactionStyle.hideOnMedium : transactionStyle.showOnMedium}`}>
+      <button type="button" className={parentStyle.action} onClick={onClick}>
+        <ExpandIcon expand={expand} />
+      </button>
+    </div>
+  );
+};

--- a/frontends/web/src/components/transactions/components/status.tsx
+++ b/frontends/web/src/components/transactions/components/status.tsx
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import type { ITransaction } from '@/api/account';
+import { ProgressRing } from '@/components/progressRing/progressRing';
+import { TxDetail } from './detail';
+import transactionStyle from '@/components/transactions/transactions.module.css';
+import parentStyle from '@/components/transactions/transaction.module.css';
+
+type TProps = {
+  status: ITransaction['status'];
+  numConfirmations: number;
+  numConfirmationsComplete: number;
+}
+
+export const TxStatus = ({
+  status,
+  numConfirmations,
+  numConfirmationsComplete,
+}: TProps) => {
+  const { t } = useTranslation();
+  const statusText = t(`transaction.status.${status}`);
+  const progress = numConfirmations < numConfirmationsComplete ? (numConfirmations / numConfirmationsComplete) * 100 : 100;
+  const isComplete = numConfirmations >= numConfirmationsComplete;
+  return (
+    <div className={transactionStyle.status}>
+      <span className={parentStyle.columnLabel}>
+        {t('transaction.details.status')}:
+      </span>
+      <ProgressRing
+        className="m-right-quarter"
+        width={14}
+        value={progress}
+        isComplete={isComplete}
+      />
+      <span className={parentStyle.status}>{statusText}</span>
+    </div>
+  );
+};
+
+export const TxStatusDetail = ({
+  status,
+  numConfirmations,
+  numConfirmationsComplete,
+}: TProps) => {
+  const { t } = useTranslation();
+  const statusText = t(`transaction.status.${status}`);
+  const progress = numConfirmations < numConfirmationsComplete ? (numConfirmations / numConfirmationsComplete) * 100 : 100;
+  const isComplete = numConfirmations >= numConfirmationsComplete;
+  return (
+    <TxDetail label={t('transaction.details.status')}>
+      <ProgressRing
+        className="m-right-quarter"
+        width={14}
+        value={progress}
+        isComplete={isComplete}
+      />
+      <span className={parentStyle.status}>
+        {statusText}{status === 'pending' && <span> {`(${numConfirmations}/${numConfirmationsComplete})`}</span>}
+      </span>
+    </TxDetail>
+  );
+};

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -87,7 +87,7 @@ export const Transaction = ({
   );
   const sign = ((type === 'send') && '−') || ((type === 'receive') && '+') || '';
   const typeClassName = (status === 'failed' && style.failed) || (type === 'send' && style.send) || (type === 'receive' && style.receive) || '';
-  const sDate = time ? parseTimeShort(time) : '---';
+  const shortDate = time ? parseTimeShort(time) : '---';
   const statusText = t(`transaction.status.${status}`);
   const progress = numConfirmations < numConfirmationsComplete ? (numConfirmations / numConfirmationsComplete) * 100 : 100;
 
@@ -100,7 +100,7 @@ export const Transaction = ({
             <span className={style.columnLabel}>
               {t('transaction.details.date')}:
             </span>
-            <span className={style.date}>{sDate}</span>
+            <span className={style.date}>{shortDate}</span>
           </div>
           { note ? (
             <div className={parentStyle.activity}>
@@ -208,7 +208,7 @@ export const Transaction = ({
             </div>
             <div className={style.detail}>
               <label>{t('transaction.details.date')}</label>
-              <p>{sDate}</p>
+              <p>{shortDate}</p>
             </div>
             <div className={style.detail}>
               <label>{t('transaction.details.fiat')}</label>

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -27,6 +27,7 @@ import { FiatConversion } from '@/components/rates/rates';
 import { Amount } from '@/components/amount/amount';
 import { ArrowIn, ArrowOut, ArrowSelf } from './components/icons';
 import { Note } from './note';
+import { TxDetail } from './components/detail';
 import parentStyle from './transactions.module.css';
 import style from './transaction.module.css';
 
@@ -180,81 +181,60 @@ export const Transaction = ({
               internalID={internalID}
               note={note}
             />
-            <div className={style.detail}>
-              <label>{t('transaction.details.type')}</label>
-              <p>{arrow}</p>
-            </div>
-            <div className={style.detail}>
-              <label>{t('transaction.confirmation')}</label>
-              <p>{numConfirmations}</p>
-            </div>
-            <div className={style.detail}>
-              <label>{t('transaction.details.status')}</label>
-              <p className="flex flex-items-center">
-                <ProgressRing
-                  className="m-right-quarter"
-                  width={14}
-                  value={progress}
-                  isComplete={numConfirmations >= numConfirmationsComplete}
-                />
-                <span className={style.status}>
-                  {statusText} {
-                    status === 'pending' && (
-                      <span>({numConfirmations}/{numConfirmationsComplete})</span>
-                    )
-                  }
-                </span>
-              </p>
-            </div>
-            <div className={style.detail}>
-              <label>{t('transaction.details.date')}</label>
-              <p>{shortDate}</p>
-            </div>
-            <div className={style.detail}>
-              <label>{t('transaction.details.fiat')}</label>
-              <p>
-                <span className={`${style.fiat} ${typeClassName}`}>
-                  <FiatConversion amount={amount} sign={sign} noAction />
-                </span>
-              </p>
-            </div>
-            <div className={style.detail}>
-              <label>{t('transaction.details.fiatAtTime')}</label>
-              <p>
-                <span className={`${style.fiat} ${typeClassName}`}>
-                  { transactionInfo.amountAtTime ?
-                    <FiatConversion amount={transactionInfo.amountAtTime} sign={sign} noAction />
-                    :
-                    <FiatConversion noAction />
-                  }
-                </span>
-              </p>
-            </div>
-            <div className={style.detail}>
-              <label>{t('transaction.details.amount')}</label>
-              <p className={typeClassName}>
-                <span className={style.amount}>
-                  {sign}
-                  <Amount amount={amount.amount} unit={amount.unit}/>
-                </span>
-                {' '}
-                <span className={style.currencyUnit}>{transactionInfo.amount.unit}</span>
-              </p>
-            </div>
-            <div className={style.detail}>
-              <label>{t('transaction.fee')}</label>
-              {
-                transactionInfo.fee && transactionInfo.fee.amount ? (
-                  <p title={feeRatePerKb.amount ? feeRatePerKb.amount + ' ' + feeRatePerKb.unit + '/Kb' : ''}>
-                    <Amount amount={transactionInfo.fee.amount} unit={transactionInfo.fee.unit}/>
-                    {' '}
-                    <span className={style.currencyUnit}>{transactionInfo.fee.unit}</span>
-                  </p>
-                ) : (
-                  <p>---</p>
-                )
-              }
-            </div>
+            <TxDetail label={t('transaction.details.type')}>{arrow}</TxDetail>
+            <TxDetail label={t('transaction.confirmation')}>{numConfirmations}</TxDetail>
+            <TxDetail label={t('transaction.details.status')}>
+              <ProgressRing
+                className="m-right-quarter"
+                width={14}
+                value={progress}
+                isComplete={numConfirmations >= numConfirmationsComplete}
+              />
+              <span className={style.status}>
+                {statusText} {
+                  status === 'pending' && (
+                    <span>({numConfirmations}/{numConfirmationsComplete})</span>
+                  )
+                }
+              </span>
+            </TxDetail>
+            <TxDetail label={t('transaction.details.date')}>{shortDate}</TxDetail>
+            <TxDetail label={t('transaction.details.fiat')}>
+              <span className={`${style.fiat} ${typeClassName}`}>
+                <FiatConversion amount={amount} sign={sign} noAction />
+              </span>
+            </TxDetail>
+            <TxDetail label={t('transaction.details.fiatAtTime')}>
+              <span className={`${style.fiat} ${typeClassName}`}>
+                {transactionInfo.amountAtTime ?
+                  <FiatConversion amount={transactionInfo.amountAtTime} sign={sign} noAction />
+                  :
+                  <FiatConversion noAction />
+                }
+              </span>
+            </TxDetail>
+            <TxDetail label={t('transaction.details.amount')}>
+              <span className={`${style.amount} ${typeClassName}`}>
+                {sign}
+                <Amount amount={amount.amount} unit={amount.unit} />
+              </span>
+              {' '}
+              <span className={`${style.currencyUnit} ${typeClassName}`}>{transactionInfo.amount.unit}</span>
+            </TxDetail>
+            {
+              transactionInfo.fee && transactionInfo.fee.amount ? (
+                <TxDetail
+                  label={t('transaction.fee')}
+                  title={feeRatePerKb.amount ? feeRatePerKb.amount + ' ' + feeRatePerKb.unit + '/Kb' : ''}
+                >
+                  <Amount amount={transactionInfo.fee.amount} unit={transactionInfo.fee.unit} />
+                  {' '}
+                  <span className={style.currencyUnit}>{transactionInfo.fee.unit}</span>
+                </TxDetail>
+              ) : (
+                <TxDetail label={t('transaction.fee')}>---</TxDetail>
+              )
+            }
             <div className={`${style.detail} ${style.addresses}`}>
               <label>{t('transaction.details.address')}</label>
               <div className={style.detailAddresses}>
@@ -271,54 +251,39 @@ export const Transaction = ({
             </div>
             {
               transactionInfo.gas ? (
-                <div className={style.detail}>
-                  <label>{t('transaction.gas')}</label>
-                  <p>{transactionInfo.gas}</p>
-                </div>
+                <TxDetail label={t('transaction.gas')}>{transactionInfo.gas}</TxDetail>
               ) : null
             }
             {
-              transactionInfo.nonce !== null ? (
-                <div className={style.detail}>
-                  <label>Nonce</label>
-                  <p>{transactionInfo.nonce}</p>
-                </div>
+              transactionInfo.nonce ? (
+                <TxDetail label="Nonce">{transactionInfo.nonce}</TxDetail>
               ) : null
             }
             {
               transactionInfo.weight ? (
-                <div className={style.detail}>
-                  <label>{t('transaction.weight')}</label>
-                  <p>
-                    {transactionInfo.weight}
-                    {' '}
-                    <span className={style.currencyUnit}>WU</span>
-                  </p>
-                </div>
+                <TxDetail label={t('transaction.weight')}>
+                  {transactionInfo.weight}
+                  {' '}
+                  <span className={style.currencyUnit}>WU</span>
+                </TxDetail>
               ) : null
             }
             {
               transactionInfo.vsize ? (
-                <div className={style.detail}>
-                  <label>{t('transaction.vsize')}</label>
-                  <p>
-                    {transactionInfo.vsize}
-                    {' '}
-                    <span className={style.currencyUnit}>b</span>
-                  </p>
-                </div>
+                <TxDetail label={t('transaction.vsize')}>
+                  {transactionInfo.vsize}
+                  {' '}
+                  <span className={style.currencyUnit}>b</span>
+                </TxDetail>
               ) : null
             }
             {
               transactionInfo.size ? (
-                <div className={style.detail}>
-                  <label>{t('transaction.size')}</label>
-                  <p>
-                    {transactionInfo.size}
-                    {' '}
-                    <span className={style.currencyUnit}>b</span>
-                  </p>
-                </div>
+                <TxDetail label={t('transaction.size')}>
+                  {transactionInfo.size}
+                  {' '}
+                  <span className={style.currencyUnit}>b</span>
+                </TxDetail>
               ) : null
             }
             <div className={`${style.detail} ${style.addresses}`}>

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -30,6 +30,15 @@ import { Note } from './note';
 import parentStyle from './transactions.module.css';
 import style from './transaction.module.css';
 
+const parseTimeShort = (time: string, lang: string) => {
+  const options = {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  } as Intl.DateTimeFormatOptions;
+  return new Date(Date.parse(time)).toLocaleString(lang, options);
+};
+
 type Props = {
   accountCode: accountApi.AccountCode;
   index: number;
@@ -55,15 +64,6 @@ export const Transaction = ({
   const [transactionDialog, setTransactionDialog] = useState<boolean>(false);
   const [transactionInfo, setTransactionInfo] = useState<accountApi.ITransaction>();
 
-  const parseTimeShort = (time: string) => {
-    const options = {
-      year: 'numeric',
-      month: 'numeric',
-      day: 'numeric',
-    } as Intl.DateTimeFormatOptions;
-    return new Date(Date.parse(time)).toLocaleString(i18n.language, options);
-  };
-
   const showDetails = () => {
     accountApi.getTransaction(accountCode, internalID).then(transaction => {
       if (!transaction) {
@@ -87,7 +87,7 @@ export const Transaction = ({
   );
   const sign = ((type === 'send') && '−') || ((type === 'receive') && '+') || '';
   const typeClassName = (status === 'failed' && style.failed) || (type === 'send' && style.send) || (type === 'receive' && style.receive) || '';
-  const shortDate = time ? parseTimeShort(time) : '---';
+  const shortDate = time ? parseTimeShort(time, i18n.language) : '---';
   const statusText = t(`transaction.status.${status}`);
   const progress = numConfirmations < numConfirmationsComplete ? (numConfirmations / numConfirmationsComplete) * 100 : 100;
 

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -18,17 +18,14 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as accountApi from '@/api/account';
-import { A } from '@/components/anchor/anchor';
-import { Dialog } from '@/components/dialog/dialog';
 import { FiatConversion } from '@/components/rates/rates';
 import { Amount } from '@/components/amount/amount';
-import { Note } from './note';
-import { TxDetail } from './components/detail';
 import { Arrow } from './components/arrow';
-import { TxDate, TxDateDetail } from './components/date';
-import { TxStatus, TxStatusDetail } from './components/status';
+import { TxDate } from './components/date';
+import { TxStatus } from './components/status';
 import { ShowDetailsButton } from './components/show-details-button';
-import { TxAddress, TxDetailCopyableValues } from './components/address-or-txid';
+import { TxAddress } from './components/address-or-txid';
+import { TxDetailsDialog } from './components/details';
 import parentStyle from './transactions.module.css';
 import style from './transaction.module.css';
 
@@ -45,7 +42,6 @@ export const Transaction = ({
   explorerURL,
   type,
   amount,
-  feeRatePerKb,
   numConfirmations,
   numConfirmationsComplete,
   time,
@@ -55,19 +51,6 @@ export const Transaction = ({
 }: Props) => {
   const { t } = useTranslation();
   const [transactionDialog, setTransactionDialog] = useState<boolean>(false);
-  const [transactionInfo, setTransactionInfo] = useState<accountApi.ITransaction>();
-
-  const showDetails = () => {
-    accountApi.getTransaction(accountCode, internalID).then(transaction => {
-      if (!transaction) {
-        console.error('Unable to retrieve transaction ' + internalID);
-        return null;
-      }
-      setTransactionInfo(transaction);
-      setTransactionDialog(true);
-    })
-      .catch(console.error);
-  };
 
   const sign = ((type === 'send') && '−') || ((type === 'receive') && '+') || '';
   const typeClassName = (status === 'failed' && style.failed) || (type === 'send' && style.send) || (type === 'receive' && style.receive) || '';
@@ -96,7 +79,7 @@ export const Transaction = ({
             />
           )}
           <ShowDetailsButton
-            onClick={showDetails}
+            onClick={() => setTransactionDialog(true)}
             expand={!transactionDialog}
             hideOnMedium
           />
@@ -122,132 +105,27 @@ export const Transaction = ({
             </span>
           </div>
           <ShowDetailsButton
-            onClick={showDetails}
+            onClick={() => setTransactionDialog(true)}
             expand={!transactionDialog}
           />
         </div>
       </div>
-      {/*
-        Amount and Confirmations info are displayed using props data
-        instead of transactionInfo because they are live updated.
-      */}
-      <Dialog
+      <TxDetailsDialog
         open={transactionDialog}
-        title={t('transaction.details.title')}
         onClose={() => setTransactionDialog(false)}
-        slim
-        medium>
-        {transactionInfo && (
-          <>
-            <Note
-              accountCode={accountCode}
-              internalID={internalID}
-              note={note}
-            />
-            <TxDetail label={t('transaction.details.type')}>
-              <Arrow
-                status={status}
-                type={type}
-              />
-            </TxDetail>
-            <TxDetail label={t('transaction.confirmation')}>{numConfirmations}</TxDetail>
-            <TxStatusDetail
-              status={status}
-              numConfirmations={numConfirmations}
-              numConfirmationsComplete={numConfirmationsComplete}
-            />
-            <TxDateDetail time={time} />
-            <TxDetail label={t('transaction.details.fiat')}>
-              <span className={`${style.fiat} ${typeClassName}`}>
-                <FiatConversion amount={amount} sign={sign} noAction />
-              </span>
-            </TxDetail>
-            <TxDetail label={t('transaction.details.fiatAtTime')}>
-              <span className={`${style.fiat} ${typeClassName}`}>
-                {transactionInfo.amountAtTime ?
-                  <FiatConversion amount={transactionInfo.amountAtTime} sign={sign} noAction />
-                  :
-                  <FiatConversion noAction />
-                }
-              </span>
-            </TxDetail>
-            <TxDetail label={t('transaction.details.amount')}>
-              <span className={`${style.amount} ${typeClassName}`}>
-                {sign}
-                <Amount amount={amount.amount} unit={amount.unit} />
-              </span>
-              {' '}
-              <span className={`${style.currencyUnit} ${typeClassName}`}>{transactionInfo.amount.unit}</span>
-            </TxDetail>
-            {
-              transactionInfo.fee && transactionInfo.fee.amount ? (
-                <TxDetail
-                  label={t('transaction.fee')}
-                  title={feeRatePerKb.amount ? feeRatePerKb.amount + ' ' + feeRatePerKb.unit + '/Kb' : ''}
-                >
-                  <Amount amount={transactionInfo.fee.amount} unit={transactionInfo.fee.unit} />
-                  {' '}
-                  <span className={style.currencyUnit}>{transactionInfo.fee.unit}</span>
-                </TxDetail>
-              ) : (
-                <TxDetail label={t('transaction.fee')}>---</TxDetail>
-              )
-            }
-            <TxDetailCopyableValues
-              label={t('transaction.details.address')}
-              values={transactionInfo.addresses}
-            />
-            {
-              transactionInfo.gas ? (
-                <TxDetail label={t('transaction.gas')}>{transactionInfo.gas}</TxDetail>
-              ) : null
-            }
-            {
-              transactionInfo.nonce ? (
-                <TxDetail label="Nonce">{transactionInfo.nonce}</TxDetail>
-              ) : null
-            }
-            {
-              transactionInfo.weight ? (
-                <TxDetail label={t('transaction.weight')}>
-                  {transactionInfo.weight}
-                  {' '}
-                  <span className={style.currencyUnit}>WU</span>
-                </TxDetail>
-              ) : null
-            }
-            {
-              transactionInfo.vsize ? (
-                <TxDetail label={t('transaction.vsize')}>
-                  {transactionInfo.vsize}
-                  {' '}
-                  <span className={style.currencyUnit}>b</span>
-                </TxDetail>
-              ) : null
-            }
-            {
-              transactionInfo.size ? (
-                <TxDetail label={t('transaction.size')}>
-                  {transactionInfo.size}
-                  {' '}
-                  <span className={style.currencyUnit}>b</span>
-                </TxDetail>
-              ) : null
-            }
-            <TxDetailCopyableValues
-              label={t('transaction.explorer')}
-              values={[transactionInfo.txID]}
-            />
-            <div className={`${style.detail} flex-center`}>
-              <A
-                href={explorerURL + transactionInfo.txID}
-                title={`${t('transaction.explorerTitle')}\n${explorerURL}${transactionInfo.txID}`}>
-                {t('transaction.explorerTitle')}
-              </A>
-            </div>
-          </>
-        )}
-      </Dialog>
+        accountCode={accountCode}
+        internalID={internalID}
+        note={note}
+        status={status}
+        type={type}
+        numConfirmations={numConfirmations}
+        numConfirmationsComplete={numConfirmationsComplete}
+        time={time}
+        amount={amount}
+        sign={sign}
+        typeClassName={typeClassName}
+        explorerURL={explorerURL}
+      />
     </div>
   );
 };

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -92,8 +92,8 @@ export const Transaction = ({
   const progress = numConfirmations < numConfirmationsComplete ? (numConfirmations / numConfirmationsComplete) * 100 : 100;
 
   return (
-    <div className={[style.container, index === 0 ? style.first : ''].join(' ')}>
-      <div className={[parentStyle.columns, style.row].join(' ')}>
+    <div className={`${style.container} ${index === 0 ? style.first : ''}`}>
+      <div className={`${parentStyle.columns} ${style.row}`}>
         <div className={parentStyle.columnGroup}>
           <div className={parentStyle.type}>{arrow}</div>
           <div className={parentStyle.date}>
@@ -123,7 +123,7 @@ export const Transaction = ({
               </span>
             </div>
           )}
-          <div className={[parentStyle.action, parentStyle.hideOnMedium].join(' ')}>
+          <div className={`${parentStyle.action} ${parentStyle.hideOnMedium}`}>
             <button type="button" className={style.action} onClick={showDetails}>
               <ExpandIcon expand={!transactionDialog} />
             </button>
@@ -156,7 +156,7 @@ export const Transaction = ({
               <span className={style.currencyUnit}>&nbsp;{amount.unit}</span>
             </span>
           </div>
-          <div className={[parentStyle.action, parentStyle.showOnMedium].join(' ')}>
+          <div className={`${parentStyle.action} ${parentStyle.showOnMedium}`}>
             <button type="button" className={style.action} onClick={showDetails}>
               <ExpandIcon expand={!transactionDialog} />
             </button>
@@ -255,7 +255,7 @@ export const Transaction = ({
                 )
               }
             </div>
-            <div className={[style.detail, style.addresses].join(' ')}>
+            <div className={`${style.detail} ${style.addresses}`}>
               <label>{t('transaction.details.address')}</label>
               <div className={style.detailAddresses}>
                 { transactionInfo.addresses.map((address) => (
@@ -321,7 +321,7 @@ export const Transaction = ({
                 </div>
               ) : null
             }
-            <div className={[style.detail, style.addresses].join(' ')}>
+            <div className={`${style.detail} ${style.addresses}`}>
               <label>{t('transaction.explorer')}</label>
               <div className={style.detailAddresses}>
                 <CopyableInput
@@ -332,7 +332,7 @@ export const Transaction = ({
                   value={transactionInfo.txID} />
               </div>
             </div>
-            <div className={[style.detail, 'flex-center'].join(' ')}>
+            <div className={`${style.detail} flex-center`}>
               <A
                 href={explorerURL + transactionInfo.txID}
                 title={`${t('transaction.explorerTitle')}\n${explorerURL}${transactionInfo.txID}`}>

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -20,25 +20,17 @@ import { useTranslation } from 'react-i18next';
 import * as accountApi from '@/api/account';
 import { A } from '@/components/anchor/anchor';
 import { Dialog } from '@/components/dialog/dialog';
-import { CopyableInput } from '@/components/copy/Copy';
-import { Warning, ExpandIcon } from '@/components/icon/icon';
-import { ProgressRing } from '@/components/progressRing/progressRing';
 import { FiatConversion } from '@/components/rates/rates';
 import { Amount } from '@/components/amount/amount';
-import { ArrowIn, ArrowOut, ArrowSelf } from './components/icons';
 import { Note } from './note';
 import { TxDetail } from './components/detail';
+import { Arrow } from './components/arrow';
+import { TxDate, TxDateDetail } from './components/date';
+import { TxStatus, TxStatusDetail } from './components/status';
+import { ShowDetailsButton } from './components/show-details-button';
+import { TxAddress, TxDetailCopyableValues } from './components/address-or-txid';
 import parentStyle from './transactions.module.css';
 import style from './transaction.module.css';
-
-const parseTimeShort = (time: string, lang: string) => {
-  const options = {
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric',
-  } as Intl.DateTimeFormatOptions;
-  return new Date(Date.parse(time)).toLocaleString(lang, options);
-};
 
 type Props = {
   accountCode: accountApi.AccountCode;
@@ -61,7 +53,7 @@ export const Transaction = ({
   status,
   note = '',
 }: Props) => {
-  const { i18n, t } = useTranslation();
+  const { t } = useTranslation();
   const [transactionDialog, setTransactionDialog] = useState<boolean>(false);
   const [transactionInfo, setTransactionInfo] = useState<accountApi.ITransaction>();
 
@@ -77,72 +69,44 @@ export const Transaction = ({
       .catch(console.error);
   };
 
-  const arrow = status === 'failed' ? (
-    <Warning style={{ maxWidth: '18px' }} />
-  ) : type === 'receive' ? (
-    <ArrowIn />
-  ) : type === 'send' ? (
-    <ArrowOut />
-  ) : (
-    <ArrowSelf />
-  );
   const sign = ((type === 'send') && '−') || ((type === 'receive') && '+') || '';
   const typeClassName = (status === 'failed' && style.failed) || (type === 'send' && style.send) || (type === 'receive' && style.receive) || '';
-  const shortDate = time ? parseTimeShort(time, i18n.language) : '---';
-  const statusText = t(`transaction.status.${status}`);
-  const progress = numConfirmations < numConfirmationsComplete ? (numConfirmations / numConfirmationsComplete) * 100 : 100;
 
   return (
     <div className={`${style.container} ${index === 0 ? style.first : ''}`}>
       <div className={`${parentStyle.columns} ${style.row}`}>
         <div className={parentStyle.columnGroup}>
-          <div className={parentStyle.type}>{arrow}</div>
-          <div className={parentStyle.date}>
-            <span className={style.columnLabel}>
-              {t('transaction.details.date')}:
-            </span>
-            <span className={style.date}>{shortDate}</span>
+          <div className={parentStyle.type}>
+            <Arrow
+              status={status}
+              type={type}
+            />
           </div>
-          { note ? (
+          <TxDate time={time} />
+          {note ? (
             <div className={parentStyle.activity}>
               <span className={style.address}>
                 {note}
               </span>
             </div>
           ) : (
-            <div className={parentStyle.activity}>
-              <span className={style.label}>
-                {t(type === 'receive' ? 'transaction.tx.received' : 'transaction.tx.sent')}
-              </span>
-              <span className={style.address}>
-                {addresses[0]}
-                {addresses.length > 1 && (
-                  <span className={style.badge}>
-                    (+{addresses.length - 1})
-                  </span>
-                )}
-              </span>
-            </div>
+            <TxAddress
+              label={t(type === 'receive' ? 'transaction.tx.received' : 'transaction.tx.sent')}
+              addresses={addresses}
+            />
           )}
-          <div className={`${parentStyle.action} ${parentStyle.hideOnMedium}`}>
-            <button type="button" className={style.action} onClick={showDetails}>
-              <ExpandIcon expand={!transactionDialog} />
-            </button>
-          </div>
+          <ShowDetailsButton
+            onClick={showDetails}
+            expand={!transactionDialog}
+            hideOnMedium
+          />
         </div>
         <div className={parentStyle.columnGroup}>
-          <div className={parentStyle.status}>
-            <span className={style.columnLabel}>
-              {t('transaction.details.status')}:
-            </span>
-            <ProgressRing
-              className="m-right-quarter"
-              width={14}
-              value={progress}
-              isComplete={numConfirmations >= numConfirmationsComplete}
-            />
-            <span className={style.status}>{statusText}</span>
-          </div>
+          <TxStatus
+            status={status}
+            numConfirmations={numConfirmations}
+            numConfirmationsComplete={numConfirmationsComplete}
+          />
           <div className={parentStyle.fiat}>
             <span className={`${style.fiat} ${typeClassName}`}>
               <FiatConversion amount={amount} sign={sign} noAction />
@@ -157,11 +121,10 @@ export const Transaction = ({
               <span className={style.currencyUnit}>&nbsp;{amount.unit}</span>
             </span>
           </div>
-          <div className={`${parentStyle.action} ${parentStyle.showOnMedium}`}>
-            <button type="button" className={style.action} onClick={showDetails}>
-              <ExpandIcon expand={!transactionDialog} />
-            </button>
-          </div>
+          <ShowDetailsButton
+            onClick={showDetails}
+            expand={!transactionDialog}
+          />
         </div>
       </div>
       {/*
@@ -181,24 +144,19 @@ export const Transaction = ({
               internalID={internalID}
               note={note}
             />
-            <TxDetail label={t('transaction.details.type')}>{arrow}</TxDetail>
-            <TxDetail label={t('transaction.confirmation')}>{numConfirmations}</TxDetail>
-            <TxDetail label={t('transaction.details.status')}>
-              <ProgressRing
-                className="m-right-quarter"
-                width={14}
-                value={progress}
-                isComplete={numConfirmations >= numConfirmationsComplete}
+            <TxDetail label={t('transaction.details.type')}>
+              <Arrow
+                status={status}
+                type={type}
               />
-              <span className={style.status}>
-                {statusText} {
-                  status === 'pending' && (
-                    <span>({numConfirmations}/{numConfirmationsComplete})</span>
-                  )
-                }
-              </span>
             </TxDetail>
-            <TxDetail label={t('transaction.details.date')}>{shortDate}</TxDetail>
+            <TxDetail label={t('transaction.confirmation')}>{numConfirmations}</TxDetail>
+            <TxStatusDetail
+              status={status}
+              numConfirmations={numConfirmations}
+              numConfirmationsComplete={numConfirmationsComplete}
+            />
+            <TxDateDetail time={time} />
             <TxDetail label={t('transaction.details.fiat')}>
               <span className={`${style.fiat} ${typeClassName}`}>
                 <FiatConversion amount={amount} sign={sign} noAction />
@@ -235,20 +193,10 @@ export const Transaction = ({
                 <TxDetail label={t('transaction.fee')}>---</TxDetail>
               )
             }
-            <div className={`${style.detail} ${style.addresses}`}>
-              <label>{t('transaction.details.address')}</label>
-              <div className={style.detailAddresses}>
-                { transactionInfo.addresses.map((address) => (
-                  <CopyableInput
-                    key={address}
-                    alignRight
-                    borderLess
-                    flexibleHeight
-                    className={style.detailAddress}
-                    value={address} />
-                )) }
-              </div>
-            </div>
+            <TxDetailCopyableValues
+              label={t('transaction.details.address')}
+              values={transactionInfo.addresses}
+            />
             {
               transactionInfo.gas ? (
                 <TxDetail label={t('transaction.gas')}>{transactionInfo.gas}</TxDetail>
@@ -286,17 +234,10 @@ export const Transaction = ({
                 </TxDetail>
               ) : null
             }
-            <div className={`${style.detail} ${style.addresses}`}>
-              <label>{t('transaction.explorer')}</label>
-              <div className={style.detailAddresses}>
-                <CopyableInput
-                  alignRight
-                  borderLess
-                  flexibleHeight
-                  className={style.detailAddress}
-                  value={transactionInfo.txID} />
-              </div>
-            </div>
+            <TxDetailCopyableValues
+              label={t('transaction.explorer')}
+              values={[transactionInfo.txID]}
+            />
             <div className={`${style.detail} flex-center`}>
               <A
                 href={explorerURL + transactionInfo.txID}


### PR DESCRIPTION
Refactor the transaction.tsx component to be more concise and easier to understand, also fix some minor nits like using template literals for element class names.

The PR implements all suggestions from #2549 and does not do anything else. **The commits can be reviewed own their own.** But the [first](https://github.com/BitBoxSwiss/bitbox-wallet-app/pull/2776/commits/3621dcde23cb5579d8e35e2c4feca70eff3349f9) and the [third](https://github.com/BitBoxSwiss/bitbox-wallet-app/pull/2776/commits/388c932dc78feee5eee0bbc92843427f08472fd7) could be skipped because the changed code is moved in other commits.

The last commit moves, and changes the transaction dialog to its own component which is why everything editing something in `Dialog` prior to that commit can also be reviewed later in the last commit. 

Please note that the many additions are caused by the license and other overhead from extracting sub-components. I think the refactor is almost addition/deletion neutral without those.