### PR TITLE
Final improvments before refactor

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -65,7 +65,7 @@ export interface IAccount {
   active: boolean;
   watch: boolean;
   coinCode: CoinCode;
-  coinUnit: string;
+  coinUnit: CoinUnit;
   coinName: string;
   code: AccountCode;
   name: string;

--- a/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
@@ -31,22 +31,15 @@ type TFiatValueProps = {
 }
 
 export const ConfirmSend = (props: TConfirmSendProps) => {
-  switch (props.device) {
-  case 'bitbox':
-    return (
-      <ConfirmingWaitDialog
-        {...props}
-      />
-    );
-  case 'bitbox02':
-    return (
-      <BB02ConfirmSend
-        {...props}
-      />
-    );
-  default:
-    return null;
-  }
+  return (props.bb01Paired !== undefined ? (
+    <ConfirmingWaitDialog
+      {...props}
+    />
+  ) : (
+    <BB02ConfirmSend
+      {...props}
+    />
+  ));
 };
 
 export const BB02ConfirmSend = ({
@@ -57,7 +50,7 @@ export const BB02ConfirmSend = ({
   selectedUTXOs,
   coinCode,
   transactionDetails
-}: Omit<TConfirmSendProps, 'device'>) => {
+}: Omit<TConfirmSendProps, 'bb01Paired'>) => {
 
   const { t } = useTranslation();
   const {

--- a/frontends/web/src/routes/account/send/components/confirm/dialogs/confirm-wait-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/dialogs/confirm-wait-dialog.tsx
@@ -31,7 +31,7 @@ export const ConfirmingWaitDialog = ({
   selectedUTXOs,
   coinCode,
   transactionDetails
-}: Omit<TConfirmSendProps, 'device'>) => {
+}: Omit<TConfirmSendProps, 'bb01Paired'>) => {
   const { t } = useTranslation();
   const [signProgress, setSignProgress] = useState<TSignProgress>();
 

--- a/frontends/web/src/routes/account/send/components/confirm/types.ts
+++ b/frontends/web/src/routes/account/send/components/confirm/types.ts
@@ -15,7 +15,6 @@
  */
 
 import { ConversionUnit, CoinCode, FeeTargetCode, Fiat, IAmount } from '@/api/account';
-import { TProductName } from '@/api/devices';
 
 export type TransactionDetails = {
     proposedAmount?: IAmount;
@@ -28,7 +27,7 @@ export type TransactionDetails = {
   }
 
 export type TConfirmSendProps = {
-    device: TProductName;
+    bb01Paired: boolean | undefined;
     baseCurrencyUnit: ConversionUnit;
     note: string;
     hasSelectedUTXOs: boolean;

--- a/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
@@ -1,7 +1,8 @@
 import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Checkbox, Input } from '@/components/forms';
 import { IAmount, IBalance } from '@/api/account';
+import { TProposalError } from '@/routes/account/send/services';
+import { Checkbox, Input } from '@/components/forms';
 import style from './coin-input.module.css';
 
 type TProps = {
@@ -9,7 +10,7 @@ type TProps = {
     onAmountChange: (amount: string) => void;
     onSendAllChange: (sendAll: boolean) => void;
     sendAll: boolean;
-    amountError?: string;
+    errorHandling: TProposalError;
     proposedAmount?: IAmount;
     amount: string;
     hasSelectedUTXOs: boolean;
@@ -20,7 +21,7 @@ export const CoinInput = ({
   onAmountChange,
   onSendAllChange,
   sendAll,
-  amountError,
+  errorHandling,
   proposedAmount,
   amount,
   hasSelectedUTXOs
@@ -35,11 +36,12 @@ export const CoinInput = ({
       id="amount"
       onInput={(e: ChangeEvent<HTMLInputElement>) => onAmountChange(e.target.value)}
       disabled={sendAll}
-      error={amountError}
-      value={sendAll ? (proposedAmount ? proposedAmount.amount : '') : amount}
+      error={errorHandling.amountError}
+      value={sendAll ? (proposedAmount ? proposedAmount.amount : amount) : amount}
       placeholder={t('send.amount.placeholder')}
       labelSection={
         <Checkbox
+          disabled={!!errorHandling.feeError || !!errorHandling.addressError}
           label={t(hasSelectedUTXOs ? 'send.maximumSelectedCoins' : 'send.maximum')}
           id="sendAll"
           onChange={(e: ChangeEvent<HTMLInputElement>) => onSendAllChange(e.target.checked)}

--- a/frontends/web/src/routes/account/send/components/inputs/note-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/note-input.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Input } from '@/components/forms';
 import style from './note-input.module.css';
-import { ChangeEvent } from 'react';
 
 type TProps = {
-    onNoteChange: (event: ChangeEvent<HTMLInputElement>) => void;
+    onNoteChange: (note: string) => void;
     note: string;
 }
 
@@ -35,7 +35,7 @@ export const NoteInput = ({ onNoteChange, note }: TProps) => {
         </span>
       }
       id="note"
-      onInput={onNoteChange}
+      onInput={(e: ChangeEvent<HTMLInputElement>) => onNoteChange(e.target.value)}
       value={note}
       placeholder={t('note.input.placeholder')}
     />

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -26,7 +26,6 @@ import { HideAmountsButton } from '@/components/hideamountsbutton/hideamountsbut
 import { Button } from '@/components/forms';
 import { BackButton } from '@/components/backbutton/backbutton';
 import { Column, ColumnButtons, Grid, GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
-import { Status } from '@/components/status/status';
 import { translate, TranslateProps } from '@/decorators/translate';
 import { FeeTargets } from './feetargets';
 import { isBitcoinBased } from '@/routes/account/utils';
@@ -39,7 +38,6 @@ import { FiatInput } from './components/inputs/fiat-input';
 import { NoteInput } from './components/inputs/note-input';
 import { TSelectedUTXOs } from './utxos';
 import { TProposalError, txProposalErrorHandling } from './services';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { CoinControl } from './coin-control';
 import style from './send.module.css';
 
@@ -53,7 +51,6 @@ interface SendProps {
 type Props = SendProps & TranslateProps;
 
 export type State = {
-    account?: accountApi.IAccount;
     balance?: accountApi.IBalance;
     proposedFee?: accountApi.IAmount;
     proposedTotal?: accountApi.IAmount;
@@ -71,7 +68,6 @@ export type State = {
     addressError?: TProposalError['addressError'];
     amountError?: TProposalError['amountError'];
     feeError?: TProposalError['feeError'];
-    paired?: boolean;
     note: string;
 }
 
@@ -390,7 +386,6 @@ class Send extends Component<Props, State> {
       addressError,
       amountError,
       feeError,
-      paired,
       note,
     } = this.state;
 
@@ -408,11 +403,6 @@ class Send extends Component<Props, State> {
       <GuideWrapper>
         <GuidedContent>
           <Main>
-            <ContentWrapper>
-              <Status type="warning" hidden={paired !== false}>
-                {t('warning.sendPairing')}
-              </Status>
-            </ContentWrapper>
             <Header
               title={<h2>{t('send.title', { accountName: account.coinName })}</h2>}
             >

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -263,7 +263,7 @@ class Send extends Component<Props, State> {
 
   private feeTargetChange = (feeTarget: accountApi.FeeTargetCode) => {
     this.setState(
-      { feeTarget, customFee: '' },
+      { feeTarget },
       () => this.validateAndDisplayFee(this.state.sendAll),
     );
   };

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -190,6 +190,7 @@ class Send extends Component<Props, State> {
         this.setState({ valid: false });
         console.error('Failed to propose transaction:', error);
       } finally {
+        this.setState({ isUpdatingProposal: false });
         // cleanup regardless of success or failure
         if (proposePromise === this.lastProposal) {
           this.lastProposal = null;
@@ -211,21 +212,13 @@ class Send extends Component<Props, State> {
   ) => {
     this.setState({ valid: result.success });
     if (result.success) {
-      this.setState({
-        errorHandling: {},
-        isUpdatingProposal: false,
-        proposalResult: result,
-      });
+      this.setState({ errorHandling: {}, proposalResult: result });
       if (updateFiat) {
         this.convertToFiat(result.amount.amount);
       }
     } else {
       const errorHandling = txProposalErrorHandling(result.errorCode);
-      this.setState({
-        errorHandling,
-        isUpdatingProposal: false,
-        proposalResult: undefined,
-      });
+      this.setState({ errorHandling, proposalResult: undefined });
       // In case sendAll is true, but there is no proposedAmount we fall back to the last typed
       // amount. So we also need to convert it to fiat.
       if (this.state.sendAll) {

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -52,11 +52,9 @@ type Props = SendProps & TranslateProps;
 
 export type State = {
     balance?: accountApi.IBalance;
-    proposedFee?: accountApi.IAmount;
-    proposedTotal?: accountApi.IAmount;
     recipientAddress: string;
-    proposedAmount?: accountApi.IAmount;
     valid: boolean;
+    proposalResult: accountApi.TTxProposalResult | undefined;
     amount: string;
     fiatAmount: string;
     sendAll: boolean;
@@ -88,6 +86,7 @@ class Send extends Component<Props, State> {
     note: '',
     customFee: '',
     errorHandling: {},
+    proposalResult: undefined,
   };
 
   public componentDidMount() {
@@ -127,13 +126,11 @@ class Send extends Component<Props, State> {
           sendAll: false,
           isConfirming: false,
           recipientAddress: '',
-          proposedAmount: undefined,
-          proposedFee: undefined,
-          proposedTotal: undefined,
           fiatAmount: '',
           amount: '',
           note: '',
           customFee: '',
+          proposalResult: undefined,
         });
         this.selectedUTXOs = {};
       }
@@ -167,7 +164,6 @@ class Send extends Component<Props, State> {
 
   private validateAndDisplayFee = (updateFiat: boolean = true) => {
     this.setState({
-      proposedTotal: undefined,
       errorHandling: {},
     });
     const txInput = this.getValidTxInputData();
@@ -217,20 +213,23 @@ class Send extends Component<Props, State> {
     if (result.success) {
       this.setState({
         errorHandling: {},
-        proposedFee: result.fee,
-        proposedAmount: result.amount,
-        proposedTotal: result.total,
         isUpdatingProposal: false,
+        proposalResult: result,
       });
       if (updateFiat) {
         this.convertToFiat(result.amount.amount);
       }
     } else {
       const errorHandling = txProposalErrorHandling(result.errorCode);
-      this.setState({ errorHandling, isUpdatingProposal: false });
-      if (errorHandling.amountError
-        || Object.keys(errorHandling).length === 0) {
-        this.setState({ proposedFee: undefined });
+      this.setState({
+        errorHandling,
+        isUpdatingProposal: false,
+        proposalResult: undefined,
+      });
+      // In case sendAll is true, but there is no proposedAmount we fall back to the last typed
+      // amount. So we also need to convert it to fiat.
+      if (this.state.sendAll) {
+        this.convertToFiat(this.state.amount);
       }
     }
   };
@@ -368,10 +367,7 @@ class Send extends Component<Props, State> {
 
     const {
       balance,
-      proposedFee,
-      proposedTotal,
       recipientAddress,
-      proposedAmount,
       valid,
       amount,
       /* data, */
@@ -384,7 +380,14 @@ class Send extends Component<Props, State> {
       isUpdatingProposal,
       errorHandling,
       note,
+      proposalResult
     } = this.state;
+
+    const {
+      fee: proposedFee,
+      amount: proposedAmount,
+      total: proposedTotal,
+    } = proposalResult?.success ? proposalResult : { fee: undefined, amount: undefined, total: undefined };
 
     const waitDialogTransactionDetails = {
       proposedFee,
@@ -436,7 +439,7 @@ class Send extends Component<Props, State> {
                       onAmountChange={this.onCoinAmountChange}
                       onSendAllChange={this.onSendAllChange}
                       sendAll={sendAll}
-                      amountError={errorHandling.amountError}
+                      errorHandling={errorHandling}
                       proposedAmount={proposedAmount}
                       amount={amount}
                       hasSelectedUTXOs={this.hasSelectedUTXOs()}

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ChangeEvent, Component } from 'react';
+import { Component } from 'react';
 import * as accountApi from '@/api/account';
 import { syncdone } from '@/api/accountsync';
 import { convertFromCurrency, convertToCurrency, parseExternalBtcAmount } from '@/api/coins';
@@ -197,13 +197,6 @@ class Send extends Component<Props, State> {
         }
       }
     }, 400); // Delay the proposal by 400 ms
-  };
-
-  private handleNoteInput = (event: ChangeEvent<HTMLInputElement>) => {
-    const target = event.target;
-    this.setState({
-      'note': target.value,
-    });
   };
 
   private txProposal = (
@@ -465,7 +458,7 @@ class Send extends Component<Props, State> {
                   <Column>
                     <NoteInput
                       note={note}
-                      onNoteChange={this.handleNoteInput}
+                      onNoteChange={note => this.setState({ note: note })}
                     />
                     <ColumnButtons
                       className="m-top-default m-bottom-xlarge"

--- a/frontends/web/src/routes/account/send/services.ts
+++ b/frontends/web/src/routes/account/send/services.ts
@@ -19,19 +19,19 @@ import { alertUser } from '@/components/alert/Alert';
 import { i18n } from '@/i18n/i18n';
 
 export type TProposalError = {
-    addressError: string;
-    amountError: string;
-    feeError: string;
+    addressError?: string;
+    amountError?: string;
+    feeError?: string;
 }
 
-export const txProposalErrorHandling = (errorCode?: string) => {
+export const txProposalErrorHandling = (errorCode?: string): TProposalError => {
   const { t } = i18n;
   switch (errorCode) {
   case 'invalidAddress':
     return { addressError: t('send.error.invalidAddress') };
   case 'invalidAmount':
   case 'insufficientFunds':
-    return { amountError: t(`send.error.${errorCode}`), proposedFee: undefined };
+    return { amountError: t(`send.error.${errorCode}`) };
   case 'feeTooLow':
   case 'feesNotAvailable':
     return { feeError: t(`send.error.${errorCode}`) };
@@ -39,6 +39,6 @@ export const txProposalErrorHandling = (errorCode?: string) => {
     if (errorCode) {
       alertUser(errorCode);
     }
-    return { proposedFee: undefined };
+    return {};
   }
 };

--- a/frontends/web/src/routes/account/utils.test.ts
+++ b/frontends/web/src/routes/account/utils.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { CoinCode, IAccount } from '@/api/account';
+import { CoinCode, CoinUnit, IAccount } from '@/api/account';
 import { getAccountsByKeystore } from './utils';
 
 
@@ -31,7 +31,7 @@ const createAccount = ({
     code: 'v0-123de678-tbtc-0',
     coinCode: 'tbtc' as CoinCode,
     coinName: 'Bitcoin Testnet',
-    coinUnit: 'TBTC',
+    coinUnit: 'TBTC' as CoinUnit,
     isToken: false,
     keystore: {
       connected: false,


### PR DESCRIPTION
After #2955 

Refactoring the `Send` component I noticed these as either improvements or required preparation for the refactor. The commits are quite small and I don't think they need to be tested individually, just test HEAD of the PR, I can also squash them all into one "Send component improvements" commit ?

Please review each commit individually.

Putting the result of the proposal request into the state changes the most:
be190c667e638cad6bf975d427be3c8fadcd641a

But it also fixes a bug that exists on master right now, to reproduce:

1. Type some value X into the amount field. It will show Y in the fiat field.
2. Deleted some part of the address, to make it invalid.
3. Type in the amount field again it will show Y' and X'.
4. Click on send all, now it shows Y but in fiat still X'.

After this commit there will never be any `proposedStuff` in case the last proposal (and thus partially our current state) is invalid. To prevent this the "send all" checkbox is disabled on address/fee errors. And we fallback on the last typed amount/fiat in case we end up in the state of `sendAll = true` but `proposalResult = undefined`.

In case you think we should reset the custom fee I can drop this:
9c6765387c165e122b8248889f82a53908f2cf43

But it will let us remove the handler function later and only pass the state setter when we refactor `Send` to functional in case we don't reset the custom fee.