### PR TITLE
frontend: don't disable back-button in send

### DIFF
--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -605,7 +605,6 @@ class Send extends Component<Props, State> {
                         {t('send.button')}
                       </Button>
                       <BackButton
-                        disabled={activeCoinControl || activeScanQR}
                         enableEsc>
                         {t('button.back')}
                       </BackButton>


### PR DESCRIPTION
Don't disable the back button in send.tsx when a dialog/modal (QR scanner, or UTXO selection) is open. It is a UX best practice to do this when a modal is open **however** a) our dialog CSS creates an overlay which means nothing behind it can be clicked anyways, and b) the back button currently supports ESC which should close the modal but navigates back from the send route right now.

If we don't need the is-open state for these modals we can simplify the send component in another refactor by extracting coin control into its own sub-component (moving `activeCoinControl` there) and moving `activeScanQR` into `ReceiverAddressInput`.


This PR does not change anything because the back-button is not clickable because of the screen size (100%) overlay used:
https://github.com/BitBoxSwiss/bitbox-wallet-app/blob/bdf270c0bfc824f3dfda91176f76852eb4a524f7/frontends/web/src/components/dialog/dialog.module.css#L9-L12