### PR TITLE
frontend: use Intl.DisplayNames to localise currency names

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -35,6 +35,11 @@ export type ERC20CoinCode = 'erc20Test' | 'eth-erc20-usdt' | 'eth-erc20-usdc' | 
 
 export type CoinCode = NativeCoinCode | ERC20CoinCode;
 
+export type FiatWithDisplayName = {
+  currency: Fiat,
+  displayName: string
+}
+
 export type Terc20Token = {
   code: ERC20CoinCode;
   name: string;

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -15,38 +15,10 @@
  * limitations under the License.
  */
 import { useContext } from 'react';
-import { Fiat, ConversionUnit, IAmount } from '@/api/account';
+import { ConversionUnit, IAmount } from '@/api/account';
 import { RatesContext } from '@/contexts/RatesContext';
 import { Amount } from '@/components/amount/amount';
 import style from './rates.module.css';
-
-type FiatWithDisplayName = {
-  currency: Fiat,
-  displayName: string
-}
-
-export const currenciesWithDisplayName: FiatWithDisplayName[] = [
-  { currency: 'AUD', displayName: 'Australian Dollar' },
-  { currency: 'BRL', displayName: 'Brazilian Real' },
-  { currency: 'CAD', displayName: 'Canadian Dollar' },
-  { currency: 'CHF', displayName: 'Swiss franc' },
-  { currency: 'CNY', displayName: 'Chinese Yuan' },
-  { currency: 'CZK', displayName: 'Czech Koruna' },
-  { currency: 'EUR', displayName: 'Euro' },
-  { currency: 'GBP', displayName: 'British Pound' },
-  { currency: 'HKD', displayName: 'Hong Kong Dollar' },
-  { currency: 'ILS', displayName: 'Israeli New Shekel' },
-  { currency: 'JPY', displayName: 'Japanese Yen' },
-  { currency: 'KRW', displayName: 'South Korean Won' },
-  { currency: 'NOK', displayName: 'Norwegian Krone' },
-  { currency: 'PLN', displayName: 'Polish Zloty' },
-  { currency: 'RUB', displayName: 'Russian ruble' },
-  { currency: 'SEK', displayName: 'Swedish Krona' },
-  { currency: 'SGD', displayName: 'Singapore Dollar' },
-  { currency: 'USD', displayName: 'United States Dollar' },
-  { currency: 'BTC', displayName: 'Bitcoin' },
-  { currency: 'sat', displayName: 'Satoshi' }
-];
 
 type TProvidedProps = {
     amount?: IAmount;
@@ -140,6 +112,5 @@ export const DefaultCurrencyRotator = ({
   return <td className={textStyle} onClick={rotateDefaultCurrency}>{displayedCurrency}</td>;
 };
 
-export const formattedCurrencies = currenciesWithDisplayName.map((fiat) => ({ label: `${fiat.displayName} (${fiat.currency})`, value: fiat.currency }));
 
 export const FiatConversion = Conversion;

--- a/frontends/web/src/hooks/localized.test.ts
+++ b/frontends/web/src/hooks/localized.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { useLocalizedPunctuation } from './localized';
+import { useLocalizedFormattedCurrencies, useLocalizedPunctuation } from './localized';
 import { describe, expect, it } from 'vitest';
 
 
@@ -158,5 +158,50 @@ describe('useLocalizedPunctuation', () => {
     });
   });
 
+
+});
+
+
+describe('useLocalizedFormattedCurrencies', () => {
+  it('should return currencies formatted in English (en)', () => {
+    const { result } = renderHook(() => useLocalizedFormattedCurrencies('en'));
+
+    const { formattedCurrencies } = result.current;
+
+    expect(formattedCurrencies).toEqual(
+      expect.arrayContaining([
+        { label: 'Australian Dollar (AUD)', value: 'AUD' },
+        { label: 'Brazilian Real (BRL)', value: 'BRL' },
+        { label: 'Canadian Dollar (CAD)', value: 'CAD' }
+      ])
+    );
+  });
+
+  it('should return currencies formatted in German (de)', () => {
+    const { result } = renderHook(() => useLocalizedFormattedCurrencies('de'));
+
+    const { formattedCurrencies } = result.current;
+
+    expect(formattedCurrencies).toEqual(
+      expect.arrayContaining([
+        { label: 'Australischer Dollar (AUD)', value: 'AUD' },
+        { label: 'Brasilianischer Real (BRL)', value: 'BRL' },
+        { label: 'Kanadischer Dollar (CAD)', value: 'CAD' }
+      ])
+    );
+  });
+
+  it('should not change the displayName for BTC and sat', () => {
+    const { result } = renderHook(() => useLocalizedFormattedCurrencies('de'));
+
+    const { formattedCurrencies } = result.current;
+
+    expect(formattedCurrencies).toEqual(
+      expect.arrayContaining([
+        { label: 'Bitcoin (BTC)', value: 'BTC' },
+        { label: 'Satoshi (sat)', value: 'sat' }
+      ])
+    );
+  });
 
 });

