### PR TITLE
frontend: replace history entry when redirecting

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -100,7 +100,8 @@ export const App = () => {
     }
     // if on index page and have at least 1 account, route to /account-summary
     if (isIndex && accounts.length) {
-      navigate('/account-summary');
+      // replace current history entry so that the user cannot go back to "index"
+      navigate('/account-summary', { replace: true });
       return;
     }
     // if on the /buy/ view and there are no accounts view route to /

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -83,8 +83,13 @@ export const App = () => {
       return;
     }
     // if no devices are registered on specified views route to /
-    if (Object.keys(devices).length === 0 &&
-        currentURL.startsWith('/settings/device-settings/')) {
+    if (
+      Object.keys(devices).length === 0
+      && (
+        currentURL.startsWith('/settings/device-settings/')
+        || currentURL.startsWith('/manage-backups/')
+      )
+    ) {
       navigate('/');
       return;
     }

--- a/frontends/web/src/routes/bitsurance/account.tsx
+++ b/frontends/web/src/routes/bitsurance/account.tsx
@@ -70,7 +70,8 @@ export const BitsuranceAccount = ({ code, accounts }: TProps) => {
         if (!connectResult.success) {
           return;
         }
-        navigate(`/bitsurance/widget/${btcAccounts[0].code}`);
+        // replace current history item when redirecting so that the user can go back
+        navigate(`/bitsurance/widget/${btcAccounts[0].code}`, { replace: true });
       });
     }
   }, [btcAccounts, navigate]);

--- a/frontends/web/src/routes/bitsurance/bitsurance.tsx
+++ b/frontends/web/src/routes/bitsurance/bitsurance.tsx
@@ -47,7 +47,8 @@ export const Bitsurance = ({ accounts }: TProps) => {
 
   useEffect(() => {
     if (accounts.some(({ bitsuranceStatus }) => bitsuranceStatus)) {
-      navigate('/bitsurance/dashboard');
+      // replace current history item when redirecting so that the user can go back
+      navigate('/bitsurance/dashboard', { replace: true });
     } else {
       setRedirecting(false);
     }

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -58,7 +58,8 @@ export const BuyInfo = ({ code, accounts }: TProps) => {
       const accountCode = supportedAccounts[0].code;
       connectKeystore(accountCode).then(connected => {
         if (connected) {
-          navigate(`/buy/exchange/${accountCode}`);
+          // replace current history item when redirecting so that the user can go back
+          navigate(`/buy/exchange/${accountCode}`, { replace: true });
         }
       });
     }

--- a/frontends/web/src/routes/device/manage-backups/manage-backups.tsx
+++ b/frontends/web/src/routes/device/manage-backups/manage-backups.tsx
@@ -16,7 +16,6 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 import { TDevices } from '@/api/devices';
 import { BackButton } from '@/components/backbutton/backbutton';
 import { Guide } from '@/components/guide/guide';
@@ -36,10 +35,8 @@ export const ManageBackups = ({
   devices,
 }: TProps) => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
 
   if (!deviceID || !devices[deviceID]) {
-    navigate('/');
     return null;
   }
 

--- a/frontends/web/src/routes/settings/mobile-settings.tsx
+++ b/frontends/web/src/routes/settings/mobile-settings.tsx
@@ -37,7 +37,8 @@ export const MobileSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSetting
   const { t } = useTranslation();
   useEffect(() => {
     if (!isMobile) {
-      navigate('/settings/general');
+      // replace current history item when redirecting so that the user can go back
+      navigate('/settings/general', { replace: true });
     }
   }, [isMobile, navigate]);
   return (


### PR DESCRIPTION
When automatic navigation occurs (redirects) the history entry should be replaced so that the user can go back.

This fixes issues when the user tries to go back but lands on the same page again due to previous step redirecting.

This also removes some routing logic from manage-backups which can be handled centrally by app.tsx routing.
