### PR TITLE
backend/btc: add support for payment request transactions

### DIFF
--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -33,15 +33,33 @@ type AddressList struct {
 	Addresses  []Address
 }
 
+// TextMemo represents a slip-0024 text memo.
+type TextMemo struct {
+	Note string
+}
+
+// PaymentRequest contains the data needed to fulfill a slip-0024 payment request.
+// Text memos are the only memo type supported, currently.
+type PaymentRequest struct {
+	RecipientName string
+	Memos         []TextMemo
+	Nonce         []byte
+	TotalAmount   uint64
+	Signature     []byte
+	// TxOut is a pointer to the TxOut which will satisfay the payment request.
+	TxOut *wire.TxOut
+}
+
 // TxProposalArgs are the arguments needed when creating a tx proposal.
 type TxProposalArgs struct {
 	RecipientAddress string
 	Amount           coin.SendAmount
 	FeeTargetCode    FeeTargetCode
 	// Only applies if FeeTargetCode == Custom. It is provided in sat/vB for BTC/LTC and Gwei for ETH.
-	CustomFee     string
-	SelectedUTXOs map[wire.OutPoint]struct{}
-	Note          string
+	CustomFee       string
+	SelectedUTXOs   map[wire.OutPoint]struct{}
+	Note            string
+	PaymentRequests []*PaymentRequest
 }
 
 // Interface is the API of a Account.

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -17,6 +17,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -364,6 +365,51 @@ func (handlers *Handlers) getAccountBalance(*http.Request) (interface{}, error) 
 	}, nil
 }
 
