### PR TITLE
btc: refactor sighashes

### DIFF
--- a/backend/coins/btc/maketx/maketx.go
+++ b/backend/coins/btc/maketx/maketx.go
@@ -29,6 +29,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/sirupsen/logrus"
 )
@@ -53,6 +54,11 @@ type TxProposal struct {
 	// ChangeAddress is the address of the wallet to which the change of the transaction is sent.
 	ChangeAddress   *addresses.AccountAddress
 	PreviousOutputs PreviousOutputs
+}
+
+// SigHashes computes the hashes cache to speed up per-input sighash computations.
+func (txProposal *TxProposal) SigHashes() *txscript.TxSigHashes {
+	return txscript.NewTxSigHashes(txProposal.Transaction, txProposal.PreviousOutputs)
 }
 
 // Total is amount+fee.

--- a/backend/coins/btc/sign.go
+++ b/backend/coins/btc/sign.go
@@ -36,7 +36,6 @@ type ProposedTransaction struct {
 	GetPrevTx                    func(chainhash.Hash) (*wire.MsgTx, error)
 	// Signatures collects the signatures, one per transaction input.
 	Signatures []*types.Signature
-	SigHashes  *txscript.TxSigHashes
 	FormatUnit coin.BtcUnit
 }
 
@@ -58,7 +57,6 @@ func (account *Account) signTransaction(
 		GetAccountAddress:            account.getAddress,
 		GetPrevTx:                    getPrevTx,
 		Signatures:                   make([]*types.Signature, len(txProposal.Transaction.TxIn)),
-		SigHashes:                    txscript.NewTxSigHashes(txProposal.Transaction, previousOutputs),
 		FormatUnit:                   account.coin.formatUnit,
 	}
 
@@ -82,7 +80,7 @@ func (account *Account) signTransaction(
 
 	// Sanity check: see if the created transaction is valid.
 	if err := txValidityCheck(txProposal.Transaction, previousOutputs,
-		proposedTransaction.SigHashes); err != nil {
+		txProposal.SigHashes()); err != nil {
 		account.log.WithError(err).Panic("Failed to pass transaction validity check.")
 	}
 

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -154,6 +154,7 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 	signatureHashes := [][]byte{}
 	keyPaths := []string{}
 	transaction := btcProposedTx.TXProposal.Transaction
+	sigHashes := btcProposedTx.TXProposal.SigHashes()
 	for index, txIn := range transaction.TxIn {
 		spentOutput, ok := btcProposedTx.TXProposal.PreviousOutputs[txIn.PreviousOutPoint]
 		if !ok {
@@ -165,7 +166,7 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 		var signatureHash []byte
 		if isSegwit {
 			var err error
-			signatureHash, err = txscript.CalcWitnessSigHash(subScript, btcProposedTx.SigHashes,
+			signatureHash, err = txscript.CalcWitnessSigHash(subScript, sigHashes,
 				txscript.SigHashAll, transaction, index, spentOutput.Value)
 			if err != nil {
 				return errp.Wrap(err, "Failed to calculate SegWit signature hash")

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -191,6 +191,7 @@ func (keystore *Keystore) SignTransaction(
 	keystore.log.Info("Sign transaction.")
 	transaction := btcProposedTx.TXProposal.Transaction
 	signatures := make([]*types.Signature, len(transaction.TxIn))
+	sigHashes := btcProposedTx.TXProposal.SigHashes()
 	for index, txIn := range transaction.TxIn {
 		spentOutput, ok := btcProposedTx.TXProposal.PreviousOutputs[txIn.PreviousOutPoint]
 		if !ok {
@@ -211,7 +212,7 @@ func (keystore *Keystore) SignTransaction(
 		if address.Configuration.ScriptType() == signing.ScriptTypeP2TR {
 			prv = txscript.TweakTaprootPrivKey(*prv, nil)
 			signatureHash, err := txscript.CalcTaprootSignatureHash(
-				btcProposedTx.SigHashes, txscript.SigHashDefault, transaction,
+				sigHashes, txscript.SigHashDefault, transaction,
 				index, btcProposedTx.TXProposal.PreviousOutputs)
 			if err != nil {
 				return errp.Wrap(err, "Failed to calculate Taproot signature hash")
@@ -231,7 +232,7 @@ func (keystore *Keystore) SignTransaction(
 			isSegwit, subScript := address.ScriptForHashToSign()
 			if isSegwit {
 				var err error
-				signatureHash, err = txscript.CalcWitnessSigHash(subScript, btcProposedTx.SigHashes,
+				signatureHash, err = txscript.CalcWitnessSigHash(subScript, sigHashes,
 					txscript.SigHashAll, transaction, index, spentOutput.Value)
 				if err != nil {
 					return errp.Wrap(err, "Failed to calculate SegWit signature hash")


### PR DESCRIPTION
The SigHashes struct is a precomputation of hashes to speed up the computation of per-input sighashes. The idea is to compute it once, not per-input.

We made the instance after creating the tx, before signing it. This works fine, but with Silent Payments (BIP-352), the signer also modifies the transaction: it generates the silent payment output.

THe pre-computed sighashes are not valid in that case, as the transaction changes afterwards. We simply fix this by creating the instance after signing in the BitBox02 (which will support silent payments), and use it as before in the other keystores.