### PR TITLE
frontend/backend: pass final tx. note to `sendtx` and remove `propose-tx-note` handler

### DIFF
--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -74,8 +74,8 @@ type Interface interface {
 	// Must enforce that initial sync is done before returning.
 	Balance() (*Balance, error)
 	// SendTx signs and sends the active tx proposal, set by TxProposal. Errors if none
-	// available. The note, if set by ProposeTxNote(), is persisted for the transaction.
-	SendTx() error
+	// available.
+	SendTx(txNote string) error
 	FeeTargets() ([]FeeTarget, FeeTargetCode)
 	TxProposal(*TxProposalArgs) (coin.Amount, coin.Amount, coin.Amount, error)
 	// GetUnusedReceiveAddresses gets a list of list of receive addresses. The result can be one
@@ -87,9 +87,6 @@ type Interface interface {
 
 	Notes() *notes.Notes
 	TxNote(txID string) string
-	// ProposeTxnote stores a note. The note is persisted in the notes database upon calling
-	// SendTx(). This function must be called before `SendTx()`.
-	ProposeTxNote(string)
 	// SetTxNote sets a tx note and refreshes the account.
 	SetTxNote(txID string, note string) error
 

--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -72,9 +71,6 @@ type BaseAccount struct {
 
 	// notes handles transaction notes.
 	notes *notes.Notes
-
-	proposedTxNote   string
-	proposedTxNoteMu sync.Mutex
 
 	log *logrus.Entry
 }
@@ -223,25 +219,6 @@ func (account *BaseAccount) migrateLegacyNotes() error {
 		_ = os.Remove(notesFile)
 	}
 	return nil
-}
-
-// ProposeTxNote implements accounts.Account.
-func (account *BaseAccount) ProposeTxNote(note string) {
-	account.proposedTxNoteMu.Lock()
-	defer account.proposedTxNoteMu.Unlock()
-
-	account.proposedTxNote = note
-}
-
-// GetAndClearProposedTxNote returns the note previously set using ProposeTxNote(). If none was set,
-// the empty string is returned. The proposed note is cleared by calling this function.
-func (account *BaseAccount) GetAndClearProposedTxNote() string {
-	account.proposedTxNoteMu.Lock()
-	defer func() {
-		account.proposedTxNote = ""
-		account.proposedTxNoteMu.Unlock()
-	}()
-	return account.proposedTxNote
 }
 
 // SetTxNote implements accounts.Account.

--- a/backend/accounts/baseaccount_test.go
+++ b/backend/accounts/baseaccount_test.go
@@ -173,12 +173,6 @@ func TestBaseAccount(t *testing.T) {
 			require.True(t, os.IsNotExist(err))
 		}
 
-		require.Equal(t, "", account.GetAndClearProposedTxNote())
-		account.ProposeTxNote("test note")
-		require.Equal(t, "test note", account.GetAndClearProposedTxNote())
-		// Was cleared by the previous call.
-		require.Equal(t, "", account.GetAndClearProposedTxNote())
-
 		require.NoError(t, account.SetTxNote("test-tx-id", "another test note"))
 		require.Equal(t, types.EventStatusChanged, checkEvent())
 		require.Equal(t, "another test note", account.TxNote("test-tx-id"))

--- a/backend/accounts/mocks/account.go
+++ b/backend/accounts/mocks/account.go
@@ -73,7 +73,7 @@ var _ accounts.Interface = &InterfaceMock{}
 //			ProposeTxNoteFunc: func(s string)  {
 //				panic("mock out the ProposeTxNote method")
 //			},
-//			SendTxFunc: func() error {
+//			SendTxFunc: func(txNote string) error {
 //				panic("mock out the SendTx method")
 //			},
 //			SetTxNoteFunc: func(txID string, note string) error {
@@ -153,7 +153,7 @@ type InterfaceMock struct {
 	ProposeTxNoteFunc func(s string)
 
 	// SendTxFunc mocks the SendTx method.
-	SendTxFunc func() error
+	SendTxFunc func(txNote string) error
 
 	// SetTxNoteFunc mocks the SetTxNote method.
 	SetTxNoteFunc func(txID string, note string) error
@@ -771,7 +771,7 @@ func (mock *InterfaceMock) ProposeTxNoteCalls() []struct {
 }
 
 // SendTx calls SendTxFunc.
-func (mock *InterfaceMock) SendTx() error {
+func (mock *InterfaceMock) SendTx(txNote string) error {
 	if mock.SendTxFunc == nil {
 		panic("InterfaceMock.SendTxFunc: method is nil but Interface.SendTx was just called")
 	}
@@ -780,7 +780,7 @@ func (mock *InterfaceMock) SendTx() error {
 	mock.lockSendTx.Lock()
 	mock.calls.SendTx = append(mock.calls.SendTx, callInfo)
 	mock.lockSendTx.Unlock()
-	return mock.SendTxFunc()
+	return mock.SendTxFunc("")
 }
 
 // SendTxCalls gets all the calls that were made to SendTx.

--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -228,7 +228,7 @@ func (account *Account) getAddress(scriptHashHex blockchain.ScriptHashHex) *addr
 }
 
 // SendTx implements accounts.Interface.
-func (account *Account) SendTx() error {
+func (account *Account) SendTx(txNote string) error {
 	unlock := account.activeTxProposalLock.RLock()
 	txProposal := account.activeTxProposal
 	unlock()
@@ -246,8 +246,7 @@ func (account *Account) SendTx() error {
 		return err
 	}
 
-	note := account.BaseAccount.GetAndClearProposedTxNote()
-	if err := account.SetTxNote(txProposal.Transaction.TxHash().String(), note); err != nil {
+	if err := account.SetTxNote(txProposal.Transaction.TxHash().String(), txNote); err != nil {
 		// Not critical.
 		account.log.WithError(err).Error("Failed to save transaction note when sending a tx")
 	}

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -670,7 +670,7 @@ func (account *Account) storePendingOutgoingTransaction(transaction *types.Trans
 }
 
 // SendTx implements accounts.Interface.
-func (account *Account) SendTx() error {
+func (account *Account) SendTx(txNote string) error {
 	unlock := account.updateLock.RLock()
 	txProposal := account.activeTxProposal
 	unlock()
@@ -697,8 +697,7 @@ func (account *Account) SendTx() error {
 		return err
 	}
 
-	note := account.BaseAccount.GetAndClearProposedTxNote()
-	if err := account.SetTxNote(txProposal.Tx.Hash().Hex(), note); err != nil {
+	if err := account.SetTxNote(txProposal.Tx.Hash().Hex(), txNote); err != nil {
 		// Not critical.
 		account.log.WithError(err).Error("Failed to save transaction note when sending a tx")
 	}

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -264,10 +264,6 @@ export const postNotesTx = (code: AccountCode, {
   return apiPost(`account/${code}/notes/tx`, { internalTxID, note });
 };
 
-export const proposeTxNote = (code: AccountCode, note: string): Promise<null> => {
-  return apiPost(`account/${code}/propose-tx-note`, note);
-};
-
 export const getTransactionList = (code: AccountCode): Promise<TTransactions> => {
   return apiGet(`account/${code}/transactions`);
 };
@@ -342,8 +338,8 @@ export interface ISendTx {
     errorCode?: string;
 }
 
-export const sendTx = (code: AccountCode): Promise<ISendTx> => {
-  return apiPost(`account/${code}/sendtx`);
+export const sendTx = (code: AccountCode, txNote: string): Promise<ISendTx> => {
+  return apiPost(`account/${code}/sendtx`, txNote);
 };
 
 export type FeeTargetCode = 'custom' | 'low' | 'economy' | 'normal' | 'high';

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -159,8 +159,6 @@ class Send extends Component<Props, State> {
 
   public componentWillUnmount() {
     unsubscribe(this.unsubscribeList);
-    // Wipe proposed tx note.
-    accountApi.proposeTxNote(this.props.account.code, '');
   }
 
   private send = async () => {
@@ -176,7 +174,7 @@ class Send extends Component<Props, State> {
 
     this.setState({ signProgress: undefined, isConfirming: true });
     try {
-      const result = await accountApi.sendTx(code);
+      const result = await accountApi.sendTx(code, this.state.note);
       if (result.success) {
         this.setState({
           sendAll: false,
@@ -283,8 +281,6 @@ class Send extends Component<Props, State> {
     const target = event.target;
     this.setState({
       'note': target.value,
-    }, () => {
-      accountApi.proposeTxNote(this.props.account.code, this.state.note);
     });
   };
 


### PR DESCRIPTION
Noticed this when planning the refactor of (frontend) `send.tsx`, this PR does not change anything and should be a pure refactor.
- the `propose-tx-note` handler did nothing but setting a field on `BaseAccount` it did not validate anything, thus removing it and just using the final tx note reduces the code size but changes nothing.

We initially separated the note from the txProposal because we did not want to perform any actions when (e.g calculate fee) when user types a note:
https://github.com/BitBoxSwiss/bitbox-wallet-app/commit/4eb692c84351dbd23ae391e99ffd5d8452db08f7

It would be good to validate the note though to match the constrains here, but that would not be a refactor so maybe in another PR:
https://github.com/BitBoxSwiss/bitbox-wallet-app/blob/87d6219ddb566a52aa410c54cd75d63669e5cec6/backend/accounts/notes/notes.go#L92
