### PR TITLE
frontend: move `activeScanQR` into `ReceiverAddressInput` sub-component

### DIFF
--- a/frontends/web/src/routes/account/send/components/inputs/receiver-address-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/receiver-address-input.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Shift Crypto AG
+ * Copyright 2023-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { ChangeEvent, useCallback, useContext } from 'react';
+import { ChangeEvent, useCallback, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { debug } from '@/utils/env';
 import { getReceiveAddressList } from '@/api/account';
+import { debug } from '@/utils/env';
 import { DarkModeContext } from '@/contexts/DarkmodeContext';
 import { Input } from '@/components/forms';
 import { QRCodeLight, QRCodeDark } from '@/components/icon';
@@ -33,9 +33,7 @@ type TReceiverAddressInputProps = {
     addressError?: string;
     onInputChange: (value: string) => void;
     recipientAddress: string;
-    activeScanQR: boolean;
     parseQRResult: (uri: string) => void;
-    onChangeActiveScanQR: (activeScanQR: boolean) => void
 }
 
 export const ScanQRButton = ({ onClick }: TToggleScanQRButtonProps) => {
@@ -51,11 +49,10 @@ export const ReceiverAddressInput = ({
   addressError,
   onInputChange,
   recipientAddress,
-  activeScanQR,
   parseQRResult,
-  onChangeActiveScanQR
 }: TReceiverAddressInputProps) => {
   const { t } = useTranslation();
+  const [activeScanQR, setActiveScanQR] = useState(false);
 
   const handleSendToSelf = useCallback(async () => {
     if (!accountCode) {
@@ -71,20 +68,16 @@ export const ReceiverAddressInput = ({
     }
   }, [accountCode, onInputChange]);
 
-  const toggleScanQR = useCallback(() => {
-    if (activeScanQR) {
-      onChangeActiveScanQR(false);
-      return;
-    }
-    onChangeActiveScanQR(true);
-  }, [activeScanQR, onChangeActiveScanQR]);
+  const toggleScanQR = () => {
+    setActiveScanQR(activeScanQR => !activeScanQR);
+  };
 
   return (
     <>
       {activeScanQR && (
         <ScanQRDialog
           toggleScanQR={toggleScanQR}
-          onChangeActiveScanQR={onChangeActiveScanQR}
+          onChangeActiveScanQR={setActiveScanQR}
           parseQRResult={parseQRResult}
         />
       )}

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -81,7 +81,6 @@ export type State = {
     signProgress?: TSignProgress;
     // show visual BitBox in dialog when instructed to sign.
     signConfirm: boolean;
-    activeScanQR: boolean;
     note: string;
 }
 
@@ -105,7 +104,6 @@ class Send extends Component<Props, State> {
     isAborted: false,
     isUpdatingProposal: false,
     noMobileChannelError: false,
-    activeScanQR: false,
     note: '',
     customFee: '',
   };
@@ -352,10 +350,6 @@ class Send extends Component<Props, State> {
     return Object.keys(this.selectedUTXOs).length !== 0;
   };
 
-  private setActiveScanQR = (activeScanQR: boolean) => {
-    this.setState({ activeScanQR });
-  };
-
   private parseQRResult = async (uri: string) => {
     let address;
     let amount = '';
@@ -447,7 +441,6 @@ class Send extends Component<Props, State> {
       paired,
       signProgress,
       signConfirm,
-      activeScanQR,
       note,
     } = this.state;
 
@@ -504,8 +497,6 @@ class Send extends Component<Props, State> {
                       onInputChange={this.onReceiverAddressInputChange}
                       recipientAddress={recipientAddress}
                       parseQRResult={this.parseQRResult}
-                      activeScanQR={activeScanQR}
-                      onChangeActiveScanQR={this.setActiveScanQR}
                     />
                   </Column>
                 </Grid>
@@ -561,7 +552,6 @@ class Send extends Component<Props, State> {
                         {t('send.button')}
                       </Button>
                       <BackButton
-                        disabled={activeScanQR}
                         enableEsc>
                         {t('button.back')}
                       </BackButton>


### PR DESCRIPTION
After #2870

In case #2870 is merged we can remove a lot of complexity from the open/closed state management of the scan QR dialog.

