### PR TITLE
frontend: remove "Security Model" from exchange guide

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1025,7 +1025,7 @@
       "accountSummary": "Account summary guide",
       "advancedSettings": "Advanced settings guide",
       "appearance": "Appearance guide",
-      "buy": "Buy guide",
+      "exchange": "Exchange guide",
       "insurance": "Insurance guide",
       "manageAccount": "Manage accounts guide",
       "manageDevice": "Manage device guide",

--- a/frontends/web/src/routes/exchange/guide.tsx
+++ b/frontends/web/src/routes/exchange/guide.tsx
@@ -39,17 +39,7 @@ export const ExchangeGuide = ({ exchange, translationContext }: BuyGuideProps) =
   const privacyLink = exchange === 'pocket' ? pocketLink : moonpayLink;
 
   return (
-    <Guide title={t('guide.guideTitle.buy')}>
-      <Entry key="guide.buy.security" entry={{
-        link: {
-          text: t('buy.info.disclaimer.security.link'),
-          url: 'https://bitbox.swiss/bitbox02/threat-model/',
-        },
-        text: t('buy.info.disclaimer.security.descriptionGeneric', {
-          context: translationContext
-        }),
-        title: t('buy.info.disclaimer.security.title'),
-      }} shown={true} />
+    <Guide title={t('guide.guideTitle.exchange')}>
       <Entry key="guide.buy.protection" entry={{
         link: exchange ? privacyLink : undefined,
         text: t('buy.info.disclaimer.protection.descriptionGeneric', { context: translationContext }),


### PR DESCRIPTION
The text is different depending on what service you use, and if one buys or sells. Each service already has the security model text in its disclaimer.

Also changed from "Buy Guide" to "Exchange guide" 

<img width="1483" alt="gfea" src="https://github.com/user-attachments/assets/61f2fa4f-0aaf-4232-a461-2fadb13dee35">
