### PR TITLE
scripts: improve regtest setup

### DIFF
--- a/scripts/regtest/account0.json
+++ b/scripts/regtest/account0.json
@@ -1,0 +1,18 @@
+[
+  {
+    "desc": "wpkh([9ec47506/84'/1'/0']tprv8fXWybzpxw9i3rvVbpEw1k8RJbKip8D9AioZU4FkbvWbAhFbURgE8VAFqTaeDvvqgsZxz6w9TdPNCUEbTYxeRaSMhshVLNnhZcAVrLNQDBR/1/*)#mftt0y2y",
+    "active": true,
+    "range": [0,999],
+    "next_index": 0,
+    "timestamp": 0,
+    "internal": true
+  },
+  {
+    "desc": "wpkh([9ec47506/84'/1'/0']tprv8fXWybzpxw9i3rvVbpEw1k8RJbKip8D9AioZU4FkbvWbAhFbURgE8VAFqTaeDvvqgsZxz6w9TdPNCUEbTYxeRaSMhshVLNnhZcAVrLNQDBR/0/*)#2aw2j36u",
+    "active": true,
+    "range": [0,999],
+    "next_index": 0,
+    "timestamp": 0,
+    "internal": false
+  }
+]

--- a/scripts/regtest/examples.sh
+++ b/scripts/regtest/examples.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+source lib.sh
+
+
+# Example 1. BB02 send 1BTC to alice and bob in one tx.
+example_sendmany_alice_bob() {
+    addressAlice=$(alice getnewaddress)
+    addressBob=$(bob getnewaddress)
+    sendmany_json="{\"$addressAlice\":1,\"$addressBob\":1}"
+    bitbox sendmany "" $sendmany_json
+}
+# Example 2. BB02 send 1BTC to alice, bob, and self in one tx.
+example_sendmany_alice_bob_self() {
+    addressAlice=$(alice getnewaddress)
+    addressBob=$(bob getnewaddress)
+    addressSelf=$(bitbox getnewaddress)
+    sendmany_json="{\"$addressAlice\":1,\"$addressBob\":1,\"$addressSelf\":1}"
+    bitbox sendmany "" $sendmany_json
+}
+# Example 3. BB02 receive two outputs in one tx.
+example_bitbox_receive_many() {
+    address1=$(bitbox getnewaddress)
+    address2=$(bitbox getnewaddress)
+    sendmany_json="{\"$address1\":1,\"$address2\":2}"
+    main sendmany "" $sendmany_json
+}
+# Example 4. BB02 coinjoin wallet balance decrease.
+example_coinjoin_balance_decrease() {
+    echo "todo"
+}
+# Example 5. BB02 coinjoin wallet balance increase.
+# Example 6. BB02 send payjoin.
+# Example 7. BB02 receive payjoin.
+# Example 8. BB02 receive payjoin.
+# TODO: RBF after pending for mutliple blocks.
+# TODO: CPFP after pending for multiple blocks.
+# TODO: Canceled trasnaction after pending for multiple blocks.
+# TODO: Canceled PARENT with in-fight CPFP from BB02 after pending for mutliple blocks.
+# TODO: Re-Orgs
+# TODO: Etc. 

