### PR TITLE
frontend: add history entry navigating to add-account

### DIFF
--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -234,7 +234,7 @@ class ManageAccounts extends Component<Props, State> {
                   <Button
                     className={style.addAccountBtn}
                     primary
-                    onClick={() => route('/add-account', true)}>
+                    onClick={() => route('/add-account')}>
                     {t('addAccount.title')}
                   </Button>
                   <Grid col="1">


### PR DESCRIPTION
Navigating to add-account should add a history entry so that back goes back to manage-accounts.