### PR TITLE
frontend: improve bitcoin or crypto in translations

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -235,10 +235,12 @@ const Sidebar = ({
                 className={({ isActive }) => isActive || userInSpecificAccountBuyPage ? style.sidebarActive : ''}
                 to="/buy/info">
                 <div className={style.single}>
-                  <img draggable={false} src={coins} alt={t('sidebar.exchanges')}/>
+                  <img draggable={false} src={coins} />
                 </div>
                 <span className={style.sidebarLabel}>
-                  {hasOnlyBTCAccounts ? t('accountInfo.buyCTA.buy', { unit: 'Bitcoin' }) : t('sidebar.buy')}
+                  {t('generic.buy', {
+                    context: hasOnlyBTCAccounts ? 'bitcoin' : 'crypto'
+                  })}
                 </span>
               </NavLink>
             </div>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -18,8 +18,6 @@
   "accountInfo": {
     "address": "Address",
     "buyCTA": {
-      "buy": "Buy {{unit}}",
-      "buyCrypto": "Buy Crypto",
       "information": {
         "looksEmpty": "Looks like this wallet is empty.",
         "start": "Get started by depositing some coins to the wallet or buying directly in the BitBoxApp."
@@ -720,8 +718,14 @@
     "appVersion": "App version:"
   },
   "generic": {
+    "buy": "Buy {{coinCode}}",
+    "buy_bitcoin": "Buy Bitcoin",
+    "buy_crypto": "Buy crypto",
     "enabled_false": "Disabled",
-    "enabled_true": "Enabled"
+    "enabled_true": "Enabled",
+    "receive": "Receive {{coinCode}}",
+    "receive_bitcoin": "Receive Bitcoin",
+    "receive_crypto": "Receive crypto"
   },
   "genericError": "An error occurred. If you notice any issues, please restart the application.",
   "goal": {
@@ -1684,7 +1688,6 @@
   },
   "setup": "Setup device",
   "sidebar": {
-    "buy": "Buy crypto",
     "device": "Manage device",
     "insurance": "Insurance",
     "leave": "Leave",

--- a/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMediaQuery } from '../../../hooks/mediaquery';
@@ -23,15 +24,15 @@ import { Balances } from '../summary/accountssummary';
 import { isBitcoinCoin, isEthereumBased } from '../utils';
 import { getExchangeSupportedAccounts } from '../../buy/utils';
 import { WalletConnectLight } from '../../../components/icon';
-import styles from './buyReceiveCTA.module.css';
 import { useMountedRef } from '../../../hooks/mount';
+import styles from './buyReceiveCTA.module.css';
 
 type TBuyReceiveCTAProps = {
   balanceList?: IBalance[];
   code?: string;
   unit?: string;
   exchangeBuySupported?: boolean;
-  account?: IAccount
+  account?: IAccount;
 };
 
 type TAddBuyReceiveOnEmpyBalancesProps = {
@@ -39,7 +40,13 @@ type TAddBuyReceiveOnEmpyBalancesProps = {
   accounts: IAccount[];
 }
 
-export const BuyReceiveCTA = ({ code, unit, balanceList, exchangeBuySupported = true, account }: TBuyReceiveCTAProps) => {
+export const BuyReceiveCTA = ({
+  balanceList,
+  code,
+  unit,
+  exchangeBuySupported = true,
+  account,
+}: TBuyReceiveCTAProps) => {
   const formattedUnit = isBitcoinCoin(unit as CoinUnit) ? 'BTC' : unit;
   const { t } = useTranslation();
   const isMobile = useMediaQuery('(max-width: 768px)');
@@ -58,16 +65,38 @@ export const BuyReceiveCTA = ({ code, unit, balanceList, exchangeBuySupported = 
 
   return (
     <div className={`${styles.main}`}>
-      <h3 className="subTitle">{t('accountInfo.buyCTA.information.looksEmpty')}</h3>
-      <h3 className="subTitle">{t('accountInfo.buyCTA.information.start')}</h3>
+      <h3 className="subTitle">
+        {t('accountInfo.buyCTA.information.looksEmpty')}
+      </h3>
+      <h3 className="subTitle">
+        {t('accountInfo.buyCTA.information.start')}
+      </h3>
       <div className={styles.container}>
-        {balanceList && <Button primary onClick={onReceiveCTA}>{formattedUnit ? t('receive.title', { accountName: formattedUnit }) : t('receive.title', { accountName: t('buy.info.crypto') })}</Button>}
-        {exchangeBuySupported && <Button primary onClick={onBuyCTA}>{formattedUnit ? t('accountInfo.buyCTA.buy', { unit: formattedUnit }) : t('accountInfo.buyCTA.buyCrypto')}</Button>}
-        {account && isEthereumBased(account.coinCode) && !account.isToken && <Button primary onClick={onWalletConnect} className={styles.walletConnect}>{isMobile ? <WalletConnectLight width={28} height={28} /> : <><WalletConnectLight width={28} height={28} /> <span>Wallet Connect</span></>}</Button>}
+        {balanceList && (
+          <Button primary onClick={onReceiveCTA}>
+            {formattedUnit ? t('receive.title', { accountName: formattedUnit }) : t('receive.title', { accountName: t('buy.info.crypto') })}
+          </Button>
+        )}
+        {exchangeBuySupported && (
+          <Button primary onClick={onBuyCTA}>
+            {formattedUnit ? t('accountInfo.buyCTA.buy', { unit: formattedUnit }) : t('accountInfo.buyCTA.buyCrypto')}
+          </Button>
+        )}
+        {account && isEthereumBased(account.coinCode) && !account.isToken && (
+          <Button primary onClick={onWalletConnect} className={styles.walletConnect}>
+            {isMobile ? (
+              <WalletConnectLight width={28} height={28} />
+            ) : (
+              <>
+                <WalletConnectLight width={28} height={28} /> <span>Wallet Connect</span>
+              </>
+            )}
+          </Button>
+        )}
       </div>
-    </div>);
+    </div>
+  );
 };
-
 
 export const AddBuyReceiveOnEmptyBalances = ({ balances, accounts }: TAddBuyReceiveOnEmpyBalancesProps) => {
   const mounted = useMountedRef();
@@ -89,9 +118,11 @@ export const AddBuyReceiveOnEmptyBalances = ({ balances, accounts }: TAddBuyRece
   if (balances === undefined || supportedAccounts === undefined) {
     return null;
   }
-  const balanceList = accounts
-    .map(account => balances[account.code])
-    .filter(balance => !!balance);
+  const balanceList = (
+    accounts
+      .map(account => balances[account.code])
+      .filter(balance => !!balance)
+  );
 
   // at least 1 active account has balance
   if (balanceList.some(entry => entry.hasAvailable)) {
@@ -100,8 +131,19 @@ export const AddBuyReceiveOnEmptyBalances = ({ balances, accounts }: TAddBuyRece
 
   // all active accounts are bitcoin
   if (balanceList.map(entry => entry.available.unit).every(isBitcoinCoin)) {
-    return <BuyReceiveCTA code={onlyHasOneActiveAccount ? accounts[0].code : undefined} unit={'BTC'} balanceList={balanceList} />;
+    return (
+      <BuyReceiveCTA
+        balanceList={balanceList}
+        code={onlyHasOneActiveAccount ? accounts[0].code : undefined}
+        unit="BTC"
+      />
+    );
   }
 
-  return <BuyReceiveCTA exchangeBuySupported={supportedAccounts.length > 0} balanceList={balanceList} />;
+  return (
+    <BuyReceiveCTA
+      balanceList={balanceList}
+      exchangeBuySupported={supportedAccounts.length > 0}
+    />
+  );
 };

--- a/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
@@ -16,8 +16,8 @@
 
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import { useMediaQuery } from '../../../hooks/mediaquery';
-import { route } from '../../../utils/route';
 import { CoinUnit, IAccount, IBalance } from '../../../api/account';
 import { Button } from '../../../components/forms';
 import { Balances } from '../summary/accountssummary';
@@ -47,19 +47,20 @@ export const BuyReceiveCTA = ({
   exchangeBuySupported = true,
   account,
 }: TBuyReceiveCTAProps) => {
-  const formattedUnit = isBitcoinCoin(unit as CoinUnit) ? 'BTC' : unit;
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const formattedUnit = isBitcoinCoin(unit as CoinUnit) ? 'BTC' : unit;
   const isMobile = useMediaQuery('(max-width: 768px)');
 
-  const onBuyCTA = () => route(code ? `/buy/info/${code}` : '/buy/info');
-  const onWalletConnect = () => route(`/account/${code}/wallet-connect/dashboard`);
+  const onBuyCTA = () => navigate(code ? `/buy/info/${code}` : '/buy/info');
+  const onWalletConnect = () => navigate(`/account/${code}/wallet-connect/dashboard`);
   const onReceiveCTA = () => {
     if (balanceList) {
       if (balanceList.length > 1) {
-        route('accounts/select-receive');
+        navigate('accounts/select-receive');
         return;
       }
-      route(`/account/${code}/receive`);
+      navigate(`/account/${code}/receive`);
     }
   };
 

--- a/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
@@ -49,7 +49,7 @@ export const BuyReceiveCTA = ({
 }: TBuyReceiveCTAProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const formattedUnit = isBitcoinCoin(unit as CoinUnit) ? 'BTC' : unit;
+  const isBitcoin = isBitcoinCoin(unit as CoinUnit);
   const isMobile = useMediaQuery('(max-width: 768px)');
 
   const onBuyCTA = () => navigate(code ? `/buy/info/${code}` : '/buy/info');
@@ -75,12 +75,20 @@ export const BuyReceiveCTA = ({
       <div className={styles.container}>
         {balanceList && (
           <Button primary onClick={onReceiveCTA}>
-            {formattedUnit ? t('receive.title', { accountName: formattedUnit }) : t('receive.title', { accountName: t('buy.info.crypto') })}
+            {/* "Receive Bitcoin", "Receive crypto" or "Receive LTC" (via placeholder "Receive {{coinCode}}") */}
+            {t('generic.receive', {
+              context: isBitcoin ? 'bitcoin' : (unit ? '' : 'crypto'),
+              coinCode: unit
+            })}
           </Button>
         )}
         {exchangeBuySupported && (
           <Button primary onClick={onBuyCTA}>
-            {formattedUnit ? t('accountInfo.buyCTA.buy', { unit: formattedUnit }) : t('accountInfo.buyCTA.buyCrypto')}
+            {/* "Buy Bitcoin", "Buy crypto" or "Buy LTC" (via placeholder "Buy {{coinCode}}") */}
+            {t('generic.buy', {
+              context: isBitcoin ? 'bitcoin' : (unit ? '' : 'crypto'),
+              coinCode: unit
+            })}
           </Button>
         )}
         {account && isEthereumBased(account.coinCode) && !account.isToken && (

--- a/frontends/web/src/routes/accounts/select-receive.tsx
+++ b/frontends/web/src/routes/accounts/select-receive.tsx
@@ -36,7 +36,9 @@ export const ReceiveAccountsSelector = ({ activeAccounts }: TReceiveAccountsSele
 
   const hasOnlyBTCAccounts = activeAccounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
 
-  const title = t('receive.title', { accountName: hasOnlyBTCAccounts ? 'Bitcoin' : t('buy.info.crypto') });
+  const title = t('generic.receive', {
+    context: hasOnlyBTCAccounts ? 'bitcoin' : 'crypto'
+  });
 
   return (
     <>

--- a/frontends/web/src/routes/buy/exchange.tsx
+++ b/frontends/web/src/routes/buy/exchange.tsx
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import 'flag-icons';
 import { useState, useEffect } from 'react';
-import { i18n } from '../../i18n/i18n';
 import { useTranslation } from 'react-i18next';
+import { SingleValue } from 'react-select';
+import { i18n } from '../../i18n/i18n';
 import { Button } from '../../components/forms';
 import * as exchangesAPI from '../../api/exchanges';
 import { AccountCode, IAccount } from '../../api/account';
@@ -35,9 +37,8 @@ import { InfoButton } from '../../components/infobutton/infobutton';
 import { InfoContent } from './components/infocontent';
 import { getNativeLocale } from '../../api/nativelocale';
 import { getConfig, setConfig } from '../../utils/config';
-import { SingleValue } from 'react-select';
-import style from './exchange.module.css';
 import { CountrySelect, TOption } from './components/countryselect';
+import style from './exchange.module.css';
 
 type TProps = {
     code: AccountCode;

--- a/frontends/web/src/routes/buy/exchange.tsx
+++ b/frontends/web/src/routes/buy/exchange.tsx
@@ -78,7 +78,10 @@ export const Exchange = ({ code, accounts }: TProps) => {
       return;
     }
     const regionNames = new Intl.DisplayNames([i18n.language], { type: 'region' }) || '';
-    const regions = regionList.regions.map(region => ({ value: region.code, label: regionNames.of(region.code) } as TOption));
+    const regions: TOption[] = regionList.regions.map(region => ({
+      value: region.code,
+      label: regionNames.of(region.code) || region.code
+    }));
 
     regions.sort((a, b) => a.label.localeCompare(b.label, i18n.language));
     setRegions(regions);


### PR DESCRIPTION
In some languages Bitcoin or crypto can have special ending depending
on the context, so translating crypto does not work in all cases.

This is the first step changing keys using bitcoin or crypto
context so that terms like Bitcoin or crypto can be translated
differently.

Added generic buy and receive keys with context, without context
this keys still use a coinCode placeholder. i.e.
- Buy Bitcoin
- Buy crypto
- Buy LTC / Buy {{coinCode}}

Reason to not offer different keys for each token/coin is that it
would required a different key for each coin/token.