--- a/scripts/regtest/lib.sh
+++ b/scripts/regtest/lib.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+btc_cli() {
+    if [ "$DOCKER_REGTEST" = 1 ]; then
+        output=$(docker exec --user=$(id -u) -it bitcoind-regtest bitcoin-cli -regtest -datadir=/bitcoin -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 "$@")
+        echo $output | tr -d '\r'
+else
+    bitcoin-cli -regtest "$@"
+    fi
+}
+
+main() {
+    btc_cli -rpcwallet="main" "$@"
+}
+
+alice() {
+    btc_cli -rpcwallet="alice" "$@"
+}
+
+bob() {
+    btc_cli -rpcwallet="bob" "$@"
+}
+
+bitbox() {
+    btc_cli -rpcwallet="bitbox" "$@"
+}
+
+############################
+
+mine_blocks () {
+    wallet=${2:-main} 
+    btc_cli -rpcwallet=main generatetoaddress $1 $($wallet getnewaddress) 
+    main generatetoaddress $1 $($wallet getnewaddress) 
+}
+
+# Send $2 BTC to wallet $1 from main wallet.
+fund_wallet () {
+    wallet=${2:-main}
+    recv_address=$($wallet getnewaddress)
+    main sendtoaddress $recv_address $1
+    mine_blocks 6
+}
+
+############################
+
+# DOCKER_REGTEST=1 will use the bitcoind-regtest environmnent.
+if [ "${DOCKER_REGTEST}" = 1 ]; then
+    echo "Using bitcoind-regtest container. Make sure to run run_regtest.sh too"
+else
+    echo "Using local bitcoind -regtest. In case you want to run run_regtest.sh set the DOCKER_REGTEST=1"
+fi
+
+# Create or load wallets.
+wallets=($(btc_cli listwalletdir | jq -r '.wallets[].name'))
+loaded_wallets=($(btc_cli listwallets | jq -r '.[]'))
+for wallet in main alice bob bitbox; do
+    if [[ "${wallets[@]}" =~ ${wallet} ]]; then
+        if [[ ! "${loaded_wallets[@]}" =~ ${wallet} ]]; then
+          echo "load wallet: $wallet"
+          btc_cli loadwallet $wallet
+        fi 
+    else
+        echo "create wallet: $wallet"
+        if [[ "$wallet" == "bitbox" ]]; then
+            # Create a blank=true wallet to avoid accidentially using the wrong keys.
+            # Import the first account using descriptors.
+            btc_cli createwallet $wallet false true
+            bitbox importdescriptors "$(cat account0.json)"
+        else
+            btc_cli createwallet $wallet
+        fi 
+    fi
+done
+
+echo "=== Functions ==="
+echo "Any function that takes <wallet> as an argument can omit it to fallback on the main wallet."
+
+echo ""
+echo "1. mine_blocks <n> <wallet>"
+echo "   Description: Mines n-blocks to <wallet>."
+echo "   Example: mine_blocks 50 bitbox"
+
+echo ""
+echo "2. fund_wallet <n> <wallet>"
+echo "   Description: Sends n-BTC (from main) to <wallet> and mines 6 blocks for full confirmation."
+echo "   Example: fund_wallet 10 bitbox"
+
+echo ""
+echo "=== Aliases ==="
+echo "Use 'btc_cli' as an alias for 'bitcoin-cli'."
+echo "Example: btc_cli --rpcwallet=<wallet> getnewaddress"
+
+echo ""
+echo "Use <wallet> directly as an alias for 'btc_cli --rpcwallet=<wallet>'."
+echo "Example: alice getnewaddress"
+
+echo ""
+echo "=== Available Wallets ==="
+echo "main, alice, bob, bitbox"
+echo "IN CASE YOU USE LOCAL bitcoind -regtest YOU MIGHT WANT TO rm -rf ~/.bitcoin/regtest FOR A CLEAN SETUP AFTER RUNNING THIS"

