### PR TITLE
frontend: improve send error handling

### DIFF
--- a/frontends/web/src/routes/account/send/services.ts
+++ b/frontends/web/src/routes/account/send/services.ts
@@ -19,19 +19,19 @@ import { alertUser } from '@/components/alert/Alert';
 import { i18n } from '@/i18n/i18n';
 
 export type TProposalError = {
-    addressError: string;
-    amountError: string;
-    feeError: string;
+    addressError?: string;
+    amountError?: string;
+    feeError?: string;
 }
 
-export const txProposalErrorHandling = (errorCode?: string) => {
+export const txProposalErrorHandling = (errorCode?: string): TProposalError => {
   const { t } = i18n;
   switch (errorCode) {
   case 'invalidAddress':
     return { addressError: t('send.error.invalidAddress') };
   case 'invalidAmount':
   case 'insufficientFunds':
-    return { amountError: t(`send.error.${errorCode}`), proposedFee: undefined };
+    return { amountError: t(`send.error.${errorCode}`) };
   case 'feeTooLow':
   case 'feesNotAvailable':
     return { feeError: t(`send.error.${errorCode}`) };
@@ -39,6 +39,6 @@ export const txProposalErrorHandling = (errorCode?: string) => {
     if (errorCode) {
       alertUser(errorCode);
     }
-    return { proposedFee: undefined };
+    return {};
   }
 };


### PR DESCRIPTION
The `txProposalErrorHandling` function should **only** return errors and not set any state. Although this isn't causing an issue right now, the function should not set state in principle. 

Return only `TProposalError` from the function but make all fields optional. Additionally, this will be necesary for an upcoming refactor of the `Send` component.

To keep the logic the same we set `proposedFee` to `undefined` according to the same logic (ie. `{}` or `{ amountError: ... }` is returned) but in the `Send` component not in the error handling function.