### PR TITLE
frontend/dialog: remove disableClose param

### DIFF
--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -29,7 +29,6 @@ type TProps = {
     centered?: boolean;
     disableEscape?: boolean;
     onClose?: (e?: Event) => void;
-    disabledClose?: boolean;
     children: React.ReactNode;
     open: boolean;
 }
@@ -43,7 +42,6 @@ export const Dialog = ({
   centered,
   disableEscape,
   onClose,
-  disabledClose,
   children,
   open,
 }: TProps) => {
@@ -204,7 +202,7 @@ export const Dialog = ({
               { onClose ? (
                 <button className={style.closeButton} onClick={() => {
                   deactivate(true);
-                }} disabled={disabledClose}>
+                }}>
                   <CloseXDark className="show-in-lightmode" />
                   <CloseXWhite className="show-in-darkmode" />
                 </button>

--- a/frontends/web/src/routes/settings/components/device-settings/factory-reset-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/factory-reset-setting.tsx
@@ -32,7 +32,6 @@ type TProps = {
 type TDialog = {
     open: boolean;
     handleCloseDialog: () => void;
-    isConfirming: boolean;
     understand: boolean;
     handleUnderstandChange: (e: ChangeEvent<HTMLInputElement>) => void;
     handleReset: () => void;
@@ -84,7 +83,6 @@ const FactoryResetSetting = ({ deviceID }: TProps) => {
       <FactoryResetDialog
         open={activeDialog}
         handleCloseDialog={abort}
-        isConfirming={isConfirming}
         understand={understand}
         handleUnderstandChange={handleUnderstandChange}
         handleReset={reset}
@@ -98,7 +96,6 @@ const FactoryResetSetting = ({ deviceID }: TProps) => {
 const FactoryResetDialog = ({
   open,
   handleCloseDialog,
-  isConfirming,
   understand,
   handleUnderstandChange,
   handleReset
@@ -109,7 +106,6 @@ const FactoryResetDialog = ({
       open={open}
       title={t('reset.title')}
       onClose={handleCloseDialog}
-      disabledClose={isConfirming}
       small>
       <div className="columnsContainer half">
         <div className="columns">


### PR DESCRIPTION
Only used in the factory reset dialog during isConfirming, but when isConfirming is true, the FactoryResetWaitDialog is shown and the original dialog is hidden anyway.