### PR TITLE
frontend/dialog: remove disableEscape param, use onClose instead

### DIFF
--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -28,7 +28,6 @@ type TProps = {
     large?: boolean;
     slim?: boolean;
     centered?: boolean;
-    disableEscape?: boolean;
     onClose?: (e?: Event) => void;
     children: React.ReactNode;
     open: boolean;
@@ -41,7 +40,6 @@ export const Dialog = ({
   large,
   slim,
   centered,
-  disableEscape,
   onClose,
   children,
   open,
@@ -169,10 +167,10 @@ export const Dialog = ({
     if (!renderDialog) {
       return;
     }
-    if (!disableEscape) {
+    if (onClose !== undefined) {
       deactivate(true);
     }
-  }, [renderDialog, disableEscape, deactivate]));
+  }, [renderDialog, onClose, deactivate]));
 
   useEffect(() => {
     if (open) {

--- a/frontends/web/src/routes/account/receive/receive-bb01.tsx
+++ b/frontends/web/src/routes/account/receive/receive-bb01.tsx
@@ -252,7 +252,6 @@ export const Receive = ({
                   <Dialog
                     open={((!!account) && forceVerification && verifying)}
                     title={verifyLabel}
-                    disableEscape={true}
                     medium centered>
                     <div className="text-center">
                       {account && <>

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -291,9 +291,8 @@ export const Receive = ({
                   <Dialog
                     open={!!(account && verifying)}
                     title={t('receive.verifyBitBox02')}
-                    // disable escape for secure outputs like the BitBox02, where the dialog is
+                    // disable exit/escape for secure outputs like the BitBox02, where the dialog is
                     // dimissed by tapping the device
-                    disableEscape={verifying === 'secure'}
                     onClose={verifying === 'insecure' ? () => {
                       setVerifying(false);
                     } : undefined}

--- a/frontends/web/src/routes/buy/pocket.tsx
+++ b/frontends/web/src/routes/buy/pocket.tsx
@@ -245,7 +245,6 @@ export const Pocket = ({ code }: TProps) => {
           <Dialog
             open={verifying}
             title={t('receive.verifyBitBox02')}
-            disableEscape={true}
             medium centered>
             <div className="text-center">{t('buy.pocket.verifyBitBox02')}</div>
           </Dialog>


### PR DESCRIPTION
If onClose is undefined, there is on close button, and ESC should then also not work, and vice versa.

This also fixes some dialogs that could be escaped via ESC that shouldn't have, like the BB02 backup check dialog.