### PR TITLE
frontend: improve translations with crypto, bitcoin or coincode

### DIFF
--- a/frontends/web/src/components/terms/moonpay-terms.tsx
+++ b/frontends/web/src/components/terms/moonpay-terms.tsx
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import { useTranslation } from 'react-i18next';
-import { getCryptoName } from '../../routes/account/utils';
 import { ChangeEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { isBitcoinBased } from '../../routes/account/utils';
 import { Button, Checkbox } from '../forms';
 import { setConfig } from '../../utils/config';
 import { IAccount } from '../../api/account';
@@ -32,24 +32,27 @@ type TProps = {
 export const MoonpayTerms = ({ account, onAgreedTerms }: TProps) => {
   const { t } = useTranslation();
 
-  const name = getCryptoName(t('buy.info.crypto'), account);
-
   const handleSkipDisclaimer = (e: ChangeEvent<HTMLInputElement>) => {
     setConfig({ frontend: { skipMoonpayDisclaimer: e.target.checked } });
   };
+
+  const coinCode = account.coinCode.toUpperCase();
+  const isBitcoin = isBitcoinBased(account.coinCode);
 
   return (
     <div className={style.disclaimerContainer}>
       <div className={style.disclaimer}>
         <h2 className={style.title}>
-          {t('buy.info.disclaimer.title', { name })}
+          {t('buy.info.disclaimer.title', {
+            context: isBitcoin ? 'bitcoin' : 'crypto'
+          })}
         </h2>
-        <p>{t('buy.info.disclaimer.intro.0', { name })}</p>
-        <p>{t('buy.info.disclaimer.intro.1', { name })}</p>
+        <p>{t('buy.info.disclaimer.intro.0', { coinCode })}</p>
+        <p>{t('buy.info.disclaimer.intro.1', { coinCode })}</p>
         <h2 className={style.title}>
           {t('buy.info.disclaimer.payment.title')}
         </h2>
-        <p>{t('buy.info.disclaimer.payment.details', { name })}</p>
+        <p>{t('buy.info.disclaimer.payment.details', { coinCode })}</p>
         <div className={style.table}>
           <table>
             <colgroup>
@@ -82,7 +85,11 @@ export const MoonpayTerms = ({ account, onAgreedTerms }: TProps) => {
         <h2 className={style.title}>
           {t('buy.info.disclaimer.security.title')}
         </h2>
-        <p>{t('buy.info.disclaimer.security.description', { name })}</p>
+        <p>
+          {t('buy.info.disclaimer.security.description', {
+            context: isBitcoin ? 'bitcoin' : 'crypto'
+          })}
+        </p>
         <p>
           <A href="https://bitbox.swiss/bitbox02/threat-model/">
             {t('buy.info.disclaimer.security.link')}
@@ -91,7 +98,11 @@ export const MoonpayTerms = ({ account, onAgreedTerms }: TProps) => {
         <h2 className={style.title}>
           {t('buy.info.disclaimer.protection.title')}
         </h2>
-        <p>{t('buy.info.disclaimer.protection.description', { name })}</p>
+        <p>
+          {t('buy.info.disclaimer.protection.description', {
+            context: isBitcoin ? 'bitcoin' : 'crypto'
+          })}
+        </p>
         <p>
           <A href="https://www.moonpay.com/privacy_policy">
             {t('buy.info.disclaimer.privacyPolicy')}

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -454,19 +454,18 @@
       },
       "noExchanges": "Sorry, there are no available exchanges in this region.",
       "region": "Region",
-      "selectRegion": "Not specified",
-      "title": "Buy {{name}}"
+      "selectRegion": "Not specified"
     },
     "info": {
       "continue": "Agree and continue",
       "crypto": "crypto",
       "disclaimer": {
         "intro": [
-          "We partner with MoonPay to offer you a seamless way to buy {{name}} directly within the BitBoxApp. It's just a few clicks.",
-          "MoonPay is a platform that makes it easy and quick to buy {{name}} in over 160+ countries."
+          "We partner with MoonPay to offer you a seamless way to buy {{coinCode}} directly within the BitBoxApp. It's just a few clicks.",
+          "MoonPay is a platform that makes it easy and quick to buy {{coinCode}} in over 160+ countries."
         ],
         "payment": {
-          "details": "You can buy {{name}} instantly via MoonPay with the following payment methods. Credit or debit card orders are instant and convenient, but more expensive due to increased chargeback risk. We recommend using the bank transfer option for larger amounts. The minimum fee is 4 USD/EUR or equivalent.",
+          "details": "You can buy {{coinCode}} instantly via MoonPay with the following payment methods. Credit or debit card orders are instant and convenient, but more expensive due to increased chargeback risk. We recommend using the bank transfer option for larger amounts. The minimum fee is 4 USD/EUR or equivalent.",
           "footnote": "Please note that MoonPay's exchange rates can differ from the ones used in the BitBoxApp, resulting in slightly different amounts.",
           "table": {
             "1_description": "Lowest fees, can take up to 3 working days",
@@ -481,23 +480,27 @@
         },
         "privacyPolicy": "MoonPay privacy policy",
         "protection": {
-          "description": "The BitBoxApp does not collect any data when buying {{name}}, the incoming funds are treated like a regular transaction. MoonPay needs to collect some personal data to operate. Their Privacy Policy explains in detail how that data is handled.",
-          "descriptionGeneric": "The BitBoxApp does not collect any data when buying {{name}}, the incoming funds are treated like a regular transaction. However partner exchanges need to collect some information to operate. Please refer to their respective privacy policies to see in more detail how the data is handled.",
+          "descriptionGeneric_bitcoin": "The BitBoxApp does not collect any data when buying Bitcoin, the incoming funds are treated like a regular transaction. However partner exchanges need to collect some information to operate. Please refer to their respective privacy policies to see in more detail how the data is handled.",
+          "descriptionGeneric_crypto": "The BitBoxApp does not collect any data when buying crypto, the incoming funds are treated like a regular transaction. However partner exchanges need to collect some information to operate. Please refer to their respective privacy policies to see in more detail how the data is handled.",
+          "description_bitcoin": "The BitBoxApp does not collect any data when buying Bitcoin, the incoming funds are treated like a regular transaction. MoonPay needs to collect some personal data to operate. Their Privacy Policy explains in detail how that data is handled.",
+          "description_crypto": "The BitBoxApp does not collect any data when buying crypto, the incoming funds are treated like a regular transaction. MoonPay needs to collect some personal data to operate. Their Privacy Policy explains in detail how that data is handled.",
           "title": "Data protection"
         },
         "security": {
-          "description": "When you buy {{name}} via MoonPay, you are using an external service. This service is out of scope of the BitBox02 security threat model and relies on the safety and security of the environment which the BitBoxApp software is running in.",
-          "descriptionGeneric": "When you buy {{name}} via a partner exchange, you are using an external service. This service is out of scope of the BitBox02 security threat model and relies on the safety and security of the environment which the BitBoxApp software is running in.",
+          "descriptionGeneric_bitcoin": "When you buy Bitcoin via a partner exchange, you are using an external service. This service is out of scope of the BitBox02 security threat model and relies on the safety and security of the environment which the BitBoxApp software is running in.",
+          "descriptionGeneric_crypto": "When you buy crypto via a partner exchange, you are using an external service. This service is out of scope of the BitBox02 security threat model and relies on the safety and security of the environment which the BitBoxApp software is running in.",
+          "description_bitcoin": "When you buy Bitcoin via MoonPay, you are using an external service. This service is out of scope of the BitBox02 security threat model and relies on the safety and security of the environment which the BitBoxApp software is running in.",
+          "description_crypto": "When you buy crypto via MoonPay, you are using an external service. This service is out of scope of the BitBox02 security threat model and relies on the safety and security of the environment which the BitBoxApp software is running in.",
           "link": "Security threat model",
           "title": "Security model"
         },
-        "title": "Welcome to your one stop shop for buying {{name}}"
+        "title_bitcoin": "Welcome to your one stop shop for buying Bitcoin",
+        "title_crypto": "Welcome to your one stop shop for buying crypto"
       },
       "next": "Next",
       "selectLabel": "Choose your account",
       "selectPlaceholder": "Select a coin",
-      "skip": "Do not show again",
-      "title": "Buy {{name}}"
+      "skip": "Do not show again"
     },
     "pocket": {
       "data": {
@@ -529,8 +532,7 @@
         "p3": "With Pocket, you can also do regular buys through standing bank orders, so you can DCA (dollar-cost averaging) with ease.",
         "title": "Welcome to your one stop shop for buying bitcoin"
       }
-    },
-    "title": "Buy {{name}}"
+    }
   },
   "changePin": {
     "newTitle": "New device password",

--- a/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
@@ -57,7 +57,7 @@ export const BuyReceiveCTA = ({
   const onReceiveCTA = () => {
     if (balanceList) {
       if (balanceList.length > 1) {
-        navigate('accounts/select-receive');
+        navigate('/accounts/select-receive');
         return;
       }
       navigate(`/account/${code}/receive`);

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -24,16 +24,6 @@ export const findAccount = (
   return accounts.find(({ code }) => accountCode === code);
 };
 
-export const getCryptoName = (
-  cryptoLabel: string,
-  account?: IAccount,
-): string => {
-  if (account && isBitcoinOnly(account.coinCode)) {
-    return 'Bitcoin';
-  }
-  return cryptoLabel;
-};
-
 export const isBitcoinOnly = (coinCode: CoinCode): boolean => {
   switch (coinCode) {
   case 'btc':

--- a/frontends/web/src/routes/buy/exchange.tsx
+++ b/frontends/web/src/routes/buy/exchange.tsx
@@ -24,7 +24,7 @@ import * as exchangesAPI from '../../api/exchanges';
 import { AccountCode, IAccount } from '../../api/account';
 import { Header } from '../../components/layout';
 import { BuyGuide } from './guide';
-import { findAccount, getCryptoName } from '../account/utils';
+import { findAccount, isBitcoinOnly } from '../account/utils';
 import { route } from '../../utils/route';
 import { useLoad } from '../../hooks/api';
 import { getRegionNameFromLocale } from '../../i18n/utils';
@@ -64,7 +64,12 @@ export const Exchange = ({ code, accounts }: TProps) => {
   const config = useLoad(getConfig);
 
   const account = findAccount(accounts, code);
-  const name = getCryptoName(t('buy.info.crypto'), account);
+  const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
+  const isBitcoin = hasOnlyBTCAccounts || (account && isBitcoinOnly(account?.coinCode));
+
+  const title = t('generic.buy', {
+    context: isBitcoin ? 'bitcoin' : 'crypto',
+  });
 
   const hasOnlyOneSupportedExchange = allExchangeDeals ? allExchangeDeals.exchanges.filter(exchange => exchange.supported).length === 1 : false;
 
@@ -191,9 +196,9 @@ export const Exchange = ({ code, accounts }: TProps) => {
           {info && <InfoContent info={info} cardFee={cardFee} bankTransferFee={bankTransferFee} />}
         </Dialog>
         <div className="innerContainer scrollableContainer">
-          <Header title={<h2>{t('buy.exchange.title', { name })}</h2>} />
+          <Header title={<h2>{title}</h2>} />
           <div className={[style.exchangeContainer, 'content', 'narrow', 'isVerticallyCentered'].join(' ')}>
-            <h1 className={style.title}>{t('buy.title', { name })}</h1>
+            <h1 className={style.title}>{title}</h1>
             <p className={style.label}>{t('buy.exchange.region')}</p>
             {regions.length ? (
               <>
@@ -245,7 +250,7 @@ export const Exchange = ({ code, accounts }: TProps) => {
           </div>
         </div>
       </div>
-      <BuyGuide name={name} />
+      <BuyGuide translationContext={hasOnlyBTCAccounts ? 'bitcoin' : 'crypto'} />
     </div>
   );
 };

--- a/frontends/web/src/routes/buy/guide.tsx
+++ b/frontends/web/src/routes/buy/guide.tsx
@@ -19,11 +19,11 @@ import { Entry } from '../../components/guide/entry';
 import { Guide } from '../../components/guide/guide';
 
 interface BuyGuideProps {
-  name: string;
   exchange?: 'pocket' | 'moonpay';
+  translationContext: 'bitcoin' | 'crypto';
 }
 
-export const BuyGuide = ({ name, exchange }: BuyGuideProps) => {
+export const BuyGuide = ({ exchange, translationContext }: BuyGuideProps) => {
   const { t } = useTranslation();
 
   const pocketLink = {
@@ -45,12 +45,14 @@ export const BuyGuide = ({ name, exchange }: BuyGuideProps) => {
           text: t('buy.info.disclaimer.security.link'),
           url: 'https://bitbox.swiss/bitbox02/threat-model/',
         },
-        text: t('buy.info.disclaimer.security.descriptionGeneric', { name }),
+        text: t('buy.info.disclaimer.security.descriptionGeneric', {
+          context: translationContext
+        }),
         title: t('buy.info.disclaimer.security.title'),
       }} shown={true} />
       <Entry key="guide.buy.protection" entry={{
         link: exchange ? privacyLink : undefined,
-        text: t('buy.info.disclaimer.protection.descriptionGeneric', { name }),
+        text: t('buy.info.disclaimer.protection.descriptionGeneric', { context: translationContext }),
         title: t('buy.info.disclaimer.protection.title'),
       }} />
     </Guide>

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -85,13 +85,17 @@ export const BuyInfo = ({ code, accounts }: TProps) => {
   }
 
   const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
-  const name = hasOnlyBTCAccounts ? 'Bitcoin' : t('buy.info.crypto');
+  const translationContext = hasOnlyBTCAccounts ? 'bitcoin' : 'crypto';
 
   return (
     <Main>
       <GuideWrapper>
         <GuidedContent>
-          <Header title={<h2>{t('buy.info.title', { name })}</h2>}>
+          <Header title={
+            <h2>
+              {t('generic.buy', { context: translationContext })}
+            </h2>
+          }>
             <HideAmountsButton />
           </Header>
           <View width="550px" verticallyCentered fullscreen={false}>
@@ -99,20 +103,21 @@ export const BuyInfo = ({ code, accounts }: TProps) => {
               { !supportedAccounts || supportedAccounts.length === 0 ? (
                 <div className="content narrow isVerticallyCentered">{t('accountSummary.noAccount')}</div>
               ) : (
-                supportedAccounts &&
-                      <GroupedAccountSelector
-                        accounts={supportedAccounts}
-                        title={t('buy.title', { name })}
-                        disabled={disabled}
-                        selected={selected}
-                        onChange={setSelected}
-                        onProceed={handleProceed}
-                      />
+                supportedAccounts && (
+                  <GroupedAccountSelector
+                    accounts={supportedAccounts}
+                    title={t('generic.buy', { context: translationContext })}
+                    disabled={disabled}
+                    selected={selected}
+                    onChange={setSelected}
+                    onProceed={handleProceed}
+                  />
+                )
               )}
             </ViewContent>
           </View>
         </GuidedContent>
-        <BuyGuide name={name} />
+        <BuyGuide translationContext={translationContext} />
       </GuideWrapper>
     </Main>
   );

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -25,7 +25,7 @@ import { getMoonpayBuyInfo } from '../../api/exchanges';
 import { BuyGuide } from './guide';
 import { Header } from '../../components/layout';
 import { Spinner } from '../../components/spinner/Spinner';
-import { findAccount, getCryptoName } from '../account/utils';
+import { findAccount, isBitcoinOnly } from '../account/utils';
 import { MoonpayTerms } from '../../components/terms/moonpay-terms';
 import style from './iframe.module.css';
 
@@ -45,7 +45,6 @@ export const Moonpay = ({ accounts, code }: TProps) => {
   const moonpay = useLoad(getMoonpayBuyInfo(code));
 
   const account = findAccount(accounts, code);
-  const name = getCryptoName(t('buy.info.crypto'), account);
   const ref = createRef<HTMLDivElement>();
   let resizeTimerID: any;
 
@@ -78,12 +77,19 @@ export const Moonpay = ({ accounts, code }: TProps) => {
     return null;
   }
 
+  const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
+  const translationContext = hasOnlyBTCAccounts ? 'bitcoin' : 'crypto';
+
   return (
     <div className="contentWithGuide">
       <div className="container">
         <div className="innerContainer">
           <div className={style.header}>
-            <Header title={<h2>{t('buy.info.title', { name })}</h2>} />
+            <Header title={
+              <h2>
+                {t('generic.buy', { context: translationContext })}
+              </h2>
+            } />
           </div>
           <div ref={ref} className={style.container}>
             { !agreedTerms ? (
@@ -114,7 +120,7 @@ export const Moonpay = ({ accounts, code }: TProps) => {
           </div>
         </div>
       </div>
-      <BuyGuide name={name} exchange={'moonpay'}/>
+      <BuyGuide exchange="moonpay" translationContext={translationContext} />
     </div>
   );
 };

--- a/frontends/web/src/routes/buy/pocket.tsx
+++ b/frontends/web/src/routes/buy/pocket.tsx
@@ -52,8 +52,6 @@ export const Pocket = ({ code }: TProps) => {
   let signing = false;
   let resizeTimerID: any = undefined;
 
-  const name = 'Bitcoin';
-
   useEffect(() => {
     if (config) {
       setAgreedTerms(config.frontend.skipPocketDisclaimer);
@@ -215,7 +213,11 @@ export const Pocket = ({ code }: TProps) => {
     <div className="contentWithGuide">
       <div className="container">
         <div className={style.header}>
-          <Header title={<h2>{t('buy.info.title', { name })}</h2>} />
+          <Header title={
+            <h2>
+              {t('generic.buy', { context: 'bitcoin' })}
+            </h2>
+          } />
         </div>
         <div ref={ref} className={style.container}>
           { !agreedTerms ? (
@@ -249,7 +251,7 @@ export const Pocket = ({ code }: TProps) => {
           </Dialog>
         </div>
       </div>
-      <BuyGuide name={name} exchange={'pocket'}/>
+      <BuyGuide exchange="pocket" translationContext="bitcoin" />
     </div>
   );
 };


### PR DESCRIPTION
In some languages Bitcoin or crypto can have special ending depending
on the context, so translating crypto does not work in all cases.

Added Bitcoin and crypto context with option to show coinCode,
if needed.

For simplicity the guide is just using crypto or bitcoin.
Also buy.info.disclaimer keys need to be updated with coinCode.

Related b617b15427ffac7e0c0e9e1b7c2a8d01b59cefd0