### PR TITLE
frontend: remove i18n placeholder in error messages

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -694,8 +694,8 @@
   },
   "exchange": {
     "buySell": {
-      "coinNotSupported": "No {{action}} options available for this coin type.",
-      "regionNotSupported": "No {{action}} options available for this region.",
+      "coinNotSupported": "No options available for this coin type.",
+      "regionNotSupported": "No options available for this region.",
       "updateNow": "Update now"
     },
     "pocket": {

--- a/frontends/web/src/routes/exchange/components/buysell.tsx
+++ b/frontends/web/src/routes/exchange/components/buysell.tsx
@@ -73,10 +73,10 @@ export const BuySell = ({
     }
   }, [exchangeDealsResponse, onSelectExchange]);
 
-  const constructErrorMessage = (action: exchangesAPI.TExchangeAction): string | undefined => {
+  const constructErrorMessage = (): string | undefined => {
     if (exchangeDealsResponse?.success === false) {
       if (exchangeDealsResponse.errorCode) {
-        return t('exchange.buySell.' + exchangeDealsResponse.errorCode, { action });
+        return t('exchange.buySell.' + exchangeDealsResponse.errorCode);
       }
       return exchangeDealsResponse.errorMessage;
     } else if (paymentRequestError) {
@@ -100,7 +100,7 @@ export const BuySell = ({
         {!exchangeDealsResponse && <Skeleton/> }
         {exchangeDealsResponse?.success === false || paymentRequestError ? (
           <div className="flex flex-column">
-            <p className={style.noExchangeText}>{constructErrorMessage(action)}</p>
+            <p className={style.noExchangeText}>{constructErrorMessage()}</p>
             {exchangeDealsResponse?.success &&
               paymentRequestError &&
               hasPaymentRequestResponse?.errorCode === 'firmwareUpgradeRequired' &&


### PR DESCRIPTION
These error messages should use context so that the whole message can be translated for each language.

Adding a placeholder does often not work in every langauge and the term 'buy' or 'sell' was not translatable in this case.

Removed the action placeholder for these messages, this needs to be updated in locize as well in all langauges.