### PR TITLE
ios: embed and sign mobileserver framework

### DIFF
--- a/frontends/ios/BitBoxApp/BitBoxApp.xcodeproj/project.pbxproj
+++ b/frontends/ios/BitBoxApp/BitBoxApp.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D705EF422B601E7400CAC90C /* Mobileserver.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D76518BB2B1F8F7400DC03A9 /* Mobileserver.xcframework */; };
+		D700B5F62C884C34000496D4 /* Mobileserver.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D76518BB2B1F8F7400DC03A9 /* Mobileserver.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D76516092B1F3B1300DC03A9 /* BitBoxAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76516082B1F3B1300DC03A9 /* BitBoxAppApp.swift */; };
 		D765160D2B1F3B1500DC03A9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D765160C2B1F3B1500DC03A9 /* Assets.xcassets */; };
 		D76516102B1F3B1500DC03A9 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D765160F2B1F3B1500DC03A9 /* Preview Assets.xcassets */; };
@@ -36,6 +36,20 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		D700B5F72C884C34000496D4 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				D700B5F62C884C34000496D4 /* Mobileserver.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		D76516052B1F3B1300DC03A9 /* BitBoxApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BitBoxApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D76516082B1F3B1300DC03A9 /* BitBoxAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitBoxAppApp.swift; sourceTree = "<group>"; };
@@ -57,7 +71,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D705EF422B601E7400CAC90C /* Mobileserver.xcframework in Frameworks */,
 				D76518C22B1F911700DC03A9 /* libresolv.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -157,6 +170,7 @@
 				D76516012B1F3B1300DC03A9 /* Sources */,
 				D76516022B1F3B1300DC03A9 /* Frameworks */,
 				D76516032B1F3B1300DC03A9 /* Resources */,
+				D700B5F72C884C34000496D4 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
This was previously not possible as gomobile had output an invalid framework. This was fixwed in
https://github.com/golang/mobile/commit/268e6c3a80d13e6acfd3b93ef02c3e2605e1ef46, so we're good now.

This is required to run the app on actual devices and publish it.