+type slip24Request struct {
+	RecipientName string `json:"recipientName"`
+	Nonce         string `json:"nonce"`
+	Memos         []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"memos"`
+	Outputs []struct {
+		Amount  uint64 `json:"amount"`
+		Address string `json:"address"`
+	} `json:"outputs"`
+	Signature string `json:"signature"`
+}
+
+func (slip24 slip24Request) toPaymentRequest() (*accounts.PaymentRequest, error) {
+	if len(slip24.Outputs) != 1 {
+		return nil, errp.New("Missing or multiple payment request output unsupported")
+	}
+
+	if len(slip24.Nonce) > 0 {
+		return nil, errp.New("Nonce value unsupported")
+	}
+
+	sigBytes, err := base64.StdEncoding.DecodeString(slip24.Signature)
+	if err != nil {
+		return nil, err
+	}
+
+	memos := []accounts.TextMemo{}
+	for _, memo := range slip24.Memos {
+		if memo.Type != "text" {
+			return nil, errp.New("Payment request non-text memo unsupported")
+		}
+		memos = append(memos, accounts.TextMemo{Note: memo.Text})
+	}
+
+	return &accounts.PaymentRequest{
+		RecipientName: slip24.RecipientName,
+		Nonce:         nil,
+		Signature:     sigBytes,
+		TotalAmount:   slip24.Outputs[0].Amount,
+		Memos:         memos,
+	}, nil
+}
+
 type sendTxInput struct {
 	accounts.TxProposalArgs
 }
@@ -374,11 +420,12 @@ func (input *sendTxInput) UnmarshalJSON(jsonBytes []byte) error {
 		SendAll   string `json:"sendAll"`
 		FeeTarget string `json:"feeTarget"`
 		// Provided in Sat/vByte for BTC/LTC and in Gwei for ETH.
-		CustomFee     string   `json:"customFee"`
-		Amount        string   `json:"amount"`
-		SelectedUTXOS []string `json:"selectedUTXOS"`
-		Note          string   `json:"note"`
-		Counter       int      `json:"counter"`
+		CustomFee       string         `json:"customFee"`
+		Amount          string         `json:"amount"`
+		SelectedUTXOS   []string       `json:"selectedUTXOS"`
+		Note            string         `json:"note"`
+		Counter         int            `json:"counter"`
+		PaymentRequests *slip24Request `json:"paymentRequest"`
 	}{}
 	if err := json.Unmarshal(jsonBytes, &jsonBody); err != nil {
 		return errp.WithStack(err)
@@ -406,6 +453,13 @@ func (input *sendTxInput) UnmarshalJSON(jsonBytes []byte) error {
 		input.SelectedUTXOs[*outPoint] = struct{}{}
 	}
 	input.Note = jsonBody.Note
+	if jsonBody.PaymentRequests != nil {
+		paymentRequest, err := jsonBody.PaymentRequests.toPaymentRequest()
+		if err != nil {
+			return err
+		}
+		input.PaymentRequests = append(input.PaymentRequests, paymentRequest)
+	}
 	return nil
 }
 

--- a/backend/coins/btc/maketx/maketx.go
+++ b/backend/coins/btc/maketx/maketx.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/errors"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/addresses"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/transactions"
@@ -53,6 +54,7 @@ type TxProposal struct {
 	// ChangeAddress is the address of the wallet to which the change of the transaction is sent.
 	ChangeAddress   *addresses.AccountAddress
 	PreviousOutputs PreviousOutputs
+	PaymentRequest  []*accounts.PaymentRequest
 }
 
 // Total is amount+fee.

--- a/backend/coins/coin/conversions.go
+++ b/backend/coins/coin/conversions.go
@@ -8,7 +8,7 @@ import (
 	ratesPkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/rates"
 )
 
-// Btc2Sat is the sat equivalent of 1 BTC.
+// btc2SatUnit is the sat equivalent of 1 BTC.
 const btc2SatUnit = 1e8
 
 // Sat2Btc converts a big.Rat amount of Sat in an equivalent amount of BTC.

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"sync"
 
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/blockchain"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/types"
@@ -402,7 +403,6 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 				ScriptConfig: firmware.NewBTCScriptConfigSimple(msgScriptType),
 				Keypath:      accountConfiguration.AbsoluteKeypath().ToUInt32(),
 			})
-
 		}
 		outputs[index] = &messages.BTCSignOutputRequest{
 			Ours:              isOurs,
@@ -452,14 +452,52 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 	if btcProposedTx.FormatUnit == coinpkg.BtcUnitSats {
 		formatUnit = messages.BTCSignInitRequest_SAT
 	}
+
+	// Payment request handling
+	newBTCPaymentRequest := func(txPaymentRequest *accounts.PaymentRequest) *messages.BTCPaymentRequestRequest {
+		memos := []*messages.BTCPaymentRequestRequest_Memo{}
+		for _, m := range txPaymentRequest.Memos {
+			memo := messages.BTCPaymentRequestRequest_Memo{
+				Memo: &messages.BTCPaymentRequestRequest_Memo_TextMemo_{
+					TextMemo: &messages.BTCPaymentRequestRequest_Memo_TextMemo{
+						Note: m.Note,
+					},
+				},
+			}
+			memos = append(memos, &memo)
+		}
+
+		return &messages.BTCPaymentRequestRequest{
+			RecipientName: txPaymentRequest.RecipientName,
+			Nonce:         txPaymentRequest.Nonce,
+			TotalAmount:   txPaymentRequest.TotalAmount,
+			Signature:     txPaymentRequest.Signature,
+			Memos:         memos,
+		}
+	}
+
+	var btcPaymentRequests []*messages.BTCPaymentRequestRequest
+	for prIndex, paymentRequest := range btcProposedTx.TXProposal.PaymentRequest {
+		btcPR := newBTCPaymentRequest(paymentRequest)
+		btcPaymentRequests = append(btcPaymentRequests, btcPR)
+		prIndex := uint32(prIndex)
+		for outIndex, txOut := range tx.TxOut {
+			if paymentRequest.TxOut == txOut {
+				// outputs indexing is the same as tx.TxOut
+				outputs[outIndex].PaymentRequestIndex = &prIndex
+			}
+		}
+	}
+
 	signatures, err := keystore.device.BTCSign(
 		msgCoin,
 		scriptConfigs,
 		&firmware.BTCTx{
-			Version:  uint32(tx.Version),
-			Inputs:   inputs,
-			Outputs:  outputs,
-			Locktime: tx.LockTime,
+			Version:         uint32(tx.Version),
+			Inputs:          inputs,
+			Outputs:         outputs,
+			Locktime:        tx.LockTime,
+			PaymentRequests: btcPaymentRequests,
 		},
 		formatUnit,
 	)

--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -20,7 +20,7 @@
         "react-i18next": "14.1.2",
         "react-router-dom": "6.4.3",
         "react-select": "5.8.0",
-        "request-address": "0.0.6"
+        "request-address": "0.0.9"
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
@@ -9608,9 +9608,9 @@
       }
     },
     "node_modules/request-address": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/request-address/-/request-address-0.0.6.tgz",
-      "integrity": "sha512-+2K4JU/m1ERJ/7Pt3x+N0RqC+Pbdp9Ry6B7OVCDD9J8En3YGX6aAt1Zw6jkQLdY87dJsYPWG/hTrEFAJ2tSnMA=="
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/request-address/-/request-address-0.0.9.tgz",
+      "integrity": "sha512-RF/7SZZjj91goNC3aJM/VfwPiEfIcjPswxSYi7uOeVhNVRW2fyU1P+ADqITWOnr71QQQSn3DW1vgMsPtIVIz5A=="
     },
     "node_modules/requires-port": {
       "version": "1.0.0",

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -34,7 +34,7 @@
     "react-i18next": "14.1.2",
     "react-router-dom": "6.4.3",
     "react-select": "5.8.0",
-    "request-address": "0.0.6"
+    "request-address": "0.0.9"
   },
   "eslintConfig": {
     "extends": [

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -18,6 +18,7 @@ import { apiGet, apiPost } from '@/utils/request';
 import type { ChartData } from '@/routes/account/summary/chart';
 import type { TDetailStatus } from './bitsurance';
 import type { SuccessResponse } from './response';
+import { Slip24 } from 'request-address';
 
 export type NativeCoinCode = 'btc' | 'tbtc' | 'rbtc' | 'ltc' | 'tltc' | 'eth' | 'goeth' | 'sepeth';
 
@@ -302,7 +303,8 @@ export type TTxInput = {
   feeTarget: FeeTargetCode;
   customFee: string;
   sendAll: 'yes' | 'no';
-  selectedUTXOs: string[],
+  selectedUTXOs: string[];
+  paymentRequest: Slip24 | null;
 };
 
 export type TTxProposalResult = {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -514,6 +514,7 @@
         "p2": "Please note that Pocket’s exchange rates can differ from the ones used in the BitBoxApp, resulting in slightly different amounts.",
         "title": "Payment methods and fees"
       },
+      "paymentRequestNote": "Payment request from",
       "previousTransactions": "The transaction history of this account is not empty. Sharing this account will make all its past and future transactions visible for Pocket. Proceed anyway?",
       "security": {
         "link": "BitBox02 security threat model",

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -260,6 +260,7 @@ class Send extends Component<Props, State> {
       customFee: this.state.customFee,
       sendAll: (this.state.sendAll ? 'yes' : 'no'),
       selectedUTXOs: Object.keys(this.selectedUTXOs),
+      paymentRequest: null,
     };
   };
 


### PR DESCRIPTION
Payment requests have been supported by bitbox02 firmware since v9.19.0. This integrates the feature in the app, mocking a payment request in the Pocket widget section. Once the Pocket sell widget integration is completed the mock function will be removed.

Note: to test this it is necessary to flash a dev device with a FW having the test merchant enabled.