### PR TITLE
frontend/android: fix startup crash

### DIFF
--- a/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
+++ b/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
 
     <!-- for Go backend service -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"/>
 
     <!-- to allow external links and mailto -->
     <queries>
@@ -67,7 +69,7 @@
             <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
                 android:resource="@xml/device_filter" />
         </activity>
-        <service android:name=".GoService" />
+        <service android:name=".GoService" android:foregroundServiceType="dataSync" />
 
         <!-- to allow external apps to open local files (e.g. exported csv) -->
         <provider

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -15,6 +15,7 @@ import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
+import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -458,10 +459,15 @@ public class MainActivity extends AppCompatActivity {
         IntentFilter filter = new IntentFilter();
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
         filter.addAction(ACTION_USB_PERMISSION);
-        registerReceiver(this.usbStateReceiver, filter);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            registerReceiver(this.usbStateReceiver, filter, Context.RECEIVER_EXPORTED);
+        } else {
+            registerReceiver(this.usbStateReceiver, filter);
+        }
+
 
         // Listen on changes in the network connection. We are interested in if the user is connected to a mobile data connection.
-        registerReceiver(this.networkStateReceiver, new IntentFilter(android.net.ConnectivityManager.CONNECTIVITY_ACTION));
+        registerReceiver(this.networkStateReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
 
         Intent intent = getIntent();
         handleIntent(intent);


### PR DESCRIPTION
A recent upgrade to targetSdkVersion 34 (ffc030aa6) caused a crash when starting the app. This fixes the crash adding permission requests in the manifest and updating the `registerReceiver` call in `MainActivity` to v34 requirements.