### PR TITLE
frontend: fix progress ring background in darkmode

### DIFF
--- a/frontends/web/src/components/progressRing/progressRing.module.css
+++ b/frontends/web/src/components/progressRing/progressRing.module.css
@@ -11,13 +11,16 @@
 .background {
     stroke: var(--color-mediumgray);
 }
+:global(.dark-mode) .background {
+    stroke: var(--color-gray);
+}
 
 .foreground {
     
 }
 
 .complete {
-    stroke: var(--color-success);
+    stroke: var(--color-darkgreen);
 }
 
 .pending,


### PR DESCRIPTION
Background of the progress ring was white in darkmode. Changed to be dark gray.

cherry picked commit from https://github.com/BitBoxSwiss/bitbox-wallet-app/pull/2936