### PR TITLE
frontend: type coinUnit field in IAccount

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -65,7 +65,7 @@ export interface IAccount {
   active: boolean;
   watch: boolean;
   coinCode: CoinCode;
-  coinUnit: string;
+  coinUnit: CoinUnit;
   coinName: string;
   code: AccountCode;
   name: string;

--- a/frontends/web/src/routes/account/utils.test.ts
+++ b/frontends/web/src/routes/account/utils.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { CoinCode, IAccount } from '@/api/account';
+import { CoinCode, CoinUnit, IAccount } from '@/api/account';
 import { getAccountsByKeystore } from './utils';
 
 
@@ -31,7 +31,7 @@ const createAccount = ({
     code: 'v0-123de678-tbtc-0',
     coinCode: 'tbtc' as CoinCode,
     coinName: 'Bitcoin Testnet',
-    coinUnit: 'TBTC',
+    coinUnit: 'TBTC' as CoinUnit,
     isToken: false,
     keystore: {
       connected: false,


### PR DESCRIPTION
Type `coinUnit` field in `IAccount` to the `CoinUnit` type instead of `string`.