### PR TITLE
frontend: fix guide open on app restart

### DIFF
--- a/frontends/web/src/contexts/AppContext.tsx
+++ b/frontends/web/src/contexts/AppContext.tsx
@@ -29,7 +29,6 @@ type AppContextProps = {
     chartDisplay: TChartDisplay;
     setActiveSidebar: Dispatch<SetStateAction<boolean>>;
     setGuideExists: Dispatch<SetStateAction<boolean>>;
-    setGuideShown: Dispatch<SetStateAction<boolean>>;
     setSidebarStatus: Dispatch<SetStateAction<TSidebarStatus>>;
     setHideAmounts: Dispatch<SetStateAction<boolean>>;
     setChartDisplay: Dispatch<SetStateAction<TChartDisplay>>;

--- a/frontends/web/src/contexts/AppProvider.tsx
+++ b/frontends/web/src/contexts/AppProvider.tsx
@@ -77,7 +77,6 @@ export const AppProvider = ({ children }: TProps) => {
         sidebarStatus,
         chartDisplay,
         setActiveSidebar,
-        setGuideShown,
         setGuideExists,
         setSidebarStatus,
         setHideAmounts,

--- a/frontends/web/src/contexts/BackButtonContext.tsx
+++ b/frontends/web/src/contexts/BackButtonContext.tsx
@@ -42,14 +42,14 @@ type TProviderProps = {
 
 export const BackButtonProvider = ({ children }: TProviderProps) => {
   const [handlers, sethandlers] = useState<THandler[]>([]);
-  const { guideShown, setGuideShown } = useContext(AppContext);
+  const { guideShown, toggleGuide } = useContext(AppContext);
 
   const callTopHandler = useCallback(() => {
     // On mobile, the guide covers the whole screen.
     // Make the back button remove the guide first.
     // On desktop the guide does not cover everything and one can keep navigating while it is visible.
     if (runningOnMobile() && guideShown) {
-      setGuideShown(false);
+      toggleGuide();
       return false;
     }
 
@@ -58,7 +58,7 @@ export const BackButtonProvider = ({ children }: TProviderProps) => {
       return topHandler();
     }
     return true;
-  }, [handlers, guideShown, setGuideShown]);
+  }, [handlers, guideShown, toggleGuide]);
 
   const pushHandler = useCallback((handler: THandler) => {
     sethandlers((prevStack) => [...prevStack, handler]);


### PR DESCRIPTION
After closing the guide by going back, the guide opens on next app
restart.

Reason was BackButtonProvider closed the guide by calling:
setGuideShown but this function doesn't update the config and
should probably be internal to AppProvider.