### PR TITLE
backend: update to version 4.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 ## Unreleased
-- Add support for selling Bitcoin to Pocket using SLIP-0024 payment requests
+
+## 4.44.0
+- Add support for selling bitcoin in-app via Pocket
+- Android: make Android back button go back instead of closing the app
 
 ## 4.43.0
 - Bundle BitBox02 firmware version v9.19.0

--- a/backend/update.go
+++ b/backend/update.go
@@ -27,7 +27,7 @@ const updateFileURL = "https://bitboxapp.shiftcrypto.io/desktop.json"
 
 var (
 	// Version of the backend as displayed to the user.
-	Version = semver.NewSemVer(4, 43, 0)
+	Version = semver.NewSemVer(4, 44, 0)
 )
 
 // UpdateFile is retrieved from the server.

--- a/frontends/android/BitBoxApp/app/build.gradle
+++ b/frontends/android/BitBoxApp/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "ch.shiftcrypto.bitboxapp"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 51
-        versionName "android-4.43.0"
+        versionCode 52
+        versionName "android-4.44.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/frontends/qt/Makefile
+++ b/frontends/qt/Makefile
@@ -38,8 +38,8 @@ linux:
 	cp resources/linux/usr/share/icons/hicolor/128x128/apps/bitbox.png build/linux-tmp
 	mkdir build/tmp-deb/opt/
 	cp -aR build/linux-tmp build/tmp-deb/opt/bitbox
-	cd build/linux && fpm --after-install ../../resources/deb-afterinstall.sh -s dir -t deb -n bitbox -v 4.43.0 -C ../tmp-deb/
-	cd build/linux && fpm --after-install ../../resources/deb-afterinstall.sh -s dir -t rpm -n bitbox -v 4.43.0 -C ../tmp-deb/
+	cd build/linux && fpm --after-install ../../resources/deb-afterinstall.sh -s dir -t deb -n bitbox -v 4.44.0 -C ../tmp-deb/
+	cd build/linux && fpm --after-install ../../resources/deb-afterinstall.sh -s dir -t rpm -n bitbox -v 4.44.0 -C ../tmp-deb/
 	# create AppImage
 	cd build/linux-tmp && /opt/linuxdeployqt-7-x86_64.AppImage BitBox -appimage -unsupported-allow-new-glibc
 	mv build/linux-tmp/BitBoxApp-*-x86_64.AppImage build/linux/

--- a/frontends/qt/resources/MacOS/Info.plist
+++ b/frontends/qt/resources/MacOS/Info.plist
@@ -21,10 +21,10 @@
 	<string>APPL</string>
 
 	<key>CFBundleVersion</key>
-	<string>4.43.0</string>
+	<string>4.44.0</string>
 
 	<key>CFBundleShortVersionString</key>
-	<string>4.43.0</string>
+	<string>4.44.0</string>
 
 	<key>CFBundleSignature</key>
 	<string>????</string>

--- a/frontends/qt/setup.nsi
+++ b/frontends/qt/setup.nsi
@@ -22,7 +22,7 @@ SetCompressor /SOLID lzma
 
 # General Symbol Definitions
 !define REGKEY "SOFTWARE\$(^Name)"
-!define VERSION 4.43.0.0
+!define VERSION 4.44.0.0
 !define COMPANY "Shift Crypto AG"
 !define URL https://github.com/BitBoxSwiss/bitbox-wallet-app/releases/
 !define BINDIR "build\windows"


### PR DESCRIPTION
Added missing CHANGELOG entry.
Reworded the Pocket sell CHANGELOG entry, the technical detail is unimportant for the release note. Also the BTC are not sold *to* Pocket, but Pocket sells it for the customer as a broker.