### PR TITLE
android: specify foreground service type for API level >=29

### DIFF
--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoService.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoService.java
@@ -6,6 +6,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
@@ -63,12 +64,15 @@ public class GoService extends Service {
                 .setContentIntent(contentIntent)
                 .setAutoCancel(true)
                 .build();
-        startForeground(notificationId,notification);
 
         // The service goes in foreground to keep working normally even when the app is out of
         // focus. This is needed to avoid timeouts when the backend is polling the BitBox for e.g.
         // an address verification.
-        startForeground(notificationId, notification);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(notificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC | ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE);
+        } else {
+            startForeground(notificationId, notification);
+        }
         Util.log("GoService onCreate completed");
     }
 


### PR DESCRIPTION
https://developer.android.com/reference/android/app/Service#startForeground(int,%20android.app.Notification)

> Note: Beginning with SDK Version
Build.VERSION_CODES.UPSIDE_DOWN_CAKE, apps targeting SDK Version Build.VERSION_CODES.UPSIDE_DOWN_CAKE or higher are not allowed to start foreground services without specifying a valid foreground service type in the manifest attribute
R.attr.foregroundServiceType. See Behavior changes: Apps targeting Android 14 for more details.

In the simulator for Android 34 the app seems to work without this change.