### PR TITLE
backend: increase API response size limit for available countries

### DIFF
--- a/backend/exchanges/moonpay.go
+++ b/backend/exchanges/moonpay.go
@@ -102,7 +102,7 @@ func GetMoonpaySupportedRegions(httpClient *http.Client) (map[string]BuyMoonpayR
 	var regionsList []BuyMoonpayRegion
 	endpoint := fmt.Sprintf("%s/countries", moonpayAPILiveURL)
 
-	_, err := util.APIGet(httpClient, endpoint, "", 81920, &regionsList)
+	_, err := util.APIGet(httpClient, endpoint, "", 1000000, &regionsList)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/exchanges/pocket.go
+++ b/backend/exchanges/pocket.go
@@ -98,7 +98,7 @@ func GetPocketSupportedRegions(httpClient *http.Client) (map[string]PocketRegion
 	var regionsList []PocketRegion
 	endpoint := fmt.Sprintf("%s/availabilities", pocketAPILiveURL)
 
-	_, err := util.APIGet(httpClient, endpoint, "", 81920, &regionsList)
+	_, err := util.APIGet(httpClient, endpoint, "", 1000000, &regionsList)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The previous limit of 81,920 bytes caused issues due to increased response sizes, likely due to additional countries or fields in the JSON data. This change increases the limit to 100,000 bytes to accommodate current data and provide a buffer for future growth.