### PR TITLE
ci: install nodejs with github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
       - name: Build macOS app
         run: >
           ./scripts/github-ci.sh qt-osx;

--- a/scripts/github-ci.sh
+++ b/scripts/github-ci.sh
@@ -33,9 +33,6 @@ if [ "$OS_NAME" == "osx" ]; then
     # this script.
     go version
     brew install qt@5
-    brew install nvm
-    source /usr/local/opt/nvm/nvm.sh
-    nvm install 20 # install this node version
     export PATH="/usr/local/opt/qt@5/bin:$PATH"
     export LDFLAGS="-L/usr/local/opt/qt@5/lib"
     export CPPFLAGS="-I/usr/local/opt/qt@5/include"


### PR DESCRIPTION
Simplify nodejs setup, use GH actions instead of homebrew and nvm

https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-nodejs