### PR TITLE
prevent sleep on macOS during long running queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Bitcoin: add support for sending to silent payment (BIP-352) addresses
+- Prevent macOS from going to sleep on long running interactions with the BitBox
 
 ## 4.44.0
 - Bundle BitBox02 firmware version v9.20.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/BitBoxSwiss/bitbox-wallet-app
 go 1.22
 
 require (
-	github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20240918121853-2221e9876d20
+	github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20240925080402-a2115fee878e
 	github.com/BitBoxSwiss/block-client-go v0.0.0-20240516081043-0d604acd6519
 	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20240918121853-2221e9876d20 h1:ZXqJmnQtmF9p1AmK0TMSBjAxUkZXfyMS5NRGO6L49pA=
-github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20240918121853-2221e9876d20/go.mod h1:Wzc1QpS2F8aV+8mZOfrrKA+D15byCzGRTGFkSRJC8J8=
+github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20240925080402-a2115fee878e h1:wEIIFhiZ58RsVjoKfwSBBD0i75uZ7KATOI/elaBWOOY=
+github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20240925080402-a2115fee878e/go.mod h1:Spf6hQRSylrvdjd7Cv4Tc8rFwlcamJAC8EuA61ARy7U=
 github.com/BitBoxSwiss/block-client-go v0.0.0-20240516081043-0d604acd6519 h1:diVA/i8TJFBl9ZyMNX15KjZBpI2Gu63xQTozu6FsTrA=
 github.com/BitBoxSwiss/block-client-go v0.0.0-20240516081043-0d604acd6519/go.mod h1:SJTiQZU9ggBzVKMni97rpNS9GddPKErndFXNSDrfEGc=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/util/sleep/sleep.go
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/util/sleep/sleep.go
@@ -1,0 +1,25 @@
+// Copyright 2024 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !darwin || ios || nosleep
+
+package sleep
+
+// Prevent is a no-op on non macOS platforms or when nosleep is configured.
+func Prevent() {
+}
+
+// Allow is a no-op on non macOS platforms or when nosleep is configured.
+func Allow() {
+}

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/util/sleep/sleep_macos.go
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/util/sleep/sleep_macos.go
@@ -1,0 +1,55 @@
+// Copyright 2024 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin && !ios && !nosleep
+
+package sleep
+
+/*
+#cgo LDFLAGS: -framework IOKit
+#include <IOKit/pwr_mgt/IOPMLib.h>
+#include <IOKit/IOReturn.h>
+#include <stdbool.h>
+
+static IOPMAssertionID _assertionID;
+static bool _assertionCreated = false;
+void preventSleep() {
+    if (_assertionCreated) {
+        return;
+    }
+    IOReturn success = IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep, kIOPMAssertionLevelOn, CFSTR("Prevent Sleep"), &_assertionID);
+    if (success == kIOReturnSuccess) {
+        // Successfully disabled sleep.
+        _assertionCreated = true;
+    }
+}
+
+void allowSleep() {
+   if (_assertionCreated) {
+       IOPMAssertionRelease(_assertionID);
+       _assertionCreated = false;
+   }
+}
+*/
+import "C"
+
+// Prevent prevents macOS from going to sleep. Must be paired with `Allow()`.
+func Prevent() {
+	C.preventSleep()
+}
+
+// Allow allows macOS to go to sleep.
+func Allow() {
+	C.allowSleep()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20240918121853-2221e9876d20
+# github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20240925080402-a2115fee878e
 ## explicit; go 1.21
 github.com/BitBoxSwiss/bitbox02-api-go/api/bootloader
 github.com/BitBoxSwiss/bitbox02-api-go/api/common
@@ -7,6 +7,7 @@ github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages
 github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid
 github.com/BitBoxSwiss/bitbox02-api-go/util/errp
 github.com/BitBoxSwiss/bitbox02-api-go/util/semver
+github.com/BitBoxSwiss/bitbox02-api-go/util/sleep
 # github.com/BitBoxSwiss/block-client-go v0.0.0-20240516081043-0d604acd6519
 ## explicit; go 1.19
 github.com/BitBoxSwiss/block-client-go/electrum


### PR DESCRIPTION
To prevent USB communication interruptions when e.g. recovering from 24 words.

See https://github.com/BitBoxSwiss/bitbox02-api-go/pull/111

```
go get github.com/BitBoxSwiss/bitbox02-api-go@88d5934
go mod tidy
go mod vendor
```