### PR TITLE
frontend: update pocket T&C and info box content, remove unused translation keys

### DIFF
--- a/frontends/web/src/components/terms/pocket-terms.tsx
+++ b/frontends/web/src/components/terms/pocket-terms.tsx
@@ -20,6 +20,7 @@ import { Button, Checkbox } from '@/components/forms';
 import { setConfig } from '@/utils/config';
 import { A } from '@/components/anchor/anchor';
 import style from './terms.module.css';
+import { SimpleMarkup } from '@/utils/markup';
 
 type TProps = {
   onAgreedTerms: () => void;
@@ -34,35 +35,44 @@ export const PocketTerms = ({ onAgreedTerms }: TProps) => {
   return (
     <div className={style.disclaimerContainer}>
       <div className={style.disclaimer}>
-        <h2 className={style.title}>{t('buy.pocket.welcome.title')}</h2>
-        <p>{t('buy.pocket.welcome.p1')}</p>
-        <p>{t('buy.pocket.welcome.p2')}</p>
-        <p>{t('buy.pocket.welcome.p3')}</p>
+        <h2 className={style.title}>{t('exchange.pocket.terms.welcome.title')}</h2>
+        <p>{t('exchange.pocket.terms.welcome.p1')}</p>
 
-        <h2 className={style.title}>{t('buy.pocket.payment.title')}</h2>
-        <p>{t('buy.pocket.payment.p1')}</p>
-        <p>{t('buy.pocket.payment.p2')}</p>
+        <h2 className={style.title}>{t('exchange.pocket.terms.fees.title')}</h2>
+        <ul>
+          <li><SimpleMarkup tagName="p" markup={t('exchange.pocket.terms.fees.p1')} /></li>
+          <li><SimpleMarkup tagName="p" markup={`${t('exchange.pocket.terms.fees.p2')} ${t('exchange.pocket.terms.fees.extraNote')}`} /></li>
+        </ul>
+        <p>{t('exchange.pocket.terms.fees.note')}</p>
 
-        <h2 className={style.title}>{t('buy.pocket.security.title')}</h2>
-        <p>{t('buy.pocket.security.p1')}</p>
+        <h2 className={style.title}>{t('exchange.pocket.terms.security.title')}</h2>
+        <p>{t('exchange.pocket.terms.security.p1')}</p>
+        <ul>
+          <li><SimpleMarkup tagName="p" markup={t('exchange.pocket.terms.security.p2')} /></li>
+          <li><SimpleMarkup tagName="p" markup={t('exchange.pocket.terms.security.p3')} /></li>
+        </ul>
         <p>
           <A href="https://bitbox.swiss/bitbox02/threat-model/">
-            {t('buy.pocket.security.link')}
-          </A>
-        </p>
-        <h2 className={style.title}>{t('buy.pocket.kyc.title')}</h2>
-        <p>{t('buy.pocket.kyc.p1')}</p>
-        <p>
-          <A href="https://pocketbitcoin.com/faq">
-            {t('buy.pocket.kyc.link')}
+            {t('exchange.pocket.terms.security.link')}
           </A>
         </p>
 
-        <h2 className={style.title}>{t('buy.pocket.data.title')}</h2>
-        <p>{t('buy.pocket.data.p1')}</p>
+        <h2 className={style.title}>{t('exchange.pocket.terms.kyc.title')}</h2>
+        <ul>
+          <li><p>{t('exchange.pocket.terms.kyc.p1')}</p></li>
+          <li><p>{t('exchange.pocket.terms.kyc.p2')}</p></li>
+        </ul>
+        <p>
+          <A href="https://pocketbitcoin.com/faq">
+            {t('exchange.pocket.terms.kyc.link')}
+          </A>
+        </p>
+
+        <h2 className={style.title}>{t('exchange.pocket.terms.dataprotection.title')}</h2>
+        <p>{t('exchange.pocket.terms.dataprotection.p1')}</p>
         <p>
           <A href="https://pocketbitcoin.com/policy/privacy">
-            {t('buy.pocket.data.link')}
+            {t('exchange.pocket.terms.dataprotection.link')}
           </A>
         </p>
       </div>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -428,23 +428,26 @@
         },
         "pocket": {
           "fees": {
-            "info": "Bank transfer: {{fee}}%",
+            "info": "{{fee}}% exchange fee, plus small network transaction fee",
             "title": "Fees"
           },
           "learnMore": "Learn more about Pocket",
           "payment": {
             "bankTransfer": "Bank transfer",
             "bankTransferDetails": {
-              "sepa": "SEPA and SEPA Instant (EUR transactions in SEPA countries only)",
+              "sepa": "SEPA and SEPA Instant (EUR)",
               "sic": "Swiss Interbank Clearing (CHF transactions in CH/LI only)",
-              "uk": "UK Faster Payments (GBP transactions in the UK only)"
+              "uk": "UK Faster Payments (GBP)"
             },
             "bankTransferReccuring": "How to set up recurring purchases with a standing order?",
             "title": "Payment methods"
           },
+          "sell": {
+            "title": "Sell Bitcoin"
+          },
           "supportedCurrencies": "Supports European currencies: EUR, GBP, and CHF.",
           "verification": {
-            "info": "Only requires identity verification above daily and annual thresholds.",
+            "info": "No identitiy verification for amounts below threshold (~950 EUR/day)",
             "link": "Find current thresholds here",
             "title": "Identity verification"
           }
@@ -500,39 +503,13 @@
       "skip": "Do not show again"
     },
     "pocket": {
-      "data": {
-        "link": "Pocket privacy policy",
-        "p1": "The BitBoxApp does not collect any data when buying bitcoin, the incoming funds are treated like a regular transaction. Pocket needs to collect some personal data to operate. Their Privacy Policy explains in detail how that data is handled.",
-        "title": "Data protection"
-      },
       "error": {
         "insufficientFunds": "Insufficient funds on the selected account."
       },
-      "kyc": {
-        "link": "Read Pocket FAQs",
-        "p1": "Pocket tries to keep KYC to a minimum. For purchases under 950 EUR (1000 CHF) a day, no additional documents are required. For purchases over this amount, you will need to schedule a call with Pocket to complete the necessary KYC/AML process.",
-        "title": "KYC/AML"
-      },
-      "payment": {
-        "p1": "You can buy bitcoin instantly with Pocket via SEPA bank transfer. The fee is 1.5% and the bitcoin is deposited to your BitBox as soon as possible after Pocket receives the bank transfer (usually within the same day).",
-        "p2": "Please note that Pocket’s exchange rates can differ from the ones used in the BitBoxApp, resulting in slightly different amounts.",
-        "title": "Payment methods and fees"
-      },
       "paymentRequestNote": "Payment request from",
       "previousTransactions": "The transaction history of this account is not empty. Sharing this account will make all its past and future transactions visible for Pocket. Proceed anyway?",
-      "security": {
-        "link": "BitBox02 security threat model",
-        "p1": "When you buy bitcoin via Pocket, you are using an external service. This service is out of scope of the BitBox02 Security Threat model and relies on the safety and security of the environment which the BitBoxApp software is running in. However we work together to improve security by using a two factor authentication mechanism to verify the address you are receiving to.",
-        "title": "Security model"
-      },
       "usedAddress": "The address {{address}} has been already used, please start again with a new address.",
-      "verifyBitBox02": "Please verify that the address you received via email matches the one displayed on your Bitbox. If possible, you should open the email on a second device for better security.",
-      "welcome": {
-        "p1": "We partner with Pocket to offer you a seamless way to buy bitcoin directly within the BitBoxApp. It's just a few clicks.",
-        "p2": "Pocket is a Swiss platform that makes it quick and easy to buy bitcoin in most of Europe (anywhere where SEPA bank transfers are supported).",
-        "p3": "With Pocket, you can also do regular buys through standing bank orders, so you can DCA (dollar-cost averaging) with ease.",
-        "title": "Welcome to your one stop shop for buying bitcoin"
-      }
+      "verifyBitBox02": "Please verify that the address you received via email matches the one displayed on your Bitbox. If possible, you should open the email on a second device for better security."
     }
   },
   "changePin": {
@@ -719,6 +696,39 @@
       "coinNotSupported": "No {{action}} options available for this coin type.",
       "regionNotSupported": "No {{action}} options available for this region.",
       "updateNow": "Update now"
+    },
+    "pocket": {
+      "terms": {
+        "dataprotection": {
+          "link": "Pocket privacy policy",
+          "p1": "The BitBoxApp does not learn or collect any personal data. Pocket collects some personal data as explained in their Privacy Policy.",
+          "title": "Data Protection"
+        },
+        "fees": {
+          "extraNote": "Please note that you need to buy Bitcoin with Pocket first before you can sell.",
+          "note": "Note: Pocket's exchange rates may differ from the BitBoxApp rates.",
+          "p1": "<strong>Buying bitcoin:</strong> Use SEPA bank transfer to send EUR or CHF and get bitcoin delivered directly to your BitBox after Pocket receives the transfer, usually the same day.",
+          "p2": "<strong>Selling bitcoin:</strong> Send Bitcoin to Pocket and receive EUR or CHF in your registered bank account. The exchange rate is fixed when Pocket receives your Bitcoin.",
+          "title": "Payment Methods and Fees"
+        },
+        "kyc": {
+          "link": "Read Pocket FAQs",
+          "p1": "No additional documents are needed for exchanges up to 950 EUR (1000 CHF) per day.",
+          "p2": "For larger amounts, a call with Pocket is required to complete the KYC/AML process.",
+          "title": "KYC/AML (Know Your Customer / Anti-Money Laundering)"
+        },
+        "security": {
+          "link": "BitBox02 security threat model",
+          "p1": "Using Pocket is an external service and is not covered by the BitBox02 Security Threat model. However, we closely work with Pocket to enhance overall security.",
+          "p2": "<strong>Buying bitcoin:</strong> You’ll get an email to confirm your bitcoin receive address through a second communication channel.",
+          "p3": "<strong>Selling bitcoin:</strong> The BitBox02 verifies the Bitcoin deposit address cryptographically and displays \"Pocket\" on the hardware wallet.",
+          "title": "Security"
+        },
+        "welcome": {
+          "p1": "We work with Pocket, a Swiss broker, to make buying and selling bitcoin easy within the BitBoxApp. This service is available across Europe where SEPA bank transfers are supported.",
+          "title": "Buy and sell bitcoin with Pocket"
+        }
+      }
     }
   },
   "fiat": {

--- a/frontends/web/src/routes/exchange/components/infocontent.tsx
+++ b/frontends/web/src/routes/exchange/components/infocontent.tsx
@@ -104,6 +104,10 @@ export const PocketInfo = ({ bankTransferFee }: TPocketInfo) => {
           {t('buy.exchange.infoContent.pocket.learnMore')}
         </A>
       </p>
+      <br />
+      <p><b>{t('buy.exchange.infoContent.pocket.sell.title')}</b></p>
+      <br />
+      <p>{t('exchange.pocket.terms.fees.extraNote')}</p>
     </div>
   );
 };

--- a/frontends/web/src/routes/exchange/guide.tsx
+++ b/frontends/web/src/routes/exchange/guide.tsx
@@ -27,7 +27,7 @@ export const ExchangeGuide = ({ exchange, translationContext }: BuyGuideProps) =
   const { t } = useTranslation();
 
   const pocketLink = {
-    text: t('buy.pocket.data.link'),
+    text: t('exchange.pocket.terms.dataprotection.link'),
     url: 'https://pocketbitcoin.com/policy/privacy',
   };
 


### PR DESCRIPTION
moved & update content of pocket T&C. Removed the old / out-of-date (thus unused) pocket T&C translation keys.

T&C: 

<img width="777" alt="tnc_" src="https://github.com/user-attachments/assets/c67aa116-754f-4810-9f4c-ceb42a54ecfc">


Info box: 

<img width="608" alt="ibox" src="https://github.com/user-attachments/assets/84a98275-80ed-40aa-bb8a-01f485d12906">
