### PR TITLE
frontend: fix button fontsize on mobile

### DIFF
--- a/frontends/web/src/routes/account/account.module.css
+++ b/frontends/web/src/routes/account/account.module.css
@@ -118,11 +118,10 @@
 
     }
 
+    .exchange,
     .send,
     .receive,
-    .buy,
-    .walletConnect
-    {
+    .walletConnect {
         font-size: var(--size-small);
         margin-bottom: 0;
         width: auto;


### PR DESCRIPTION
On small screens the Buy&sell button font size is larger than the other buttons, this is probably a regression that was introduced by some renaming.