### PR TITLE
frontend: put send request result in `Send` state

### DIFF
--- a/frontends/web/src/routes/account/send/components/dialogs/message-wait-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/dialogs/message-wait-dialog.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { ISendTx } from '@/api/account';
 import { Cancel, Checked } from '@/components/icon/icon';
 import { WaitDialog } from '@/components/wait-dialog/wait-dialog';
+import { alertUser } from '@/components/alert/Alert';
 
 type TProps = {
     result: ISendTx | undefined;
@@ -11,6 +12,22 @@ export const MessageWaitDialog = ({ result }: TProps) => {
   const { t } = useTranslation();
 
   if (!result) {
+    return null;
+  }
+
+  if (!result.aborted && !result.success) {
+    switch (result.errorCode) {
+    case 'erc20InsufficientGasFunds':
+      alertUser(t(`send.error.${result.errorCode}`));
+      break;
+    default:
+      const { errorMessage } = result;
+      if (errorMessage) {
+        alertUser(t('unknownError', { errorMessage }));
+      } else {
+        alertUser(t('unknownError'));
+      }
+    }
     return null;
   }
   return (

--- a/frontends/web/src/routes/account/send/components/dialogs/message-wait-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/dialogs/message-wait-dialog.tsx
@@ -1,50 +1,34 @@
 import { useTranslation } from 'react-i18next';
+import { ISendTx } from '@/api/account';
 import { Cancel, Checked } from '@/components/icon/icon';
 import { WaitDialog } from '@/components/wait-dialog/wait-dialog';
 
 type TProps = {
-    isShown: boolean;
-    messageType: 'sent' | 'abort';
+    result: ISendTx | undefined;
 }
 
-type TIconProps = {
-    messageType: TProps['messageType']
-}
+export const MessageWaitDialog = ({ result }: TProps) => {
+  const { t } = useTranslation();
 
-export const MessageWaitDialog = ({ isShown, messageType }: TProps) => {
-
-  if (!isShown) {
+  if (!result) {
     return null;
   }
   return (
     <WaitDialog>
       <div className="flex flex-row flex-center flex-items-center">
-        <IconAndMessage messageType={messageType} />
+        {result.success && (
+          <>
+            <Checked style={{ height: 18, marginRight: '1rem' }} />
+            {t('send.success')}
+          </>
+        )}
+        {result.aborted && (
+          <>
+            <Cancel alt="Abort" style={{ height: 18, marginRight: '1rem' }} />
+            {t('send.abort')}
+          </>
+        )}
       </div>
     </WaitDialog>
   );
 };
-
-const IconAndMessage = ({ messageType }: TIconProps) => {
-  const { t } = useTranslation();
-  switch (messageType) {
-  case 'sent':
-    return (
-      <>
-        <Checked style={{ height: 18, marginRight: '1rem' }} />
-        {t('send.success')}
-      </>
-    );
-  case 'abort':
-    return (
-      <>
-        <Cancel alt="Abort" style={{ height: 18, marginRight: '1rem' }} />
-        {t('send.abort')}
-      </>
-    );
-  default:
-    return null;
-  }
-};
-
-

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -169,11 +169,8 @@ class Send extends Component<Props, State> {
     this.setState({ signProgress: undefined, isConfirming: true });
     try {
       const result = await accountApi.sendTx(code, this.state.note);
-      this.setState({ sendResult: result });
-      setTimeout(() => this.setState({
-        sendResult: undefined,
-        isConfirming: false,
-      }), 5000);
+      this.setState({ sendResult: result, isConfirming: false });
+      setTimeout(() => this.setState({ sendResult: undefined }), 5000);
       if (result.success) {
         this.setState({
           sendAll: false,
@@ -188,19 +185,6 @@ class Send extends Component<Props, State> {
           customFee: '',
         });
         this.selectedUTXOs = {};
-      } else if (result.errorCode) {
-        switch (result.errorCode) {
-        case 'erc20InsufficientGasFunds':
-          alertUser(this.props.t(`send.error.${result.errorCode}`));
-          break;
-        default:
-          const { errorMessage } = result;
-          if (errorMessage) {
-            alertUser(this.props.t('unknownError', { errorMessage }));
-          } else {
-            alertUser(this.props.t('unknownError'));
-          }
-        }
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
Put the result from the send request into the `Send` components state and use it directly instead of `isSent` and `isAborted`. This simplifies the component and will make the refactor to a functional component easier because we'll be able to use a `useEffect` with a dependncy on the `sendResult` state that can `switch` over it and also reset the form.