--- a/scripts/regtest/run_regtest.sh
+++ b/scripts/regtest/run_regtest.sh
@@ -1,0 +1,112 @@
+#!/bin/bash -e
+# Copyright 2018 Shift Devices AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+BITCOIN_DATADIR="/tmp/regtest/btcdata"
+ELECTRS_DATADIR1="/tmp/regtest/electrsdata1"
+ELECTRS_DATADIR2="/tmp/regtest/electrsdata2"
+
+trap 'killall' EXIT
+
+killall() {
+    # https://unix.stackexchange.com/questions/55558/how-can-i-kill-and-wait-for-background-processes-to-finish-in-a-shell-script-whe
+    trap '' INT TERM # ignore INT and TERM while shutting down
+    echo "**** Shutting down... ****"
+    kill -TERM 0
+    wait
+    rm -rf $BITCOIN_DATADIR
+    rm -rf $ELECTRS_DATADIR1
+    rm -rf $ELECTRS_DATADIR2
+    docker rm bitcoind-regtest
+    docker rm electrs-regtest1
+    docker rm electrs-regtest2
+    echo DONE
+}
+
+mkdir -p $BITCOIN_DATADIR
+mkdir -p $ELECTRS_DATADIR1
+mkdir -p $ELECTRS_DATADIR2
+echo -n "dbb:dbb" > $ELECTRS_DATADIR1/rpccreds
+echo -n "dbb:dbb" > $ELECTRS_DATADIR2/rpccreds
+echo "bitcoind datadir: ${BITCOIN_DATADIR}"
+echo "electrs datadir1: ${ELECTRS_DATADIR1}"
+echo "electrs datadir2: ${ELECTRS_DATADIR2}"
+
+# Default docker bridge.
+DOCKER_IP="172.17.0.1"
+BITCOIND_PORT=12340
+BITCOIND_RPC_PORT=10332
+ELECTRS_RPC_PORT1=52001
+ELECTRS_RPC_PORT2=52002
+
+docker run -v $BITCOIN_DATADIR:/bitcoin/.bitcoin --name=bitcoind-regtest \
+       -e DISABLEWALLET=0 \
+       -e PRINTTOCONSOLE=0 \
+       -e RPCUSER=dbb \
+       -e RPCPASSWORD=dbb \
+       -p ${BITCOIND_RPC_PORT}:${BITCOIND_RPC_PORT} \
+       -p ${BITCOIND_PORT}:${BITCOIND_PORT} \
+       kylemanna/bitcoind \
+       -regtest \
+       -fallbackfee=0.00001 \
+       -port=${BITCOIND_PORT} \
+       -rpcport=${BITCOIND_RPC_PORT} \
+       -rpcbind=0.0.0.0 \
+       -rpcallowip=$DOCKER_IP/16 &
+
+docker run \
+       -u $(id -u $USER) \
+       --net=host \
+       -v $BITCOIN_DATADIR/.bitcoin:/bitcoin/.bitcoin \
+       -v $ELECTRS_DATADIR1:/data \
+       --name=electrs-regtest1 \
+       benma2/electrs:v0.9.9 \
+        --cookie-file=/data/rpccreds \
+        --log-filters INFO \
+        --timestamp \
+        --network=regtest \
+        --daemon-rpc-addr=${DOCKER_IP}:${BITCOIND_RPC_PORT} \
+        --daemon-p2p-addr=${DOCKER_IP}:${BITCOIND_PORT} \
+        --electrum-rpc-addr=127.0.0.1:${ELECTRS_RPC_PORT1} \
+        --daemon-dir=/bitcoin/.bitcoin \
+        --db-dir=/data &
+
+docker run \
+       -u $(id -u $USER) \
+       --net=host \
+       -v $BITCOIN_DATADIR/.bitcoin:/bitcoin/.bitcoin \
+       -v $ELECTRS_DATADIR2:/data \
+       --name=electrs-regtest2 \
+       benma2/electrs:v0.9.9 \
+        --cookie-file=/data/rpccreds \
+        --log-filters INFO \
+        --timestamp \
+        --network=regtest \
+        --daemon-rpc-addr=${DOCKER_IP}:${BITCOIND_RPC_PORT} \
+        --daemon-p2p-addr=${DOCKER_IP}:${BITCOIND_PORT} \
+        --electrum-rpc-addr=127.0.0.1:${ELECTRS_RPC_PORT2} \
+        --daemon-dir=/bitcoin/.bitcoin \
+        --db-dir=/data &
+
+echo "Interact with the regtest chain (e.g. generate 101 blocks and send coins):"
+echo "    docker exec --user=`id -u` -it bitcoind-regtest bitcoin-cli -regtest -datadir=/bitcoin -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 createwallet"
+echo "    docker exec --user=`id -u` -it bitcoind-regtest bitcoin-cli -regtest -datadir=/bitcoin -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 getnewaddress"
+echo "    docker exec --user=`id -u` -it bitcoind-regtest bitcoin-cli -regtest -datadir=/bitcoin -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 generatetoaddress 101 <newaddress>"
+echo "    docker exec --user=`id -u` -it bitcoind-regtest bitcoin-cli -regtest -datadir=/bitcoin -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 sendtoaddress <address> <amount>"
+echo "Delete headers-rbtc.bin in the app cache folder before running the BitBoxApp, otherwise it can conflict the fresh regtest chain."
+echo "Also delete all rbtc account caches in the app cache folder before running the BitBoxApp."
+echo "You may need to disable VPN, as it can prevent Electrs/bitcoin-cli from connecting to bitcoind."
+
+while true; do sleep 1; done


### PR DESCRIPTION
Use PIN _remote_ in webdev. You might have to _eject software keystore_ and reconnect after sending the first tx. to the wallet so that the tx shows up, after that all txs will show up immediately (no idea why).

Set `export DOCKER_REGTEST=1` in case you are using it with the `run_regtest.sh` script.

Source `lib.sh` or `example.sh` from the `regtest` folder so that `account0.json` can be imported into `bitcoin-cli` correctly (I used a relative path because this is a WIP)