### PR TITLE
scripts: fix run_regtest.sh electrs panic

### DIFF
--- a/scripts/run_regtest.sh
+++ b/scripts/run_regtest.sh
@@ -50,6 +50,7 @@ BITCOIND_PORT=12340
 BITCOIND_RPC_PORT=10332
 ELECTRS_RPC_PORT1=52001
 ELECTRS_RPC_PORT2=52002
+ELECTRS_MONITORING_PORT2=24225
 
 docker run -v $BITCOIN_DATADIR:/bitcoin/.bitcoin --name=bitcoind-regtest \
        -e DISABLEWALLET=0 \
@@ -97,6 +98,7 @@ docker run \
         --daemon-rpc-addr=${DOCKER_IP}:${BITCOIND_RPC_PORT} \
         --daemon-p2p-addr=${DOCKER_IP}:${BITCOIND_PORT} \
         --electrum-rpc-addr=127.0.0.1:${ELECTRS_RPC_PORT2} \
+        --monitoring-addr=127.0.0.1:${ELECTRS_MONITORING_PORT2} \
         --daemon-dir=/bitcoin/.bitcoin \
         --db-dir=/data &
 


### PR DESCRIPTION
By default electrs serves Prometheus metrics on 127.0.0.1:24224 for regtest. Because we run two electrs containers one always panic because the port is alrady in use. This commit configures one of the two electrs servers to serve metrics on 24225 instead to avoid the crash.

```
[2024-08-05T19:54:21.513Z INFO  electrs::metrics::metrics_impl] serving Prometheus metrics on 127.0.0.1:24224
[2024-08-05T19:54:21.513Z INFO  electrs::server] serving Electrum RPC on 127.0.0.1:52001
thread 'metrics' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 98, kind: AddrInUse, message: "Address already in use" }', src/metrics.rs:30:49
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```