### PR TITLE
backend/transaction: auto select highest fee for payment requests

### DIFF
--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -480,7 +480,7 @@ func (account *Account) Notifier() accounts.Notifier {
 // For the other coins or in case mempool.space is not available it fallbacks on Bitcoin Core.
 // The minimum relay fee is used as a last resource fallback in case also Bitcoin Core is
 // unavailable.
-func (account *Account) feeTargets() []*FeeTarget {
+func (account *Account) feeTargets() FeeTargets {
 	// for mainnet BTC we fetch mempool.space fees, as they should be more reliable.
 	var mempoolFees *accounts.MempoolSpaceFees
 	if account.coin.Code() == coin.CodeBTC {
@@ -493,16 +493,16 @@ func (account *Account) feeTargets() []*FeeTarget {
 	}
 
 	// feeTargets must be sorted by ascending priority.
-	var feeTargets []*FeeTarget
+	var feeTargets FeeTargets
 	if mempoolFees != nil {
-		feeTargets = []*FeeTarget{
+		feeTargets = FeeTargets{
 			{blocks: 12, code: accounts.FeeTargetCodeMempoolEconomy},
 			{blocks: 3, code: accounts.FeeTargetCodeMempoolHour},
 			{blocks: 2, code: accounts.FeeTargetCodeMempoolHalfHour},
 			{blocks: 1, code: accounts.FeeTargetCodeMempoolFastest},
 		}
 	} else {
-		feeTargets = []*FeeTarget{
+		feeTargets = FeeTargets{
 			{blocks: 24, code: accounts.FeeTargetCodeEconomy},
 			{blocks: 12, code: accounts.FeeTargetCodeLow},
 			{blocks: 6, code: accounts.FeeTargetCodeNormal},

--- a/backend/coins/btc/feetarget.go
+++ b/backend/coins/btc/feetarget.go
@@ -50,3 +50,21 @@ func (feeTarget *FeeTarget) FormattedFeeRate() string {
 	feePerByte = strings.TrimRight(strings.TrimRight(feePerByte, "0"), ".")
 	return feePerByte + " sat/vB"
 }
+
+// FeeTargets represents an array of FeeTarget pointers.
+type FeeTargets []*FeeTarget
+
+// highest returns the feeTarget with the highest fee.
+func (feeTargets FeeTargets) highest() *FeeTarget {
+	var highestFeeTarget *FeeTarget
+	for _, feeTarget := range feeTargets {
+		if feeTarget == nil || feeTarget.feeRatePerKb == nil {
+			continue
+		}
+
+		if highestFeeTarget == nil || *feeTarget.feeRatePerKb > *highestFeeTarget.feeRatePerKb {
+			highestFeeTarget = feeTarget
+		}
+	}
+	return highestFeeTarget
+}

--- a/backend/coins/btc/feetarget_test.go
+++ b/backend/coins/btc/feetarget_test.go
@@ -23,16 +23,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func amt(v uint64) *btcutil.Amount {
+	x := btcutil.Amount(v)
+	return &x
+}
+
 func TestFeeTarget(t *testing.T) {
 	require.Equal(t,
 		accounts.FeeTargetCodeLow,
 		(&FeeTarget{code: accounts.FeeTargetCodeLow}).Code(),
 	)
 
-	amt := func(v uint64) *btcutil.Amount {
-		x := btcutil.Amount(v)
-		return &x
-	}
 	require.Equal(t,
 		"0.123 sat/vB",
 		(&FeeTarget{feeRatePerKb: amt(123)}).FormattedFeeRate(),
@@ -53,4 +54,49 @@ func TestFeeTarget(t *testing.T) {
 		"10.001 sat/vB",
 		(&FeeTarget{feeRatePerKb: amt(10001)}).FormattedFeeRate(),
 	)
+}
+
+func TestFeeTargets(t *testing.T) {
+	// empty slice
+	var feeTargets FeeTargets
+	require.Nil(t, feeTargets.highest())
+
+	// non-empty slice, with all nil feeRates
+	feeTargets = FeeTargets{
+		{blocks: 12, code: accounts.FeeTargetCodeMempoolEconomy},
+		{blocks: 3, code: accounts.FeeTargetCodeMempoolHour},
+		{blocks: 2, code: accounts.FeeTargetCodeMempoolHalfHour},
+		{blocks: 1, code: accounts.FeeTargetCodeMempoolFastest},
+	}
+	require.Nil(t, feeTargets.highest())
+
+	// non-empty slice, with all nil feeRates
+	feeTargets = FeeTargets{
+		{blocks: 12, code: accounts.FeeTargetCodeMempoolEconomy},
+		{blocks: 3, code: accounts.FeeTargetCodeMempoolHour},
+		{blocks: 2, code: accounts.FeeTargetCodeMempoolHalfHour},
+		{blocks: 1, code: accounts.FeeTargetCodeMempoolFastest},
+	}
+	require.Nil(t, feeTargets.highest())
+
+	// non-empty slice, with some nil feeRates
+	feeTargetsSlice := []*FeeTarget{
+		{blocks: 12, code: accounts.FeeTargetCodeMempoolEconomy},
+		{blocks: 3, code: accounts.FeeTargetCodeMempoolHour, feeRatePerKb: amt(12)},
+		{blocks: 2, code: accounts.FeeTargetCodeMempoolHalfHour},
+		{blocks: 1, code: accounts.FeeTargetCodeMempoolFastest, feeRatePerKb: amt(123)},
+	}
+	feeTargets = feeTargetsSlice
+	require.Equal(t, feeTargetsSlice[3], feeTargets.highest())
+
+	// non-empty slice, with unsorted not-nil feeRates
+	feeTargetsSlice = []*FeeTarget{
+		{blocks: 3, code: accounts.FeeTargetCodeMempoolHour, feeRatePerKb: amt(12)},
+		{blocks: 12, code: accounts.FeeTargetCodeMempoolEconomy, feeRatePerKb: amt(1)},
+		{blocks: 1, code: accounts.FeeTargetCodeMempoolFastest, feeRatePerKb: amt(1234)},
+		{blocks: 2, code: accounts.FeeTargetCodeMempoolHalfHour, feeRatePerKb: amt(123)},
+	}
+	feeTargets = feeTargetsSlice
+	require.Equal(t, feeTargetsSlice[2], feeTargets.highest())
+
 }

--- a/frontends/web/src/routes/exchange/pocket.tsx
+++ b/frontends/web/src/routes/exchange/pocket.tsx
@@ -203,7 +203,8 @@ export const Pocket = ({ code, action }: TProps) => {
     const txInput: TTxInput = {
       address: message.bitcoinAddress,
       amount: parsedAmount.amount,
-      feeTarget: 'high',
+      // feeTarget will be automatically set on the highest in the BE.
+      feeTarget: 'custom',
       customFee: '',
       sendAll: 'no',
       selectedUTXOs: [],
@@ -226,8 +227,10 @@ export const Pocket = ({ code, action }: TProps) => {
     } else {
       if (result.errorCode === 'insufficientFunds') {
         alertUser(t('buy.pocket.error.' + result.errorCode));
+      } else if (result.errorCode) {
+        alertUser(t('send.error.' + result.errorCode));
       } else {
-        alertUser(t('unknownError', { errorMessage: 'Error code: ' + result.errorCode }));
+        alertUser(t('genericError'));
       }
     }
   };


### PR DESCRIPTION
There was a bug in the payment request implementation that didn't correctly support mempool.space fees and resulted in a fee error during the tx proposal on production environment.

This commit moves the fee target selection for payment requests in the BE and fixes the bug.