### PR TITLE
ci: downgrade nvm and install from github

### DIFF
--- a/scripts/github-ci.sh
+++ b/scripts/github-ci.sh
@@ -33,9 +33,10 @@ if [ "$OS_NAME" == "osx" ]; then
     # this script.
     go version
     brew install qt@5
-    brew install nvm
-    source /usr/local/opt/nvm/nvm.sh
-    nvm install 20 # install this node version
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+    export NVM_DIR="$HOME/.nvm"
+    source "$NVM_DIR/nvm.sh"
+    nvm install 20
     export PATH="/usr/local/opt/qt@5/bin:$PATH"
     export LDFLAGS="-L/usr/local/opt/qt@5/lib"
     export CPPFLAGS="-I/usr/local/opt/qt@5/include"


### PR DESCRIPTION
Downgrading to nvm v0.39.7, see this issue:
- https://github.com/nvm-sh/nvm/issues/3405

Homebrew installation is not supported, see:
- https://github.com/nvm-sh/nvm?tab=readme-ov-file#important-notes