### PR TITLE
frontend: label change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Android: enable export logs feature
+- Label UTXOs that were created as change, as such, in coin control
 
 # 4.45.0
 - Bundle BitBox02 firmware version v9.21.0

--- a/backend/coins/btc/coin_test.go
+++ b/backend/coins/btc/coin_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package btc_test
+package btc
 
 import (
 	"encoding/hex"
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/errors"
-	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/blockchain"
 	blockchainMock "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/blockchain/mocks"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
@@ -52,13 +51,13 @@ type testSuite struct {
 	net  *chaincfg.Params
 
 	dbFolder string
-	coin     *btc.Coin
+	coin     *Coin
 }
 
 func (s *testSuite) SetupTest() {
 	s.dbFolder = test.TstTempDir("btc-dbfolder")
 
-	s.coin = btc.NewCoin(s.code, "Some coin", s.unit, coin.BtcUnitDefault, s.net, s.dbFolder, nil,
+	s.coin = NewCoin(s.code, "Some coin", s.unit, coin.BtcUnitDefault, s.net, s.dbFolder, nil,
 		explorer, socksproxy.NewSocksProxy(false, ""))
 	blockchainMock := &blockchainMock.BlockchainMock{}
 	blockchainMock.MockHeadersSubscribe = func(

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -346,6 +346,7 @@ func (handlers *Handlers) getUTXOs(*http.Request) (interface{}, error) {
 				"scriptType":    output.Address.Configuration.ScriptType(),
 				"note":          handlers.account.TxNote(output.OutPoint.Hash.String()),
 				"addressReused": addressReused,
+				"isChange":      output.IsChange,
 			})
 	}
 

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -398,6 +398,7 @@ export type TUTXO = {
   note: string;
   scriptType: ScriptType;
   addressReused: boolean;
+  isChange: boolean;
 };
 
 export const getUTXOs = (code: AccountCode): Promise<TUTXO[]> => {

--- a/frontends/web/src/components/badge/badge.module.css
+++ b/frontends/web/src/components/badge/badge.module.css
@@ -49,3 +49,9 @@
   border-color: rgba(255, 0, 0, 0.33);
   color: rgba(255, 0, 0, 1);
 }
+
+.info {
+  background: var(--color-info-background);
+  border-color: var(--color-info-border);
+  color: var(--color-default);
+}

--- a/frontends/web/src/components/badge/badge.tsx
+++ b/frontends/web/src/components/badge/badge.tsx
@@ -17,7 +17,7 @@
 import { ReactElement, ReactNode } from 'react';
 import style from './badge.module.css';
 
-type TBadgeStyles = 'success' | 'warning' | 'danger'; // TODO: not yet implemented 'info'
+type TBadgeStyles = 'success' | 'warning' | 'danger' | 'info';
 
 type TProps = {
   children?: ReactNode;

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1550,6 +1550,7 @@
     "coincontrol": {
       "address": "Address",
       "addressReused": "Address re-used",
+      "change": "Change",
       "outpoint": "Outpoint",
       "title": "Send from output"
     },

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -136,9 +136,23 @@ export const UTXOs = ({
                       </span>
                       <div className="m-left-quarter">
                         {utxo.addressReused ?
-                          <Badge type="danger">
-                            {t('send.coincontrol.addressReused')}
-                          </Badge> :
+                          <>
+                            <Badge type="danger">
+                              {t('send.coincontrol.addressReused')}
+                            </Badge>
+                            {' '}
+                          </>
+                          :
+                          null
+                        }
+                        {utxo.isChange ?
+                          <>
+                            <Badge type="info">
+                              {t('send.coincontrol.change')}
+                            </Badge>
+                            {' '}
+                          </>
+                          :
                           null
                         }
                       </div>


### PR DESCRIPTION
Label utxos that are to change addresses from our account (subaccounts
respectively) as change to give the user more information about the utxo
when selecting it in coin control.
![requestly-isChange-for-all-tx-small png](https://github.com/BitBoxSwiss/bitbox-wallet-app/assets/90551797/37c871d9-5957-4433-bd61-254b121aceb3)
![requestly-isChange-for-all-tx](https://github.com/BitBoxSwiss/bitbox-wallet-app/assets/90551797/72d5533c-81d7-4d05-96d1-d9f0c64649e7)
