### PR TITLE
frontend: move sign confirm and sign progress to sub component

### DIFF
--- a/frontends/web/src/api/devicessync.ts
+++ b/frontends/web/src/api/devicessync.ts
@@ -83,7 +83,7 @@ export type TSignProgress = {
   step: number;
 }
 
-export const signProgress = (
+export const syncSignProgress = (
   cb: (progress: TSignProgress) => void
 ): TUnsubscribe => {
   const unsubscribe = subscribeLegacy('signProgress', event => {

--- a/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ConversionUnit } from '@/api/account';
-import { syncSignProgress, TSignProgress } from '@/api/devicessync';
 import { Amount } from '@/components/amount/amount';
 import { customFeeUnit } from '@/routes/account/utils';
 import { View, ViewContent, ViewHeader } from '@/components/view/view';
@@ -62,7 +60,6 @@ export const BB02ConfirmSend = ({
 }: Omit<TConfirmSendProps, 'device'>) => {
 
   const { t } = useTranslation();
-  const [signProgress, setSignProgress] = useState<TSignProgress>();
   const {
     proposedFee,
     proposedAmount,
@@ -72,33 +69,6 @@ export const BB02ConfirmSend = ({
     recipientAddress,
     activeCurrency: fiatUnit
   } = transactionDetails;
-
-  // Reset the signProgress state every time the dialog was closed (after send/abort).
-  const [prevIsConfirming, setPrevIsConfirming] = useState(isConfirming);
-  if (prevIsConfirming != isConfirming) {
-    setPrevIsConfirming(isConfirming);
-    if (!isConfirming) {
-      setSignProgress(undefined);
-    }
-  }
-
-  useEffect(() => {
-    return syncSignProgress((progress) => setSignProgress(progress));
-  }, []);
-
-  const confirmPrequel = (signProgress && signProgress.steps > 0) ? (
-    <div className="m-top-none m-bottom-half">
-      <span>
-        {
-          t('send.signprogress.description', {
-            steps: signProgress.steps.toString(),
-          })
-        }
-        <br />
-        {t('send.signprogress.label')}: {signProgress.step}/{signProgress.steps}
-      </span>
-    </div>
-  ) : undefined;
 
 
   if (!isConfirming) {
@@ -114,7 +84,6 @@ export const BB02ConfirmSend = ({
     <View fullscreen width="740px">
       <ViewHeader title={<div className={style.title}>{t('send.confirm.title')}</div>} />
       <ViewContent>
-        {confirmPrequel}
         <Message type="info">
           {t('send.confirm.infoMessage')}
         </Message>

--- a/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ConversionUnit } from '@/api/account';
+import { syncSignProgress, TSignProgress } from '@/api/devicessync';
 import { Amount } from '@/components/amount/amount';
 import { customFeeUnit } from '@/routes/account/utils';
 import { View, ViewContent, ViewHeader } from '@/components/view/view';
@@ -53,14 +55,14 @@ export const BB02ConfirmSend = ({
   baseCurrencyUnit,
   note,
   hasSelectedUTXOs,
+  isConfirming,
   selectedUTXOs,
   coinCode,
-  transactionStatus,
   transactionDetails
 }: Omit<TConfirmSendProps, 'device'>) => {
 
   const { t } = useTranslation();
-  const { isConfirming, signProgress } = transactionStatus;
+  const [signProgress, setSignProgress] = useState<TSignProgress>();
   const {
     proposedFee,
     proposedAmount,
@@ -71,6 +73,18 @@ export const BB02ConfirmSend = ({
     activeCurrency: fiatUnit
   } = transactionDetails;
 
+  // Reset the signProgress state every time the dialog was closed (after send/abort).
+  const [prevIsConfirming, setPrevIsConfirming] = useState(isConfirming);
+  if (prevIsConfirming != isConfirming) {
+    setPrevIsConfirming(isConfirming);
+    if (!isConfirming) {
+      setSignProgress(undefined);
+    }
+  }
+
+  useEffect(() => {
+    return syncSignProgress((progress) => setSignProgress(progress));
+  }, []);
 
   const confirmPrequel = (signProgress && signProgress.steps > 0) ? (
     <div className="m-top-none m-bottom-half">

--- a/frontends/web/src/routes/account/send/components/confirm/dialogs/confirm-wait-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/dialogs/confirm-wait-dialog.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { syncSignProgress, TSignProgress } from '@/api/devicessync';
 import { WaitDialog } from '@/components/wait-dialog/wait-dialog';
 import { Amount } from '@/components/amount/amount';
 import { customFeeUnit } from '@/routes/account/utils';
@@ -25,13 +27,14 @@ export const ConfirmingWaitDialog = ({
   baseCurrencyUnit,
   note,
   hasSelectedUTXOs,
+  isConfirming,
   selectedUTXOs,
   coinCode,
-  transactionStatus,
   transactionDetails
 }: Omit<TConfirmSendProps, 'device'>) => {
   const { t } = useTranslation();
-  const { isConfirming, signProgress } = transactionStatus;
+  const [signProgress, setSignProgress] = useState<TSignProgress>();
+
   const {
     proposedFee,
     proposedAmount,
@@ -41,6 +44,19 @@ export const ConfirmingWaitDialog = ({
     recipientAddress,
     activeCurrency
   } = transactionDetails;
+
+  // Reset the signProgress state every time the dialog was closed (after send/abort).
+  const [prevIsConfirming, setPrevIsConfirming] = useState(isConfirming);
+  if (prevIsConfirming != isConfirming) {
+    setPrevIsConfirming(isConfirming);
+    if (!isConfirming) {
+      setSignProgress(undefined);
+    }
+  }
+
+  useEffect(() => {
+    return syncSignProgress(setSignProgress);
+  }, []);
 
   if (!isConfirming) {
     return null;

--- a/frontends/web/src/routes/account/send/components/confirm/types.ts
+++ b/frontends/web/src/routes/account/send/components/confirm/types.ts
@@ -16,12 +16,6 @@
 
 import { ConversionUnit, CoinCode, FeeTargetCode, Fiat, IAmount } from '@/api/account';
 import { TProductName } from '@/api/devices';
-import { TSignProgress } from '@/api/devicessync';
-
-export type TransactionStatus = {
-    isConfirming: boolean;
-    signProgress?: TSignProgress;
-  }
 
 export type TransactionDetails = {
     proposedAmount?: IAmount;
@@ -38,9 +32,9 @@ export type TConfirmSendProps = {
     baseCurrencyUnit: ConversionUnit;
     note: string;
     hasSelectedUTXOs: boolean;
+    isConfirming: boolean;
     selectedUTXOs: string[];
     coinCode: CoinCode;
-    transactionStatus: TransactionStatus;
     transactionDetails: TransactionDetails;
   }
 


### PR DESCRIPTION
Move `signProgress` and `signConfirm` into the `ConfirmingWaitDialog`
and `BB02ConfirmSend` sub-components of the `ConfirmSend` sub-component
in `send.tsx`. This simplifies the `Send` component, makes it easier to
understand and is also better separation of bb01 and bb02 stuff.