### PR TITLE
backend/bitbox02: payment requests only from v9.20

### DIFF
--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -630,7 +630,7 @@ func (keystore *keystore) SupportsEIP1559() bool {
 
 // SupportsPaymentRequests implements keystore.Keystore.
 func (keystore *keystore) SupportsPaymentRequests() error {
-	if keystore.device.Version().AtLeast(semver.NewSemVer(9, 19, 0)) {
+	if keystore.device.Version().AtLeast(semver.NewSemVer(9, 20, 0)) {
 		return nil
 	}
 	return keystorePkg.ErrFirmwareUpgradeRequired


### PR DESCRIPTION
v9.19 had a version too, but we modified it in a breaking change (new payment request identifier for Pocket), so v9.19 would not actually work with the Pocket widget.