### PR TITLE
ci: waste less cycles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@
 # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
 name: ci
 on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # Use alternative image when running on GitHub workflows CI to avoid potential
   # rate limiting when executing jobs in parallel: they can't cache docker images


### PR DESCRIPTION
When a pull request is updated or a branch is being pushed to and a new job is created, cancel any currently running job.