### PR TITLE
backend/btc: track output index, simplify code

### DIFF
--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -46,8 +46,6 @@ type PaymentRequest struct {
 	Nonce         []byte
 	TotalAmount   uint64
 	Signature     []byte
-	// TxOut is a pointer to the TxOut which will satisfay the payment request.
-	TxOut *wire.TxOut
 }
 
 // TxProposalArgs are the arguments needed when creating a tx proposal.

--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -220,7 +220,6 @@ func (account *Account) newTx(args *accounts.TxProposalArgs) (
 
 		if args.PaymentRequest != nil {
 			account.log.Info("Payment request tx proposal")
-			args.PaymentRequest.TxOut = txOut
 			txProposal.PaymentRequest = args.PaymentRequest
 		}
 	}

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -461,12 +461,7 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 			newBTCPaymentRequest(paymentRequest),
 		}
 		prIndex := uint32(0)
-		for outIndex, txOut := range tx.TxOut {
-			if paymentRequest.TxOut == txOut {
-				// outputs indexing is the same as tx.TxOut
-				outputs[outIndex].PaymentRequestIndex = &prIndex
-			}
-		}
+		outputs[btcProposedTx.TXProposal.OutIndex].PaymentRequestIndex = &prIndex
 	}
 
 	signatures, err := keystore.device.BTCSign(


### PR DESCRIPTION
The tx proposal arg payment request had a pointer to the transaction output it is attached to.

This is the wrong location to add this pointer, as the tx proposal args don't contain this info - it is left empty when parsing the args in btc/handlers.

The proper location for it is in the tx proposal itself. However, it's simpler to just generically track the index of the recipient output. Pointers seem brittle (a hard copy would break this). We also only support one recipient output, and this is not likely to change.

Furthermore, we want to attach more metadata to the recipient output later (silent payment address), so one way to track the index for all cases is simpler.