### PR TITLE
frontend: improve firmware update indicator on small screen

### DIFF
--- a/frontends/web/src/routes/settings/components/tabs.module.css
+++ b/frontends/web/src/routes/settings/components/tabs.module.css
@@ -26,3 +26,9 @@
 .canUpgradeDot {
     vertical-align: top;
 }
+
+@media (max-width: 768px) {
+    .canUpgradeDot {
+        margin-right: 5px;
+    }
+}

--- a/frontends/web/src/routes/settings/components/tabs.tsx
+++ b/frontends/web/src/routes/settings/components/tabs.tsx
@@ -81,8 +81,7 @@ export const Tab = ({
         <SettingsItem
           settingName={name}
           onClick={() => navigate(url)}
-          extraComponent={<ChevronRightDark/>} />
-        {upgradeDot}
+          extraComponent={upgradeDot ? upgradeDot : <ChevronRightDark />} />
       </div>
     );
   }


### PR DESCRIPTION
The position of the red dot in settings on mobile looked visually a bit off.

Placed the dot in the settings item on the right so it has same look and style as when we use the red dot in other places in the settings item.