### PR TITLE
frontend: fix styling for incoming unit

### DIFF
--- a/frontends/web/src/components/rates/rates.module.css
+++ b/frontends/web/src/components/rates/rates.module.css
@@ -30,8 +30,9 @@
 }
 
 .rotatable {
-    position: relative;
     cursor: default;
+    font-size: inherit;
+    position: relative;
 }
 
 .rotatable::after { 


### PR DESCRIPTION
The rotateable unit of the incoming fiat was rendered in a larger font-size than the rest of the incoming text.

Setting the font-size to inherit fixes this issue and renders the whole message with the same font-size.