### PR TITLE
frontend: use Message component for Status

### DIFF
--- a/frontends/web/src/api/banners.ts
+++ b/frontends/web/src/api/banners.ts
@@ -15,8 +15,8 @@
  */
 
 import { apiGet } from '@/utils/request';
-import { statusType } from '@/components/status/status';
 import { subscribeEndpoint, TUnsubscribe } from './subscribe';
+import { TMessageTypes } from '@/utils/types';
 
 export type TBannerInfo = {
   id: string;
@@ -26,7 +26,7 @@ export type TBannerInfo = {
     text?: string;
   };
   dismissible?: boolean;
-  type?: statusType;
+  type?: TMessageTypes;
 }
 
 export const getBanner = (msgKey: string): Promise<TBannerInfo> => {

--- a/frontends/web/src/api/banners.ts
+++ b/frontends/web/src/api/banners.ts
@@ -16,7 +16,7 @@
 
 import { apiGet } from '@/utils/request';
 import { subscribeEndpoint, TUnsubscribe } from './subscribe';
-import { TMessageTypes } from '@/utils/types';
+import type { TMessageTypes } from '@/utils/types';
 
 export type TBannerInfo = {
   id: string;

--- a/frontends/web/src/app.module.css
+++ b/frontends/web/src/app.module.css
@@ -1,4 +1,16 @@
-.parentContainer {
+.appContent {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    height: 100vh;
     min-width: 0;
-    overflow: auto;
+    /* mobile viewport bug fix */
+    max-height: -webkit-fill-available;
+}
+
+@media (max-width: 900px) {
+    .appContent {
+        position: absolute;
+        width: 100%;
+    }
 }

--- a/frontends/web/src/app.module.css
+++ b/frontends/web/src/app.module.css
@@ -1,0 +1,4 @@
+.parentContainer {
+    min-width: 0;
+    overflow: auto;
+}

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -43,6 +43,8 @@ import { Darkmode } from './components/darkmode/darkmode';
 import { AuthRequired } from './components/auth/authrequired';
 import { WCSigningRequest } from './components/wallet-connect/incoming-signing-request';
 import { Providers } from './contexts/providers';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
+import styles from './app.module.css';
 
 export const App = () => {
   const { t } = useTranslation();
@@ -154,42 +156,47 @@ export const App = () => {
       <Providers>
         <Darkmode />
         <div className="app">
-          <AuthRequired/>
+          <AuthRequired />
           <Sidebar
             accounts={activeAccounts}
             deviceIDs={deviceIDs}
             devices={devices}
           />
-          <div className="appContent flex flex-column flex-1" style={{ minWidth: 0 }}>
-            <Update />
-            <Banner msgKey="bitbox01" />
-            <Banner msgKey="bitbox02" />
-            <MobileDataWarning />
-            <WCSigningRequest />
-            <Aopp />
-            <KeystoreConnectPrompt />
-            {
-              Object.entries(devices).map(([deviceID, productName]) => {
-                if (productName === 'bitbox02') {
-                  return (
-                    <Fragment key={deviceID}>
-                      <BitBox02Wizard
-                        deviceID={deviceID}
-                      />
-                    </Fragment>
-                  );
-                }
-                return null;
-              })
-            }
-            <AppRouter
-              accounts={accounts}
-              activeAccounts={activeAccounts}
-              deviceIDs={deviceIDs}
-              devices={devices}
-              devicesKey={devicesKey}
-            />
-            <RouterWatcher />
+          <div className={`appContent flex flex-column flex-1 ${styles.parentContainer}`}>
+            <div className="flex flex-column">
+              <ContentWrapper className={`flex flex-column ${styles.banners}`}>
+                <Update />
+                <MobileDataWarning />
+                <Banner msgKey="bitbox01" />
+                <Banner msgKey="bitbox02" />
+              </ContentWrapper>
+              <WCSigningRequest />
+              <Aopp />
+              <KeystoreConnectPrompt />
+              {
+                Object.entries(devices).map(([deviceID, productName]) => {
+                  if (productName === 'bitbox02') {
+                    return (
+                      <Fragment key={deviceID}>
+                        <BitBox02Wizard
+                          deviceID={deviceID}
+                        />
+                      </Fragment>
+                    );
+                  }
+                  return null;
+                })
+              }
+              <AppRouter
+                accounts={accounts}
+                activeAccounts={activeAccounts}
+                deviceIDs={deviceIDs}
+                devices={devices}
+                devicesKey={devicesKey}
+              />
+              <RouterWatcher />
+            </div>
+
           </div>
           <Alert />
           <Confirm />

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -32,18 +32,14 @@ import { notifyUser } from './api/system';
 import { ConnectedApp } from './connected';
 import { Alert } from './components/alert/Alert';
 import { Aopp } from './components/aopp/aopp';
-import { Banner } from './components/banner/banner';
 import { Confirm } from './components/confirm/Confirm';
 import { KeystoreConnectPrompt } from './components/keystoreconnectprompt';
-import { MobileDataWarning } from './components/mobiledatawarning';
 import { Sidebar } from './components/sidebar/sidebar';
-import { Update } from './components/update/update';
 import { RouterWatcher } from './utils/route';
 import { Darkmode } from './components/darkmode/darkmode';
 import { AuthRequired } from './components/auth/authrequired';
 import { WCSigningRequest } from './components/wallet-connect/incoming-signing-request';
 import { Providers } from './contexts/providers';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import styles from './app.module.css';
 
 export const App = () => {
@@ -156,47 +152,38 @@ export const App = () => {
       <Providers>
         <Darkmode />
         <div className="app">
-          <AuthRequired />
+          <AuthRequired/>
           <Sidebar
             accounts={activeAccounts}
             deviceIDs={deviceIDs}
             devices={devices}
           />
-          <div className={`appContent flex flex-column flex-1 ${styles.parentContainer}`}>
-            <div className="flex flex-column">
-              <ContentWrapper className={`flex flex-column ${styles.banners}`}>
-                <Update />
-                <MobileDataWarning />
-                <Banner msgKey="bitbox01" />
-                <Banner msgKey="bitbox02" />
-              </ContentWrapper>
-              <WCSigningRequest />
-              <Aopp />
-              <KeystoreConnectPrompt />
-              {
-                Object.entries(devices).map(([deviceID, productName]) => {
-                  if (productName === 'bitbox02') {
-                    return (
-                      <Fragment key={deviceID}>
-                        <BitBox02Wizard
-                          deviceID={deviceID}
-                        />
-                      </Fragment>
-                    );
-                  }
-                  return null;
-                })
-              }
-              <AppRouter
-                accounts={accounts}
-                activeAccounts={activeAccounts}
-                deviceIDs={deviceIDs}
-                devices={devices}
-                devicesKey={devicesKey}
-              />
-              <RouterWatcher />
-            </div>
-
+          <div className={styles.appContent}>
+            <WCSigningRequest />
+            <Aopp />
+            <KeystoreConnectPrompt />
+            {
+              Object.entries(devices).map(([deviceID, productName]) => {
+                if (productName === 'bitbox02') {
+                  return (
+                    <Fragment key={deviceID}>
+                      <BitBox02Wizard
+                        deviceID={deviceID}
+                      />
+                    </Fragment>
+                  );
+                }
+                return null;
+              })
+            }
+            <AppRouter
+              accounts={accounts}
+              activeAccounts={activeAccounts}
+              deviceIDs={deviceIDs}
+              devices={devices}
+              devicesKey={devicesKey}
+            />
+            <RouterWatcher />
           </div>
           <Alert />
           <Confirm />

--- a/frontends/web/src/components/banner/banner.tsx
+++ b/frontends/web/src/components/banner/banner.tsx
@@ -48,11 +48,11 @@ export const Banner = ({ msgKey }: TBannerProps) => {
     <Status
       dismissible={banner.dismissible ? `banner-${msgKey}-${banner.id}` : ''}
       type={banner.type ? banner.type : 'warning'}>
-      { message[i18n.resolvedLanguage] || message[(i18n.options.fallbackLng as string[])[0]] }
+      {message[i18n.resolvedLanguage] || message[(i18n.options.fallbackLng as string[])[0]]}
       &nbsp;
-      { link && (
+      {link && (
         <A href={link.href} className={style.link}>
-          { link.text || t('clickHere') }
+          {link.text || t('clickHere')}
         </A>
       )}
     </Status>

--- a/frontends/web/src/components/contentwrapper/contentwrapper.module.css
+++ b/frontends/web/src/components/contentwrapper/contentwrapper.module.css
@@ -1,0 +1,24 @@
+.contentWrapper {
+    margin:  auto;
+    max-width: var(--content-width);
+    padding: 0 var(--space-default);
+    width: 100%;
+}
+
+.contentWrapper > div:first-child {
+    margin-top: var(--space-half);
+}
+
+.contentWrapper > div {
+    margin-bottom: var(--space-half);
+}
+
+.contentWrapper div:last-child {
+    margin-bottom: 0;
+}
+
+@media (max-width: 768px) {
+    .contentWrapper {
+        padding: 0 var(--space-half);
+    }
+}

--- a/frontends/web/src/components/contentwrapper/contentwrapper.tsx
+++ b/frontends/web/src/components/contentwrapper/contentwrapper.tsx
@@ -1,0 +1,27 @@
+// Copyright 2024 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ReactNode } from 'react';
+import style from './contentwrapper.module.css';
+
+type TProps = {
+    className?: string
+    children: ReactNode
+  }
+
+export const ContentWrapper = ({ className = '', children }: TProps) => {
+  return (
+    <div className={`${className} ${style.contentWrapper}`}>{children}</div>
+  );
+};

--- a/frontends/web/src/components/globalbanners/globalbanners.tsx
+++ b/frontends/web/src/components/globalbanners/globalbanners.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Shift Crypto AG
+ * Copyright 2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-import { ReactNode } from 'react';
-import style from './contentwrapper.module.css';
 
-type TProps = {
-    className?: string
-    children: ReactNode
-  }
+import { Banner } from '@/components/banner/banner';
+import { MobileDataWarning } from '@/components/mobiledatawarning';
+import { Update } from '@/components/update/update';
 
-export const ContentWrapper = (({ className = '', children }: TProps) => {
+export const GlobalBanners = () => {
   return (
-    <div className={`${className} ${style.contentWrapper}`}>{children}</div>
+    <>
+      <Update />
+      <Banner msgKey="bitbox01" />
+      <Banner msgKey="bitbox02" />
+      <MobileDataWarning />
+    </>
+
   );
-});
+};

--- a/frontends/web/src/components/message/message.module.css
+++ b/frontends/web/src/components/message/message.module.css
@@ -14,6 +14,7 @@
 
 .content {
     padding-top: 2px;
+    width: 100%;
 }
 
 .message .title {

--- a/frontends/web/src/components/message/message.module.css
+++ b/frontends/web/src/components/message/message.module.css
@@ -33,7 +33,7 @@
 }
 
 .message img {
-    margin-right: 12px;
+    margin-right: 4px;
     max-width: 30px;
 }
 

--- a/frontends/web/src/components/message/message.tsx
+++ b/frontends/web/src/components/message/message.tsx
@@ -18,8 +18,8 @@
 import { ReactNode } from 'react';
 import { StatusInfo, StatusSuccess, StatusWarning, StatusError } from '@/components/icon';
 import styles from './message.module.css';
+import { TMessageTypes } from '@/utils/types';
 
-type TMessageTypes = 'success' | 'info' | 'warning' | 'error';
 type TMessageIconProps = { type: TMessageTypes };
 
 const MessageIcon = ({ type }: TMessageIconProps) => {

--- a/frontends/web/src/components/message/message.tsx
+++ b/frontends/web/src/components/message/message.tsx
@@ -50,6 +50,7 @@ type MessageProps = {
   small?: boolean;
   title?: string;
   type?: TMessageTypes;
+  noIcon?: boolean;
   children: ReactNode;
 }
 
@@ -58,6 +59,7 @@ export const Message = ({
   small,
   title,
   type = 'info',
+  noIcon = false,
   children,
 }: MessageProps) => {
   if (hidden) {
@@ -65,7 +67,7 @@ export const Message = ({
   }
   return (
     <div className={`${styles[type]} ${small ? styles.small : ''}`}>
-      <MessageIcon type={type} />
+      {!noIcon && <MessageIcon type={type} />}
       <div className={styles.content}>
         {title && (
           <h2 className={`subTitle ${styles.title}`}>{title}</h2>

--- a/frontends/web/src/components/message/message.tsx
+++ b/frontends/web/src/components/message/message.tsx
@@ -17,8 +17,8 @@
 
 import { ReactNode } from 'react';
 import { StatusInfo, StatusSuccess, StatusWarning, StatusError } from '@/components/icon';
-import styles from './message.module.css';
 import { TMessageTypes } from '@/utils/types';
+import styles from './message.module.css';
 
 type TMessageIconProps = { type: TMessageTypes };
 

--- a/frontends/web/src/components/status/status.module.css
+++ b/frontends/web/src/components/status/status.module.css
@@ -1,81 +1,27 @@
+.content {
+    margin-right: var(--space-half);
+}
+
 .container {
-    margin: 0 auto;
-    position: relative;
-    padding: calc(var(--space-default) * 1.5);
+    align-items: flex-start;
+    display: flex;
     width: 100%;
 }
 .container.withCloseBtn {
     padding-right: 60px;
 }
 
-:global(.padded) .container {
-    max-width: var(--content-width);
-}
-
-.status {
-    font-size: var(--size-subheader);
-    max-width: 800px;
-    text-align: left;
-}
-
-.success {
-    background-color: var(--color-success);
-}
-
-.warning {
-    background-color: var(--color-warning);
-}
-
-.info {
-    background-color: var(--color-info);
-}
-
-.success,
-.warning,
-.info,
-.success label, /* also force label elements to use color white */
-.warning label,
-.info label {
-    color: var(--color-alt);
-}
-
-.close-success {
-    background: var(--color-darkgreen);
-}
-
-.close-warning {
-    background: var(--color-swissred);
-}
-
-.close-info {
-    background: var(--color-darkblue);
-}
-
-.close {
+.closeButton {
+    background-color: transparent;
     border: none;
-    line-height: .5;
-    padding: var(--space-half);
-    position: absolute;
-    top: 0;
-    right: 0;
+    margin-left: auto;
 }
 
-.close svg {
-    width: 18px;
-    height: 18px;
+.closeButton img {
+    width: 16px;
+    height: 16px;
 }
 
-.withCloseBtn .status::before {
-    content: "";
-    float: right;
-    height: 18px;
-    padding-bottom: 2px;
-    padding-left: var(--space-default);
-    width: 18px;
-}
-
-@media (max-width: 1199px) {
-    .container {
-        padding: calc(var(--space-half) * 1.5);
-    }
+.messageWrapper {
+    margin-bottom: calc(var(--spacing-default) * -1);
 }

--- a/frontends/web/src/components/status/status.module.css
+++ b/frontends/web/src/components/status/status.module.css
@@ -1,5 +1,5 @@
 .content {
-    margin-right: var(--space-half);
+    margin-right: var(--space-eight);
 }
 
 .container {
@@ -20,8 +20,4 @@
 .closeButton img {
     width: 16px;
     height: 16px;
-}
-
-.messageWrapper {
-    margin-bottom: calc(var(--spacing-default) * -1);
 }

--- a/frontends/web/src/components/status/status.tsx
+++ b/frontends/web/src/components/status/status.tsx
@@ -17,30 +17,34 @@
 
 import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { getConfig, setConfig } from '@/utils/config';
-import { CloseXWhite } from '@/components/icon';
+import { CloseXDark, CloseXWhite } from '@/components/icon';
+import { useDarkmode } from '@/hooks/darkmode';
+import { Message } from '@/components/message/message';
 import style from './status.module.css';
+import { TMessageTypes } from '@/utils/types';
 
-export type statusType = 'success' | 'warning' | 'info';
 
 type TPRops = {
-    hidden?: boolean;
-    type?: statusType;
-    // used as keyName in the config if dismissing the status should be persisted, so it is not
-    // shown again. Use an empty string if it should be dismissible without storing it in the
-    // config, so the status will be shown again the next time.
-    dismissible?: string;
-    className?: string;
-    children: ReactNode;
+  hidden?: boolean;
+  type?: TMessageTypes;
+  // used as keyName in the config if dismissing the status should be persisted, so it is not
+  // shown again. Use an empty string if it should be dismissible without storing it in the
+  // config, so the status will be shown again the next time.
+  dismissible?: string;
+  className?: string;
+  children: ReactNode;
 }
 
 export const Status = ({
   hidden,
   type = 'warning',
   dismissible,
-  className,
+  className = '',
   children,
 }: TPRops) => {
   const [show, setShow] = useState(dismissible ? false : true);
+
+  const { isDarkMode } = useDarkmode();
 
   const checkConfig = useCallback(async () => {
     if (dismissible) {
@@ -70,16 +74,21 @@ export const Status = ({
   }
 
   return (
-    <div className={[style.container, style[type], className ? className : '', dismissible ? style.withCloseBtn : ''].join(' ')}>
-      <div className={style.status}>
-        {children}
-        <button
-          hidden={!dismissible}
-          className={`${style.close} ${style[`close-${type}`]}`}
-          onClick={dismiss}>
-          <CloseXWhite />
-        </button>
-      </div>
+    <div className={`${style.messageWrapper} ${className}`}>
+      <Message type={type}>
+        <div className={style.container}>
+          <div className={style.content}>
+            {children}
+          </div>
+          <button
+            hidden={!dismissible}
+            className={style.closeButton}
+            onClick={dismiss}
+          >
+            {isDarkMode ? <CloseXWhite /> : <CloseXDark />}
+          </button>
+        </div>
+      </Message>
     </div>
   );
 };

--- a/frontends/web/src/components/status/status.tsx
+++ b/frontends/web/src/components/status/status.tsx
@@ -20,13 +20,13 @@ import { getConfig, setConfig } from '@/utils/config';
 import { CloseXDark, CloseXWhite } from '@/components/icon';
 import { useDarkmode } from '@/hooks/darkmode';
 import { Message } from '@/components/message/message';
-import style from './status.module.css';
 import { TMessageTypes } from '@/utils/types';
+import style from './status.module.css';
 
-
-type TPRops = {
+type TProps = {
   hidden?: boolean;
   type?: TMessageTypes;
+  noIcon?: boolean;
   // used as keyName in the config if dismissing the status should be persisted, so it is not
   // shown again. Use an empty string if it should be dismissible without storing it in the
   // config, so the status will be shown again the next time.
@@ -38,10 +38,11 @@ type TPRops = {
 export const Status = ({
   hidden,
   type = 'warning',
+  noIcon = false,
   dismissible,
   className = '',
   children,
-}: TPRops) => {
+}: TProps) => {
   const [show, setShow] = useState(dismissible ? false : true);
 
   const { isDarkMode } = useDarkmode();
@@ -75,7 +76,7 @@ export const Status = ({
 
   return (
     <div className={`${style.messageWrapper} ${className}`}>
-      <Message type={type}>
+      <Message noIcon={noIcon} type={type}>
         <div className={style.container}>
           <div className={style.content}>
             {children}
@@ -92,3 +93,4 @@ export const Status = ({
     </div>
   );
 };
+

--- a/frontends/web/src/components/status/status.tsx
+++ b/frontends/web/src/components/status/status.tsx
@@ -75,7 +75,7 @@ export const Status = ({
   }
 
   return (
-    <div className={`${style.messageWrapper} ${className}`}>
+    <div className={className}>
       <Message noIcon={noIcon} type={type}>
         <div className={style.container}>
           <div className={style.content}>

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -47,6 +47,7 @@ import { A } from '@/components/anchor/anchor';
 import { getConfig, setConfig } from '@/utils/config';
 import { i18n } from '@/i18n/i18n';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
+import { GlobalBanners } from '@/components/globalbanners/globalbanners';
 import style from './account.module.css';
 
 type Props = {
@@ -278,6 +279,7 @@ export const Account = ({
     <div className="contentWithGuide">
       <div className="container">
         <ContentWrapper>
+          <GlobalBanners />
           <Status hidden={!hasCard} type="warning">
             {t('warning.sdcard')}
           </Status>

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -35,7 +35,6 @@ import { Status } from '@/components/status/status';
 import { Transactions } from '@/components/transactions/transactions';
 import { useLoad } from '@/hooks/api';
 import { HideAmountsButton } from '@/components/hideamountsbutton/hideamountsbutton';
-import style from './account.module.css';
 import { ActionButtons } from './actionButtons';
 import { Insured } from './components/insuredtag';
 import { AccountGuide } from './guide';
@@ -47,6 +46,8 @@ import { Dialog } from '@/components/dialog/dialog';
 import { A } from '@/components/anchor/anchor';
 import { getConfig, setConfig } from '@/utils/config';
 import { i18n } from '@/i18n/i18n';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
+import style from './account.module.css';
 
 type Props = {
   accounts: accountApi.IAccount[];
@@ -276,18 +277,20 @@ export const Account = ({
   return (
     <div className="contentWithGuide">
       <div className="container">
-        <Status hidden={!hasCard} type="warning">
-          {t('warning.sdcard')}
-        </Status>
+        <ContentWrapper>
+          <Status hidden={!hasCard} type="warning">
+            {t('warning.sdcard')}
+          </Status>
+        </ContentWrapper>
         <Dialog open={insured && uncoveredFunds.length !== 0} medium title={t('account.warning')} onClose={() => setUncoveredFunds([])}>
           <MultilineMarkup tagName="p" markup={t('account.uncoveredFunds', {
             name: account.name,
             uncovered: uncoveredFunds,
-          })}/>
+          })} />
           <A href={getBitsuranceGuideLink()}>{t('account.uncoveredFundsLink')}</A>
         </Dialog>
         <Header
-          title={<h2><span>{account.name}</span>{insured && (<Insured/>)}</h2>}>
+          title={<h2><span>{account.name}</span>{insured && (<Insured />)}</h2>}>
           <HideAmountsButton />
           <Link to={`/account/${code}/info`} title={t('accountInfo.title')} className="flex flex-row flex-items-center m-left-half">
             <Info className={style.accountIcon} />
@@ -326,7 +329,7 @@ export const Account = ({
               handleExport={exportAccount}
               explorerURL={account.blockExplorerTxPrefix}
               transactions={transactions}
-            /> }
+            />}
           </div>
         </div>
       </div>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -44,6 +44,7 @@ import { FiatInput } from './components/inputs/fiat-input';
 import { NoteInput } from './components/inputs/note-input';
 import { TSelectedUTXOs, UTXOs } from './utxos';
 import { TProposalError, txProposalErrorHandling } from './services';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import style from './send.module.css';
 
 interface SendProps {
@@ -528,9 +529,11 @@ class Send extends Component<Props, State> {
       <GuideWrapper>
         <GuidedContent>
           <Main>
-            <Status type="warning" hidden={paired !== false}>
-              {t('warning.sendPairing')}
-            </Status>
+            <ContentWrapper>
+              <Status type="warning" hidden={paired !== false}>
+                {t('warning.sendPairing')}
+              </Status>
+            </ContentWrapper>
             <Header
               title={<h2>{t('send.title', { accountName: account.coinName })}</h2>}
             >

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -36,14 +36,15 @@ import { HideAmountsButton } from '@/components/hideamountsbutton/hideamountsbut
 import { AppContext } from '@/contexts/AppContext';
 import { getAccountsByKeystore, isAmbiguiousName } from '@/routes/account/utils';
 import { RatesContext } from '@/contexts/RatesContext';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 
 type TProps = {
-    accounts: accountApi.IAccount[];
-    devices: TDevices;
+  accounts: accountApi.IAccount[];
+  devices: TDevices;
 };
 
 export type Balances = {
-    [code: string]: accountApi.IBalance;
+  [code: string]: accountApi.IBalance;
 };
 
 export const AccountsSummary = ({
@@ -197,9 +198,13 @@ export const AccountsSummary = ({
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <Status hidden={!hasCard} type="warning">
-            {t('warning.sdcard')}
-          </Status>
+          <ContentWrapper>
+            <Status hidden={!hasCard} type="warning">
+              {t('warning.sdcard')}
+            </Status>
+          </ContentWrapper>
+
+
           <Header title={<h2>{t('accountSummary.title')}</h2>}>
             <HideAmountsButton />
           </Header>
@@ -226,11 +231,11 @@ export const AccountsSummary = ({
                   keystoreName={keystore.name}
                   key={keystore.rootFingerprint}
                   accounts={accounts}
-                  totalBalancePerCoin={ balancePerCoin ? balancePerCoin[keystore.rootFingerprint] : undefined}
-                  totalBalance={ accountsTotalBalance ? accountsTotalBalance[keystore.rootFingerprint] : undefined}
+                  totalBalancePerCoin={balancePerCoin ? balancePerCoin[keystore.rootFingerprint] : undefined}
+                  totalBalance={accountsTotalBalance ? accountsTotalBalance[keystore.rootFingerprint] : undefined}
                   balances={balances}
                 />
-              )) }
+              ))}
           </View>
         </Main>
       </GuidedContent>

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -37,6 +37,7 @@ import { AppContext } from '@/contexts/AppContext';
 import { getAccountsByKeystore, isAmbiguiousName } from '@/routes/account/utils';
 import { RatesContext } from '@/contexts/RatesContext';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
+import { GlobalBanners } from '@/components/globalbanners/globalbanners';
 
 type TProps = {
   accounts: accountApi.IAccount[];
@@ -194,17 +195,17 @@ export const AccountsSummary = ({
     getAccountsBalance();
     getCoinsTotalBalance();
   }, [onStatusChanged, getAccountsBalance, getCoinsTotalBalance, accounts]);
+
   return (
     <GuideWrapper>
       <GuidedContent>
         <Main>
           <ContentWrapper>
+            <GlobalBanners />
             <Status hidden={!hasCard} type="warning">
               {t('warning.sdcard')}
             </Status>
           </ContentWrapper>
-
-
           <Header title={<h2>{t('accountSummary.title')}</h2>}>
             <HideAmountsButton />
           </Header>

--- a/frontends/web/src/routes/account/walletconnect/dashboard.tsx
+++ b/frontends/web/src/routes/account/walletconnect/dashboard.tsx
@@ -29,6 +29,7 @@ import { WCSessionCard } from './components/session-card/session-card';
 import { Button } from '@/components/forms';
 import { Status } from '@/components/status/status';
 import { WCGuide } from './guide';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import styles from './dashboard.module.css';
 
 type TProps = {
@@ -85,12 +86,14 @@ export const DashboardWalletConnect = ({ code, accounts }: TProps) => {
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <Status
-            type="info"
-            dismissible="walletConnectDisclaimerDismissed"
-          >
-            {t('walletConnect.dashboard.disclaimer')}
-          </Status>
+          <ContentWrapper>
+            <Status
+              type="info"
+              dismissible="walletConnectDisclaimerDismissed"
+            >
+              {t('walletConnect.dashboard.disclaimer')}
+            </Status>
+          </ContentWrapper>
           <Header
             title={<h2>{t('walletConnect.walletConnect')}</h2>}
           />
@@ -107,22 +110,22 @@ export const DashboardWalletConnect = ({ code, accounts }: TProps) => {
               </div>
               <hr className={styles.separator} />
               {hasSession &&
-            <div className={styles.sessionCardsContainer}>
-              <p className={styles.allSessionsHeading}>{t('walletConnect.dashboard.allSessions')}</p>
-              {sessions.map(session => {
-                return (
-                  <WCSessionCard
-                    key={session.topic}
-                    receiveAddress={session.namespaces['eip155'].accounts[0] ? getAddressFromEIPString(session.namespaces['eip155'].accounts[0]) : ''}
-                    metadata={session.peer.metadata}
-                    onDisconnect={() => handleDisconnectSession(session.topic)}
-                  />
-                );
-              })}
-            </div>
+                <div className={styles.sessionCardsContainer}>
+                  <p className={styles.allSessionsHeading}>{t('walletConnect.dashboard.allSessions')}</p>
+                  {sessions.map(session => {
+                    return (
+                      <WCSessionCard
+                        key={session.topic}
+                        receiveAddress={session.namespaces['eip155'].accounts[0] ? getAddressFromEIPString(session.namespaces['eip155'].accounts[0]) : ''}
+                        metadata={session.peer.metadata}
+                        onDisconnect={() => handleDisconnectSession(session.topic)}
+                      />
+                    );
+                  })}
+                </div>
               }
               {!hasSession &&
-            <p className={styles.noConnectedSessions}>{t('walletConnect.dashboard.noConnectedSessions')}</p>
+                <p className={styles.noConnectedSessions}>{t('walletConnect.dashboard.noConnectedSessions')}</p>
               }
             </ViewContent>
           </View>

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -211,7 +211,7 @@ const EnableInfo = ({ handleAbort, setPassphrase }: TInfoProps) => {
             <SimpleMarkup key="info-3" tagName="li" markup={t('passphrase.summary.understandList.2')} />
             <SimpleMarkup key="info-4" tagName="li" markup={t('passphrase.summary.understandList.3')} />
           </ul>
-          <Status type={understood ? 'success' : 'warning'}>
+          <Status noIcon type={understood ? 'success' : 'warning'}>
             <Checkbox
               onChange={e => setUnderstood(e.target.checked)}
               id="understood"

--- a/frontends/web/src/routes/device/bitbox02/setup/password.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/password.tsx
@@ -37,7 +37,7 @@ export const SetPassword = ({ errorText }: Props) => {
       width="600px">
       <ViewHeader title={t('bitbox02Wizard.stepPassword.title')}>
         {errorText && (
-          <Status type="warning">
+          <Status className="margin-bottom-default" type="warning">
             <span>{errorText}</span>
           </Status>
         )}

--- a/frontends/web/src/routes/settings/about.tsx
+++ b/frontends/web/src/routes/settings/about.tsx
@@ -23,6 +23,8 @@ import { MobileHeader } from './components/mobile-header';
 import { Guide } from '@/components/guide/guide';
 import { Entry } from '@/components/guide/entry';
 import { TPagePropsWithSettingsTabs } from './types';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
+import { GlobalBanners } from '@/components/globalbanners/globalbanners';
 
 export const About = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
@@ -30,6 +32,9 @@ export const About = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) =>
     <GuideWrapper>
       <GuidedContent>
         <Main>
+          <ContentWrapper>
+            <GlobalBanners />
+          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -31,6 +31,8 @@ import { MobileHeader } from './components/mobile-header';
 import { Guide } from '@/components/guide/guide';
 import { Entry } from '@/components/guide/entry';
 import { EnableAuthSetting } from './components/advanced-settings/enable-auth-setting';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
+import { GlobalBanners } from '@/components/globalbanners/globalbanners';
 
 export type TProxyConfig = {
   proxyAddress: string;
@@ -70,6 +72,9 @@ export const AdvancedSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSetti
     <GuideWrapper>
       <GuidedContent>
         <Main>
+          <ContentWrapper>
+            <GlobalBanners />
+          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/bb02-settings.tsx
+++ b/frontends/web/src/routes/settings/bb02-settings.tsx
@@ -37,8 +37,9 @@ import { RootFingerprintSetting } from './components/device-settings/root-finger
 import { Bip85Setting } from './components/device-settings/bip85-setting';
 import { ManageDeviceGuide } from '@/routes/device/bitbox02/settings-guide';
 import { MobileHeader } from './components/mobile-header';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
+import { GlobalBanners } from '@/components/globalbanners/globalbanners';
 import styles from './bb02-settings.module.css';
-
 
 type TProps = {
   deviceID: string;
@@ -60,6 +61,9 @@ const BB02Settings = ({ deviceID, deviceIDs, hasAccounts }: TWrapperProps) => {
     <Main>
       <GuideWrapper>
         <GuidedContent>
+          <ContentWrapper>
+            <GlobalBanners />
+          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/general.tsx
+++ b/frontends/web/src/routes/settings/general.tsx
@@ -31,6 +31,8 @@ import { Guide } from '@/components/guide/guide';
 import { Entry } from '@/components/guide/entry';
 import { SubTitle } from '@/components/title';
 import { TPagePropsWithSettingsTabs } from './types';
+import { GlobalBanners } from '@/components/globalbanners/globalbanners';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 
 export const General = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
@@ -38,6 +40,9 @@ export const General = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) 
     <GuideWrapper>
       <GuidedContent>
         <Main>
+          <ContentWrapper>
+            <GlobalBanners />
+          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -34,6 +34,8 @@ import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { Badge } from '@/components/badge/badge';
 import { AccountGuide } from './manage-account-guide';
 import { WatchonlySetting } from './components/manage-accounts/watchonlySetting';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
+import { GlobalBanners } from '@/components/globalbanners/globalbanners';
 import style from './manage-accounts.module.css';
 
 interface ManageAccountsProps {
@@ -220,6 +222,9 @@ class ManageAccounts extends Component<Props, State> {
       <GuideWrapper>
         <GuidedContent>
           <Main>
+            <ContentWrapper>
+              <GlobalBanners />
+            </ContentWrapper>
             <Header
               hideSidebarToggler
               title={

--- a/frontends/web/src/routes/settings/mobile-settings.tsx
+++ b/frontends/web/src/routes/settings/mobile-settings.tsx
@@ -15,13 +15,15 @@
  */
 
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { View, ViewContent } from '@/components/view/view';
 import { Header, Main } from '@/components/layout';
 import { useMediaQuery } from '@/hooks/mediaquery';
 import { Tabs } from './components/tabs';
-import { useTranslation } from 'react-i18next';
 import { TPagePropsWithSettingsTabs } from './types';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
+import { GlobalBanners } from '@/components/globalbanners/globalbanners';
 
 /**
  * The "index" page of the settings
@@ -43,6 +45,9 @@ export const MobileSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSetting
   }, [isMobile, navigate]);
   return (
     <Main>
+      <ContentWrapper>
+        <GlobalBanners />
+      </ContentWrapper>
       <Header title={<h2>{t('settings.title')}</h2>} />
       <View fullscreen={false}>
         <ViewContent>

--- a/frontends/web/src/style/layout.css
+++ b/frontends/web/src/style/layout.css
@@ -65,19 +65,6 @@
     min-height: -webkit-fill-available;
 }
 
-.appContent {
-    height: 100vh;
-    /* mobile viewport bug fix */
-    max-height: -webkit-fill-available;
-}
-
-@media (max-width: 900px) {
-    .appContent {
-        position: absolute;
-        width: 100%;
-    }
-}
-
 @media (max-width: 768px) {
     .spaced > *:not(:last-child) {
         margin-right: var(--space-quarter);

--- a/frontends/web/src/utils/types.ts
+++ b/frontends/web/src/utils/types.ts
@@ -28,3 +28,4 @@ export type KeysOf<T> = Array<keyof T>;
 export type ObjectButNotFunction = object & { prototype?: never; };
 
 export type TDeviceNameError = undefined | 'tooShort' | 'tooLong' | 'invalidChars'
+export type TMessageTypes = 'success' | 'info' | 'warning' | 'error';


### PR DESCRIPTION
to improve consistency & aesthetics, we'd like to use our revamped Message component for our Status component.

Please note that our Banner component uses Status. Therefore, with this change, Banner will also use Message component.

<img width="1483" alt="cmp" src="https://github.com/user-attachments/assets/162aa2b7-e454-4aa4-942e-59b71361d59b">
<img width="1483" alt="cma" src="https://github.com/user-attachments/assets/1631904f-e5a7-434d-8224-1bc2eef492e3">
<img width="465" alt="px7" src="https://github.com/user-attachments/assets/549e9cb5-b506-474d-9889-82d7bd5f4c63">
<img width="1483" alt="huj" src="https://github.com/user-attachments/assets/f669c550-9a73-4706-a1de-6c6fddcb3765">
