### PR TITLE
refactor: trivy scan to table format

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -8,22 +8,16 @@ on:
       - master
 jobs:
   trivy:
-    permissions:
-      # for github/codeql-action/upload-sarif to upload SARIF results
-      security-events: write
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Run Trivy vulnerability scanner in repo mode
+      - name: Run Trivy
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          scan-type: 'fs'
+          format: 'table'
           ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-results.sarif'
+          scan-type: 'fs'
+          exit-code: '1'
+          severity: 'MEDIUM,HIGH,CRITICAL'
+


### PR DESCRIPTION
I've refactor the trivy scan from using the GitHub Security tab to table format. Now within the `Run Trivy` step a table is shown with the vulnerabilities. Also `exit-code: '1'` is triggered then. No more interaction with the GitHub Security tab.