--- a/frontends/web/src/hooks/localized.ts
+++ b/frontends/web/src/hooks/localized.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { useMemo } from 'react';
+import { FiatWithDisplayName } from '@/api/account';
+import { useEffect, useMemo, useState } from 'react';
 
 export const useLocalizedPunctuation = (
   // fallback to 'de-CH' if native locale is an empty string
@@ -41,4 +42,47 @@ export const useLocalizedPunctuation = (
   }, [locale]);
 
   return { decimal, group };
+};
+
+
+export const useLocalizedFormattedCurrencies = (selectedLang = 'en') => {
+  const [currenciesWithDisplayName, setCurrenciesWithDisplayName] = useState<FiatWithDisplayName[]>([
+    { currency: 'AUD', displayName: 'Australian Dollar' },
+    { currency: 'BRL', displayName: 'Brazilian Real' },
+    { currency: 'CAD', displayName: 'Canadian Dollar' },
+    { currency: 'CHF', displayName: 'Swiss franc' },
+    { currency: 'CNY', displayName: 'Chinese Yuan' },
+    { currency: 'CZK', displayName: 'Czech Koruna' },
+    { currency: 'EUR', displayName: 'Euro' },
+    { currency: 'GBP', displayName: 'British Pound' },
+    { currency: 'HKD', displayName: 'Hong Kong Dollar' },
+    { currency: 'ILS', displayName: 'Israeli New Shekel' },
+    { currency: 'JPY', displayName: 'Japanese Yen' },
+    { currency: 'KRW', displayName: 'South Korean Won' },
+    { currency: 'NOK', displayName: 'Norwegian Krone' },
+    { currency: 'PLN', displayName: 'Polish Zloty' },
+    { currency: 'RUB', displayName: 'Russian ruble' },
+    { currency: 'SEK', displayName: 'Swedish Krona' },
+    { currency: 'SGD', displayName: 'Singapore Dollar' },
+    { currency: 'USD', displayName: 'United States Dollar' },
+    { currency: 'BTC', displayName: 'Bitcoin' },
+    { currency: 'sat', displayName: 'Satoshi' }
+  ]);
+
+  useEffect(() => {
+    const currencyName = new Intl.DisplayNames([selectedLang], { type: 'currency' });
+
+    setCurrenciesWithDisplayName(prev =>
+      prev.map(currencyDetail => ({
+        ...currencyDetail,
+        displayName:
+          (currencyDetail.currency === 'BTC' || currencyDetail.currency === 'sat') ?
+            currencyDetail.displayName : (currencyName.of(currencyDetail.currency) || currencyDetail.displayName)
+      }))
+    );
+
+  }, [selectedLang]);
+
+  return { formattedCurrencies: currenciesWithDisplayName.map((fiat) => ({ label: `${fiat.displayName} (${fiat.currency})`, value: fiat.currency })), currenciesWithDisplayName };
+
 };

--- a/frontends/web/src/routes/settings/components/appearance/activeCurrenciesDropdownSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/activeCurrenciesDropdownSetting.tsx
@@ -16,14 +16,15 @@
 
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { formattedCurrencies } from '@/components/rates/rates';
+import { RatesContext } from '@/contexts/RatesContext';
+import { useLocalizedFormattedCurrencies } from '@/hooks/localized';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
 import { ActiveCurrenciesDropdown } from '@/routes/settings/components/dropdowns/activecurrenciesdropdown';
-import { RatesContext } from '@/contexts/RatesContext';
 
 const ActiveCurrenciesDropdownSetting = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { activeCurrencies, defaultCurrency } = useContext(RatesContext);
