### PR TITLE
frontend: fix layout on mobile for spinner with error message

### DIFF
--- a/frontends/web/src/components/spinner/Spinner.module.css
+++ b/frontends/web/src/components/spinner/Spinner.module.css
@@ -23,7 +23,8 @@
 
 .spinnerText {
     margin: 0;
-    /* font-weight: bold; */
+    padding: 0 var(--spacing-default);
+    text-align: center;
 }
 
 .spinner div {


### PR DESCRIPTION
Some error messages are only partly centered and have no padding to the edge of the container.

Reason:

Spinner is used in account and other components to show loading but also unknown error messages. Each line of the message is rendered in its own paragraph element. Those paragraphs are centered by the parent element using flexbox. As soon as a paragraph contains text that spawns over multiple lines it will cause the paragraph to use the full available width with left aligned text.