### PR TITLE
backend/exchanges: change exchange deals sorting

### DIFF
--- a/backend/exchanges/exchanges.go
+++ b/backend/exchanges/exchanges.go
@@ -187,14 +187,14 @@ func GetExchangeDeals(account accounts.Interface, regionCode string, action Exch
 	}
 
 	exchangeDealsLists := []*ExchangeDealsList{}
-	if moonpaySupportsCoin && userRegion.IsMoonpayEnabled {
-		deals := MoonpayDeals(action)
+	if pocketSupportsCoin && userRegion.IsPocketEnabled {
+		deals := PocketDeals()
 		if deals != nil {
 			exchangeDealsLists = append(exchangeDealsLists, deals)
 		}
 	}
-	if pocketSupportsCoin && userRegion.IsPocketEnabled {
-		deals := PocketDeals()
+	if moonpaySupportsCoin && userRegion.IsMoonpayEnabled {
+		deals := MoonpayDeals(action)
 		if deals != nil {
 			exchangeDealsLists = append(exchangeDealsLists, deals)
 		}


### PR DESCRIPTION
Pocket currently offers the best fees among the integrated exchanges, therefore it makes sense to sort the deals showing Pocket as the first option, when available.