### PR TITLE
frontend: hide taproot account info

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -26,6 +26,7 @@
     "extendedPublicKey": "Extended public key",
     "label": "Account info",
     "scriptType": "Script type",
+    "taproot": "The Taproot extended public key is not shown to protect from accidental misuse, as raw formats for this script type are not widely supported. If you want to view this key, connect your device to wallet software that supports the output descriptor format.",
     "title": "Account information",
     "verify": "Verify on device",
     "xpubTypeChangeBtn": {

--- a/frontends/web/src/routes/account/info/info.tsx
+++ b/frontends/web/src/routes/account/info/info.tsx
@@ -24,6 +24,7 @@ import { Header } from '@/components/layout';
 import { BackButton } from '@/components/backbutton/backbutton';
 import { SigningConfiguration } from './signingconfiguration';
 import { BitcoinBasedAccountInfoGuide } from './guide';
+import { Status } from '@/components/status/status';
 import style from './info.module.css';
 
 type TProps = {
@@ -80,16 +81,27 @@ export const Info = ({
                   </button>
                 </p>
               ) : null}
-              <SigningConfiguration
-                key={viewXPub}
-                account={account}
-                code={code}
-                info={config}
-                signingConfigIndex={viewXPub}>
-                <BackButton enableEsc>
-                  {t('button.back')}
-                </BackButton>
-              </SigningConfiguration>
+              { (config.bitcoinSimple?.scriptType === 'p2tr') ? (
+                <>
+                  <Status type="info">
+                    {t('accountInfo.taproot')}
+                  </Status>
+                  <BackButton enableEsc>
+                    {t('button.back')}
+                  </BackButton>
+                </>
+              ) : (
+                <SigningConfiguration
+                  key={viewXPub}
+                  account={account}
+                  code={code}
+                  info={config}
+                  signingConfigIndex={viewXPub}>
+                  <BackButton enableEsc>
+                    {t('button.back')}
+                  </BackButton>
+                </SigningConfiguration>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Using Taproot extended public keys in raw xpub format is not widely supported and can lead to dangerous misuse. This hides the Taproot extended public key and displays an info message instead.

Most wallets will default to P2PKH when scanning a raw P2TR xpub, resulting in a non-standard combination of script type and derivation path. Recovering funds sent to addresses like this is difficult and potentially unsafe for users, as the BitBox02 does not support spending from P2PKH outputs.

As long as the BitBoxApp does not support output descriptors, expert users should instead connect their device to other wallet software to view detailed account information.

<img width="987" alt="Screenshot 2024-08-21 at 09 37 27" src="https://github.com/user-attachments/assets/e72aeb04-f473-4b4d-8c1f-528d91801853">