+  const { formattedCurrencies } = useLocalizedFormattedCurrencies(i18n.language);
   return (
     <SettingsItem
       collapseOnSmall

--- a/frontends/web/src/routes/settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -14,19 +14,23 @@
  * limitations under the License.
  */
 
-import { currenciesWithDisplayName, formattedCurrencies } from '@/components/rates/rates';
-import { SingleDropdown } from '@/routes/settings/components/dropdowns/singledropdown';
-import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
-import { Fiat } from '@/api/account';
 import { useTranslation } from 'react-i18next';
 import { useContext } from 'react';
 import { RatesContext } from '@/contexts/RatesContext';
+import { useLocalizedFormattedCurrencies } from '@/hooks/localized';
+import { SingleDropdown } from '@/routes/settings/components/dropdowns/singledropdown';
+import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
+import { Fiat } from '@/api/account';
+
 
 export const DefaultCurrencyDropdownSetting = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const currencyName = new Intl.DisplayNames([i18n.language], { type: 'currency' });
+  const { formattedCurrencies, currenciesWithDisplayName } = useLocalizedFormattedCurrencies(i18n.language);
   const { addToActiveCurrencies, updateDefaultCurrency, defaultCurrency, activeCurrencies } = useContext(RatesContext);
   const valueLabel = currenciesWithDisplayName.find(fiat => fiat.currency === defaultCurrency)?.displayName;
-  const defaultValueLabel = valueLabel ? `${valueLabel} (${defaultCurrency})` : defaultCurrency;
+  const defaultValueLabel = valueLabel ? `${currencyName.of(defaultCurrency)} (${defaultCurrency})` : defaultCurrency;
+
   return (
     <SettingsItem
       settingName={t('newSettings.appearance.defaultCurrency.title')}

--- a/frontends/web/src/routes/settings/components/dropdowns/activecurrenciesdropdown.module.css
+++ b/frontends/web/src/routes/settings/components/dropdowns/activecurrenciesdropdown.module.css
@@ -17,17 +17,16 @@
 }
 
 
+:global(.react-select__multi-value):nth-last-child(2) {
+    display: none;
+}
+
 /*
 displays ', ' as a pseudo component for all currency component
 except the last displayed component (the 3rd currency component).
-
-The reason for :nth-last-child(2) instead of just :last-child is because there's an extra
-component created by react-select after the actual last currency component. 
-
-So, we're targetting the second to last component here, 
-which is the last selected currency in the DOM.
 */
-.select:not(.hideMultiSelect) :global(.react-select__multi-value):not(:nth-last-child(2))::after {
+
+.select:not(.hideMultiSelect) :global(.react-select__multi-value):not(:nth-last-child(3))::after {
     content: ',';
     padding-right: 2px;
 }
@@ -36,7 +35,7 @@ which is the last selected currency in the DOM.
 displays '...' as a pseudo component of the 3rd currency and only when there's more than 3 selected.
 :nth-last-child(2) is used for the same reason as above
 */
-.select:not(.hideMultiSelect) :global(.react-select__multi-value):nth-child(3):not(:nth-last-child(2))::after {
+.select:not(.hideMultiSelect) :global(.react-select__multi-value):nth-child(3):not(:nth-last-child(3))::after {
     content: '\002026';
 }
 

--- a/frontends/web/src/routes/settings/components/dropdowns/activecurrenciesdropdown.tsx
+++ b/frontends/web/src/routes/settings/components/dropdowns/activecurrenciesdropdown.tsx
@@ -63,6 +63,7 @@ export const ActiveCurrenciesDropdown = ({
          ${dropdownStyles.select}
          ${activeCurrenciesDropdownStyle.select}
          ${search.length > 0 ? activeCurrenciesDropdownStyle.hideMultiSelect : ''}
+         ${formattedActiveCurrencies.length > 1 ? activeCurrenciesDropdownStyle.showComma : ''}
          `}
       classNamePrefix="react-select"
       isSearchable

--- a/frontends/web/src/routes/settings/components/dropdowns/dropdowns.module.css
+++ b/frontends/web/src/routes/settings/components/dropdowns/dropdowns.module.css
@@ -20,10 +20,6 @@
     color: var(--color-default);
 }
 
-.select :global(.react-select__option.react-select__option--is-focused):not(:hover) {
-    outline: solid 1px var(--color-blue);
-}
-
 .select :global(.react-select__option.react-select__option--is-selected),
 .select :global(.react-select__option):hover {
     background-color: var(--background-custom-select-selected);


### PR DESCRIPTION
also minor CSS fix on the active currencies dropdown. These are done to improve the UX. The standardised Intl is being used to follow best practices.