### PR TITLE
frontend: remove redundant fiatUnit state in Send

### DIFF
--- a/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
@@ -71,7 +71,7 @@ export const BB02ConfirmSend = ({
     customFee,
     feeTarget,
     recipientAddress,
-    fiatUnit
+    activeCurrency: fiatUnit
   } = transactionDetails;
 
 
@@ -225,3 +225,4 @@ const FiatValue = ({ baseCurrencyUnit, amount }: TFiatValueProps) => {
   )
   ;
 };
+

--- a/frontends/web/src/routes/account/send/components/confirm/dialogs/confirm-wait-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/dialogs/confirm-wait-dialog.tsx
@@ -40,7 +40,7 @@ export const ConfirmingWaitDialog = ({
     customFee,
     feeTarget,
     recipientAddress,
-    fiatUnit
+    activeCurrency
   } = transactionDetails;
 
   if (!isConfirming) {
@@ -80,10 +80,10 @@ export const ConfirmingWaitDialog = ({
             <small>{(proposedAmount && proposedAmount.unit) || 'N/A'}</small>
           </span>
           {
-            proposedAmount && proposedAmount.conversions && proposedAmount.conversions[fiatUnit] && (
+            proposedAmount && proposedAmount.conversions && proposedAmount.conversions[activeCurrency] && (
               <span>
                 <span className="text-gray"> / </span>
-                <Amount alwaysShowAmounts amount={proposedAmount.conversions[fiatUnit]} unit={baseCurrencyUnit}/>
+                <Amount alwaysShowAmounts amount={proposedAmount.conversions[activeCurrency]} unit={baseCurrencyUnit}/>
                 {' '}<small>{baseCurrencyUnit}</small>
               </span>)
           }
@@ -104,10 +104,10 @@ export const ConfirmingWaitDialog = ({
             {' '}
             <small>{(proposedFee && proposedFee.unit) || 'N/A'}</small>
           </span>
-          {proposedFee && proposedFee.conversions && proposedFee.conversions[fiatUnit] && (
+          {proposedFee && proposedFee.conversions && proposedFee.conversions[activeCurrency] && (
             <span key="conversation">
               <span className="text-gray"> / </span>
-              <Amount alwaysShowAmounts amount={proposedFee.conversions[fiatUnit]} unit={baseCurrencyUnit}/>
+              <Amount alwaysShowAmounts amount={proposedFee.conversions[activeCurrency]} unit={baseCurrencyUnit}/>
               {' '}<small>{baseCurrencyUnit}</small>
             </span>
           )}
@@ -142,10 +142,10 @@ export const ConfirmingWaitDialog = ({
             {' '}
             <small>{(proposedTotal && proposedTotal.unit) || 'N/A'}</small>
           </span>
-          {(proposedTotal && proposedTotal.conversions) && proposedTotal.conversions[fiatUnit] && (
+          {(proposedTotal && proposedTotal.conversions) && proposedTotal.conversions[activeCurrency] && (
             <span>
               <span className="text-gray"> / </span>
-              <strong><Amount alwaysShowAmounts amount={proposedTotal.conversions[fiatUnit]} unit={baseCurrencyUnit}/></strong>
+              <strong><Amount alwaysShowAmounts amount={proposedTotal.conversions[activeCurrency]} unit={baseCurrencyUnit}/></strong>
               {' '}<small>{baseCurrencyUnit}</small>
             </span>
           )}
@@ -155,3 +155,4 @@ export const ConfirmingWaitDialog = ({
   )
   ;
 };
+

--- a/frontends/web/src/routes/account/send/components/confirm/types.ts
+++ b/frontends/web/src/routes/account/send/components/confirm/types.ts
@@ -31,7 +31,7 @@ export type TransactionDetails = {
     feeTarget?: FeeTargetCode;
     customFee: string;
     recipientAddress: string;
-    fiatUnit: Fiat;
+    activeCurrency: Fiat;
   }
 
 export type TConfirmSendProps = {
@@ -45,3 +45,4 @@ export type TConfirmSendProps = {
     transactionStatus: TransactionStatus;
     transactionDetails: TransactionDetails;
   }
+

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -66,7 +66,6 @@ export type State = {
     valid: boolean;
     amount: string;
     fiatAmount: string;
-    fiatUnit: accountApi.Fiat;
     sendAll: boolean;
     feeTarget?: accountApi.FeeTargetCode;
     customFee: string;
@@ -108,7 +107,6 @@ class Send extends Component<Props, State> {
     isAborted: false,
     isUpdatingProposal: false,
     noMobileChannelError: false,
-    fiatUnit: this.props.activeCurrency,
     coinControl: false,
     activeCoinControl: false,
     activeScanQR: false,
@@ -317,7 +315,7 @@ class Send extends Component<Props, State> {
       const data = await convertToCurrency({
         amount,
         coinCode,
-        fiatUnit: this.state.fiatUnit,
+        fiatUnit: this.props.activeCurrency,
       });
       if (data.success) {
         this.setState({ fiatAmount: data.fiatAmount });
@@ -335,7 +333,7 @@ class Send extends Component<Props, State> {
       const data = await convertFromCurrency({
         amount,
         coinCode,
-        fiatUnit: this.state.fiatUnit,
+        fiatUnit: this.props.activeCurrency,
       });
       if (data.success) {
         this.setState({ amount: data.amount }, () => this.validateAndDisplayFee(false));
@@ -448,7 +446,7 @@ class Send extends Component<Props, State> {
   };
 
   public render() {
-    const { account, t } = this.props;
+    const { account, activeCurrency, t } = this.props;
     const {
       balance,
       proposedFee,
@@ -459,7 +457,6 @@ class Send extends Component<Props, State> {
       amount,
       /* data, */
       fiatAmount,
-      fiatUnit,
       sendAll,
       feeTarget,
       customFee,
@@ -486,7 +483,7 @@ class Send extends Component<Props, State> {
       customFee,
       feeTarget,
       recipientAddress,
-      fiatUnit,
+      activeCurrency,
     };
 
     const waitDialogTransactionStatus = {
@@ -568,7 +565,7 @@ class Send extends Component<Props, State> {
                       disabled={sendAll}
                       error={amountError}
                       fiatAmount={fiatAmount}
-                      label={fiatUnit}
+                      label={activeCurrency}
                     />
                   </Column>
                 </Grid>
@@ -578,7 +575,7 @@ class Send extends Component<Props, State> {
                       accountCode={account.code}
                       coinCode={account.coinCode}
                       disabled={!amount && !sendAll}
-                      fiatUnit={fiatUnit}
+                      fiatUnit={activeCurrency}
                       proposedFee={proposedFee}
                       customFee={customFee}
                       showCalculatingFeeLabel={isUpdatingProposal}
@@ -614,7 +611,7 @@ class Send extends Component<Props, State> {
                 <ConfirmSend
                   device={device}
                   paired={paired}
-                  baseCurrencyUnit={fiatUnit}
+                  baseCurrencyUnit={activeCurrency}
                   note={note}
                   hasSelectedUTXOs={this.hasSelectedUTXOs()}
                   selectedUTXOs={Object.keys(this.selectedUTXOs)}


### PR DESCRIPTION
Remove the `fiatUnit` state in Send because it is redundant since we can access `this.props.activeCurrency` since this commit: 373b7e89a2cbf6d4cf8f51ac69743b9a7b4efd61

Small PR preparation for `send.tsx` refactor.