### PR TITLE
frontend/backend: show outputs as individual row for receive transactions

### DIFF
--- a/backend/accounts/notes/notes.go
+++ b/backend/accounts/notes/notes.go
@@ -112,11 +112,12 @@ func (notes *Notes) SetTxNote(txID string, note string) (bool, error) {
 }
 
 // TxNote fetches a note for a transaction. Returns the empty string if no note was found.
-func (notes *Notes) TxNote(txID string) string {
+// NOTE: noteID is either txid or txid:n, n MIGHT NOT be the outpoint from the bitcoin transaction.
+func (notes *Notes) TxNote(noteID string) string {
 	notes.dataMu.RLock()
 	defer notes.dataMu.RUnlock()
 
-	return notes.data.TransactionNotes[txID]
+	return notes.data.TransactionNotes[noteID]
 }
 
 // Data retrieves all stored notes. You must not modify the returned object.

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -245,7 +245,7 @@ export interface ITransaction {
     size: number;
     status: 'complete' | 'pending' | 'failed';
     time: string | null;
-    type: 'send' | 'receive' | 'self';
+    type: 'send' | 'receive' | 'send_to_self';
     txID: string;
     vsize: number;
     weight: number;

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -230,8 +230,16 @@ export const getBalance = (code: AccountCode): Promise<IBalance> => {
   return apiGet(`account/${code}/balance`);
 };
 
+export interface IAddressAndAmount {
+    address: string;
+    amount: IAmount;
+    amountAtTime: IAmount | null;
+    note: string;
+}
+
 export interface ITransaction {
     addresses: string[];
+    outputs: IAddressAndAmount[] | null;
     amount: IAmount;
     amountAtTime: IAmount | null;
     fee: IAmount;

--- a/frontends/web/src/components/transactions/components/details.tsx
+++ b/frontends/web/src/components/transactions/components/details.tsx
@@ -40,11 +40,20 @@ type TProps = {
   numConfirmations: number;
   numConfirmationsComplete: number;
   time: string | null;
+  addresses: string[];
   amount: IAmount;
   sign: string;
   typeClassName: string;
   explorerURL: string;
+  outputIndex?: number;
 }
+
+const getAmountAtTime = (tx: ITransaction, idx: number | undefined) => {
+  if (idx) {
+    return tx.outputs![idx].amountAtTime;
+  }
+  return tx.amount;
+};
 
 export const TxDetailsDialog = ({
   open,
@@ -57,10 +66,12 @@ export const TxDetailsDialog = ({
   numConfirmations,
   numConfirmationsComplete,
   time,
+  addresses,
   amount,
   sign,
   typeClassName,
   explorerURL,
+  outputIndex,
 }: TProps) => {
   const { t } = useTranslation();
 
@@ -96,6 +107,7 @@ export const TxDetailsDialog = ({
             accountCode={accountCode}
             internalID={internalID}
             note={note}
+            outputIndex={outputIndex}
           />
           <TxDetail label={t('transaction.details.type')}>
             <Arrow
@@ -117,8 +129,8 @@ export const TxDetailsDialog = ({
           </TxDetail>
           <TxDetail label={t('transaction.details.fiatAtTime')}>
             <span className={`${parentStyle.fiat} ${typeClassName}`}>
-              {transactionInfo.amountAtTime ?
-                <FiatConversion amount={transactionInfo.amountAtTime} sign={sign} noAction />
+              { getAmountAtTime(transactionInfo, outputIndex) ?
+                <FiatConversion amount={getAmountAtTime(transactionInfo, outputIndex)!} sign={sign} noAction />
                 :
                 <FiatConversion noAction />
               }
@@ -130,7 +142,7 @@ export const TxDetailsDialog = ({
               <Amount amount={amount.amount} unit={amount.unit} />
             </span>
             {' '}
-            <span className={`${parentStyle.currencyUnit} ${typeClassName}`}>{transactionInfo.amount.unit}</span>
+            <span className={`${parentStyle.currencyUnit} ${typeClassName}`}>{amount.unit}</span>
           </TxDetail>
           {
             transactionInfo.fee && transactionInfo.fee.amount ? (
@@ -145,7 +157,7 @@ export const TxDetailsDialog = ({
           }
           <TxDetailCopyableValues
             label={t('transaction.details.address')}
-            values={transactionInfo.addresses}
+            values={addresses}
           />
           {
             transactionInfo.gas ? (

--- a/frontends/web/src/components/transactions/note.tsx
+++ b/frontends/web/src/components/transactions/note.tsx
@@ -28,9 +28,15 @@ type Props = {
   internalID: string;
   // Contains the existing note.
   note: string;
+  outputIndex?: number;
 }
 
-export const Note = ({ accountCode, note, internalID }: Props) => {
+export const Note = ({
+  accountCode,
+  note,
+  internalID,
+  outputIndex,
+}: Props) => {
   const { isDarkMode } = useDarkmode();
   const { t } = useTranslation();
   const [newNote, setNewNote] = useState<string>(note);
@@ -53,7 +59,7 @@ export const Note = ({ accountCode, note, internalID }: Props) => {
     e.preventDefault();
     if (editMode && note !== newNote) {
       accountApi.postNotesTx(accountCode, {
-        internalTxID: internalID,
+        internalTxID: outputIndex !== undefined ? `${internalID}:${outputIndex}` : internalID,
         note: newNote,
       }).catch(console.error);
     }

--- a/frontends/web/src/components/transactions/transaction.module.css
+++ b/frontends/web/src/components/transactions/transaction.module.css
@@ -232,10 +232,6 @@
         margin: 0 0 var(--space-quarter) 0;
     }
 
-    .container.first {
-        
-    }
-    
     .row {
         height: auto;
         padding: var(--space-half);

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -32,12 +32,14 @@ import style from './transaction.module.css';
 type TProps = {
   accountCode: accountApi.AccountCode;
   explorerURL: string;
+  outputIndex?: number;
 } & accountApi.ITransaction;
 
 export const Transaction = ({
   accountCode,
   internalID,
   explorerURL,
+  outputIndex,
   type,
   amount,
   numConfirmations,
@@ -119,10 +121,12 @@ export const Transaction = ({
         numConfirmations={numConfirmations}
         numConfirmationsComplete={numConfirmationsComplete}
         time={time}
+        addresses={addresses}
         amount={amount}
         sign={sign}
         typeClassName={typeClassName}
         explorerURL={explorerURL}
+        outputIndex={outputIndex}
       />
     </div>
   );

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -31,13 +31,11 @@ import style from './transaction.module.css';
 
 type Props = {
   accountCode: accountApi.AccountCode;
-  index: number;
   explorerURL: string;
 } & accountApi.ITransaction;
 
 export const Transaction = ({
   accountCode,
-  index,
   internalID,
   explorerURL,
   type,
@@ -56,7 +54,7 @@ export const Transaction = ({
   const typeClassName = (status === 'failed' && style.failed) || (type === 'send' && style.send) || (type === 'receive' && style.receive) || '';
 
   return (
-    <div className={`${style.container} ${index === 0 ? style.first : ''}`}>
+    <div className={style.container}>
       <div className={`${parentStyle.columns} ${style.row}`}>
         <div className={parentStyle.columnGroup}>
           <div className={parentStyle.type}>

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -29,7 +29,7 @@ import { TxDetailsDialog } from './components/details';
 import parentStyle from './transactions.module.css';
 import style from './transaction.module.css';
 
-type Props = {
+type TProps = {
   accountCode: accountApi.AccountCode;
   explorerURL: string;
 } & accountApi.ITransaction;
@@ -46,7 +46,7 @@ export const Transaction = ({
   addresses,
   status,
   note = '',
-}: Props) => {
+}: TProps) => {
   const { t } = useTranslation();
   const [transactionDialog, setTransactionDialog] = useState<boolean>(false);
 

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -59,13 +59,34 @@ export const Transactions = ({
         <div className={style.action}>&nbsp;</div>
       </div>
       { (transactions && transactions.success && transactions.list.length > 0)
-        ? transactions.list.map((props, _) => (
-          <Transaction
-            accountCode={accountCode}
-            key={props.internalID}
-            explorerURL={explorerURL}
-            {...props} />
-        )) : (
+        ? transactions.list.map((tx, _) => {
+          if (tx.type === 'receive') {
+            return (
+              tx.outputs!.map((output, outputIndex) => (
+                <Transaction
+                  accountCode={accountCode}
+                  key={`${tx.internalID}:${outputIndex}`}
+                  explorerURL={explorerURL}
+                  outputIndex={outputIndex}
+                  {...tx}
+                  // Overwrite with output specific values.
+                  addresses={[output.address]}
+                  amount={output.amount}
+                  amountAtTime={output.amountAtTime}
+                  note={output.note}
+                />
+              ))
+            );
+          }
+          return (
+            <Transaction
+              accountCode={accountCode}
+              key={tx.internalID}
+              explorerURL={explorerURL}
+              {...tx}
+            />
+          );
+        }) : (
           <div className={`flex flex-row flex-center ${style.empty}`}>
             { transactions && !transactions.success ? (
               <p>{t('transactions.errorLoadTransactions')}</p>

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -59,12 +59,11 @@ export const Transactions = ({
         <div className={style.action}>&nbsp;</div>
       </div>
       { (transactions && transactions.success && transactions.list.length > 0)
-        ? transactions.list.map((props, index) => (
+        ? transactions.list.map((props, _) => (
           <Transaction
             accountCode={accountCode}
             key={props.internalID}
             explorerURL={explorerURL}
-            index={index}
             {...props} />
         )) : (
           <div className={`flex flex-row flex-center ${style.empty}`}>


### PR DESCRIPTION
Closes: #1728 

Display each output of a **receive** transaction as one transaction in the app. The outputs data is only added to the endpoint response if the transaction is of type receive. Non-utxo model transactions e.g. ETH will just contain a single item in the `outputs` field which is weird but fine imo.

In the current implementation the index used for the **note key** (`txid:idx`) is set/defined by the order of the `Adresses` in the `TransactionData` struct returned by `txInfo` ([here](https://github.com/BitBoxSwiss/bitbox-wallet-app/blob/0c82d7b67b8f84c751dd19a2e4095aa0aa4fdde4/backend/coins/btc/transactions/transactions.go#L377))
- if the logic there changes all notes would be broken
- the way the frontend treats the `outputs` field right now kind of implies that we are dealing with the actual `outpoint`/output index of the transaction which is not true and could be confusing when working on the code after some time.

Probably it would be better to add `index` to `TransactionOutput` and actually set it to the transactions output index and then use that in the frontend. Let me know if you think the current implementation is fine or if I should change that.
