### PR TITLE
backend/devices: implement the has-payment-request endpoint

### DIFF
--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -276,3 +276,8 @@ func (keystore *keystore) SignETHWalletConnectTransaction(chainID uint64, tx *ty
 func (keystore *keystore) SupportsEIP1559() bool {
 	return false
 }
+
+// SupportsPaymentRequests implements keystore.Keystore.
+func (keystore *keystore) SupportsPaymentRequests() error {
+	return keystorePkg.ErrUnsupportedFeature
+}

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -649,3 +649,11 @@ func (keystore *keystore) SignETHWalletConnectTransaction(chainId uint64, tx *et
 func (keystore *keystore) SupportsEIP1559() bool {
 	return keystore.device.Version().AtLeast(semver.NewSemVer(9, 16, 0))
 }
+
+// SupportsPaymentRequests implements keystore.Keystore.
+func (keystore *keystore) SupportsPaymentRequests() error {
+	if keystore.device.Version().AtLeast(semver.NewSemVer(9, 19, 0)) {
+		return nil
+	}
+	return keystorePkg.ErrFirmwareUpgradeRequired
+}

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -35,6 +35,22 @@ const (
 	TypeSoftware Type = "software"
 )
 
+// KeystoreError represents errors related to the keystore.
+//
+//revive:disable-line:exported
+type KeystoreError string //revive:disable-line:exported
+
+func (err KeystoreError) Error() string {
+	return string(err)
+}
+
+var (
+	// ErrFirmwareUpgradeRequired is returned when the keystore device needs a FW upgrade.
+	ErrFirmwareUpgradeRequired = KeystoreError("firmwareUpgradeRequired")
+	// ErrUnsupportedFeature is returned when a certain feature is unsupported by the keystore.
+	ErrUnsupportedFeature = KeystoreError("unsupportedFeature")
+)
+
 // ErrSigningAborted is used when the user aborts a signing in process (e.g. abort on HW wallet).
 var ErrSigningAborted = errors.New("signing aborted by user")
 
@@ -119,4 +135,7 @@ type Keystore interface {
 
 	// SupportsEIP1559 returns whether the keystore supports EIP1559 type 2 transactions for Ethereum
 	SupportsEIP1559() bool
+
+	// SupportsPaymentRequests returns nil if the device supports silent payments, or an error indicating why it is not supported.
+	SupportsPaymentRequests() error
 }

--- a/backend/keystore/mocks/keystore.go
+++ b/backend/keystore/mocks/keystore.go
@@ -4,10 +4,10 @@
 package mocks
 
 import (
-	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/ethereum/go-ethereum/core/types"
 	"sync"
 )
@@ -66,6 +66,9 @@ var _ keystore.Keystore = &KeystoreMock{}
 //			},
 //			SupportsMultipleAccountsFunc: func() bool {
 //				panic("mock out the SupportsMultipleAccounts method")
+//			},
+//			SupportsPaymentRequestsFunc: func() error {
+//				panic("mock out the SupportsPaymentRequests method")
 //			},
 //			SupportsUnifiedAccountsFunc: func() bool {
 //				panic("mock out the SupportsUnifiedAccounts method")
@@ -130,6 +133,9 @@ type KeystoreMock struct {
 
 	// SupportsMultipleAccountsFunc mocks the SupportsMultipleAccounts method.
 	SupportsMultipleAccountsFunc func() bool
+
+	// SupportsPaymentRequestsFunc mocks the SupportsPaymentRequests method.
+	SupportsPaymentRequestsFunc func() error
 
 	// SupportsUnifiedAccountsFunc mocks the SupportsUnifiedAccounts method.
 	SupportsUnifiedAccountsFunc func() bool
@@ -228,6 +234,9 @@ type KeystoreMock struct {
 		// SupportsMultipleAccounts holds details about calls to the SupportsMultipleAccounts method.
 		SupportsMultipleAccounts []struct {
 		}
+		// SupportsPaymentRequests holds details about calls to the SupportsPaymentRequests method.
+		SupportsPaymentRequests []struct {
+		}
 		// SupportsUnifiedAccounts holds details about calls to the SupportsUnifiedAccounts method.
 		SupportsUnifiedAccounts []struct {
 		}
@@ -264,6 +273,7 @@ type KeystoreMock struct {
 	lockSupportsCoin                    sync.RWMutex
 	lockSupportsEIP1559                 sync.RWMutex
 	lockSupportsMultipleAccounts        sync.RWMutex
+	lockSupportsPaymentRequests         sync.RWMutex
 	lockSupportsUnifiedAccounts         sync.RWMutex
 	lockType                            sync.RWMutex
 	lockVerifyAddress                   sync.RWMutex
@@ -758,6 +768,33 @@ func (mock *KeystoreMock) SupportsMultipleAccountsCalls() []struct {
 	mock.lockSupportsMultipleAccounts.RLock()
 	calls = mock.calls.SupportsMultipleAccounts
 	mock.lockSupportsMultipleAccounts.RUnlock()
+	return calls
+}
+
+// SupportsPaymentRequests calls SupportsPaymentRequestsFunc.
+func (mock *KeystoreMock) SupportsPaymentRequests() error {
+	if mock.SupportsPaymentRequestsFunc == nil {
+		panic("KeystoreMock.SupportsPaymentRequestsFunc: method is nil but Keystore.SupportsPaymentRequests was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockSupportsPaymentRequests.Lock()
+	mock.calls.SupportsPaymentRequests = append(mock.calls.SupportsPaymentRequests, callInfo)
+	mock.lockSupportsPaymentRequests.Unlock()
+	return mock.SupportsPaymentRequestsFunc()
+}
+
+// SupportsPaymentRequestsCalls gets all the calls that were made to SupportsPaymentRequests.
+// Check the length with:
+//
+//	len(mockedKeystore.SupportsPaymentRequestsCalls())
+func (mock *KeystoreMock) SupportsPaymentRequestsCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockSupportsPaymentRequests.RLock()
+	calls = mock.calls.SupportsPaymentRequests
+	mock.lockSupportsPaymentRequests.RUnlock()
 	return calls
 }
 

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -290,3 +290,8 @@ func (keystore *Keystore) SignETHWalletConnectTransaction(chainID uint64, tx *et
 func (keystore *Keystore) SupportsEIP1559() bool {
 	return false
 }
+
+// SupportsPaymentRequests implements keystore.Keystore.
+func (keystore *Keystore) SupportsPaymentRequests() error {
+	return keystorePkg.ErrUnsupportedFeature
+}

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -397,6 +397,16 @@ export const hasSecureOutput = (code: AccountCode) => {
   };
 };
 
+type THasPaymentRequest = {
+  success: boolean;
+  errorMessage?: string;
+  errorCode?: 'firmwareUpgradeRequired' | 'unsupportedFeature';
+};
+
+export const hasPaymentRequest = (code: AccountCode): Promise<THasPaymentRequest> => {
+  return apiGet(`account/${code}/has-payment-request`);
+};
+
 export type TAddAccount = {
   success: boolean;
   accountCode?: string;

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -566,7 +566,9 @@
   },
   "device": {
     "appUpradeRequired": "Your BitBox is not compatible with this desktop application. Please download and install the latest version.",
-    "keystoreConnected": "Connected wallet"
+    "firmwareUpgradeRequired": "A firmware update is required to make use of this feature.",
+    "keystoreConnected": "Connected wallet",
+    "unsupportedFeature": "This feature is not available on this device."
   },
   "deviceLock": {
     "button": "Enable two factor authorization (2FA)",
@@ -712,7 +714,6 @@
     "buySell": {
       "coinNotSupported": "No {{action}} options available for this coin type.",
       "regionNotSupported": "No {{action}} options available for this region.",
-      "updateFirmware": "Update firmware to sell",
       "updateNow": "Update now"
     }
   },


### PR DESCRIPTION
This inserts a new `SupportsPaymentRequests` method in the device interface and creates a new related endpoint to check if the connected device supports sell action in the exchange section.