### PR TITLE
backend/handlers: fix err handling in getExchangeBuySupported

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -240,7 +240,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/socksproxy/check", handlers.postSocksProxyCheck).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/exchange/by-region/{code}", handlers.getExchangesByRegion).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/exchange/deals", handlers.getExchangeDeals).Methods("GET")
-	getAPIRouter(apiRouter)("/exchange/buy-supported/{code}", handlers.getExchangeBuySupported).Methods("GET")
+	getAPIRouterNoError(apiRouter)("/exchange/buy-supported/{code}", handlers.getExchangeBuySupported).Methods("GET")
 	getAPIRouter(apiRouter)("/exchange/moonpay/buy-info/{code}", handlers.getExchangeMoonpayBuyInfo).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/exchange/pocket/api-url", handlers.getExchangePocketURL).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/exchange/pocket/verify-address", handlers.postPocketWidgetVerifyAddress).Methods("POST")
@@ -1308,20 +1308,20 @@ func (handlers *Handlers) getExchangeDeals(r *http.Request) interface{} {
 	}
 }
 
-func (handlers *Handlers) getExchangeBuySupported(r *http.Request) (interface{}, error) {
+func (handlers *Handlers) getExchangeBuySupported(r *http.Request) interface{} {
 	type supportedExchanges struct {
 		Exchanges []string `json:"exchanges"`
 	}
 
+	supported := supportedExchanges{Exchanges: []string{}}
 	acct, err := handlers.backend.GetAccountFromCode(accountsTypes.Code(mux.Vars(r)["code"]))
 	if err != nil {
-		return nil, err
+		return supported
 	}
 
-	supported := supportedExchanges{Exchanges: []string{}}
 	accountValid := acct != nil && acct.Offline() == nil && !acct.FatalError()
 	if !accountValid {
-		return supported, nil
+		return supported
 	}
 
 	if exchanges.IsMoonpaySupported(acct.Coin().Code()) {
@@ -1331,7 +1331,7 @@ func (handlers *Handlers) getExchangeBuySupported(r *http.Request) (interface{},
 		supported.Exchanges = append(supported.Exchanges, exchanges.PocketName)
 	}
 
-	return supported, nil
+	return supported
 }
 
 func (handlers *Handlers) getExchangeMoonpayBuyInfo(r *http.Request) (interface{}, error) {


### PR DESCRIPTION
If getExchangeBuySupported was called after an account was closed it was returning a generic error, causing the frontend to display the generic error popup when disconnecting the bitbox every now and then.

This makes the endpoint to return an empty list of supported exchanges if the account is not available.