### PR TITLE
frontend: simplify terms and condition 

### DIFF
--- a/frontends/web/src/components/terms/moonpay-terms.tsx
+++ b/frontends/web/src/components/terms/moonpay-terms.tsx
@@ -17,7 +17,7 @@
 
 import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { isBitcoinBased } from '@/routes/account/utils';
+import { isBitcoinOnly } from '@/routes/account/utils';
 import { Button, Checkbox } from '@/components/forms';
 import { setConfig } from '@/utils/config';
 import { IAccount } from '@/api/account';
@@ -37,7 +37,7 @@ export const MoonpayTerms = ({ account, onAgreedTerms }: TProps) => {
   };
 
   const coinCode = account.coinCode.toUpperCase();
-  const isBitcoin = isBitcoinBased(account.coinCode);
+  const isBitcoin = isBitcoinOnly(account.coinCode);
 
   return (
     <div className={style.disclaimerContainer}>

--- a/frontends/web/src/components/terms/moonpay-terms.tsx
+++ b/frontends/web/src/components/terms/moonpay-terms.tsx
@@ -86,7 +86,7 @@ export const MoonpayTerms = ({ account, onAgreedTerms }: TProps) => {
           {t('buy.info.disclaimer.security.title')}
         </h2>
         <p>
-          {t('buy.info.disclaimer.security.description', {
+          {t('buy.info.disclaimer.security.descriptionGeneric', {
             context: isBitcoin ? 'bitcoin' : 'crypto'
           })}
         </p>
@@ -99,7 +99,7 @@ export const MoonpayTerms = ({ account, onAgreedTerms }: TProps) => {
           {t('buy.info.disclaimer.protection.title')}
         </h2>
         <p>
-          {t('buy.info.disclaimer.protection.description', {
+          {t('buy.info.disclaimer.protection.descriptionGeneric', {
             context: isBitcoin ? 'bitcoin' : 'crypto'
           })}
         </p>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -482,15 +482,11 @@
         "protection": {
           "descriptionGeneric_bitcoin": "The BitBoxApp does not collect any data when buying Bitcoin, the incoming funds are treated like a regular transaction. However partner exchanges need to collect some information to operate. Please refer to their respective privacy policies to see in more detail how the data is handled.",
           "descriptionGeneric_crypto": "The BitBoxApp does not collect any data when buying crypto, the incoming funds are treated like a regular transaction. However partner exchanges need to collect some information to operate. Please refer to their respective privacy policies to see in more detail how the data is handled.",
-          "description_bitcoin": "The BitBoxApp does not collect any data when buying Bitcoin, the incoming funds are treated like a regular transaction. MoonPay needs to collect some personal data to operate. Their Privacy Policy explains in detail how that data is handled.",
-          "description_crypto": "The BitBoxApp does not collect any data when buying crypto, the incoming funds are treated like a regular transaction. MoonPay needs to collect some personal data to operate. Their Privacy Policy explains in detail how that data is handled.",
           "title": "Data protection"
         },
         "security": {
           "descriptionGeneric_bitcoin": "When you buy Bitcoin via a partner exchange, you are using an external service. This service is out of scope of the BitBox02 security threat model and relies on the safety and security of the environment which the BitBoxApp software is running in.",
           "descriptionGeneric_crypto": "When you buy crypto via a partner exchange, you are using an external service. This service is out of scope of the BitBox02 security threat model and relies on the safety and security of the environment which the BitBoxApp software is running in.",
-          "description_bitcoin": "When you buy Bitcoin via MoonPay, you are using an external service. This service is out of scope of the BitBox02 security threat model and relies on the safety and security of the environment which the BitBoxApp software is running in.",
-          "description_crypto": "When you buy crypto via MoonPay, you are using an external service. This service is out of scope of the BitBox02 security threat model and relies on the safety and security of the environment which the BitBoxApp software is running in.",
           "link": "Security threat model",
           "title": "Security model"
         },


### PR DESCRIPTION
Removed Moonpay specific terms in favor of general disclaimer text.

And fixed small regression with LTC as it was detected as Bitcoin