### PR TITLE
chore: update github actions macos runner to 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           path: frontends/qt/build/linux/bitbox-*.rpm
           name: BitBoxApp-linux-${{github.sha}}.rpm
   macos:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Clone the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Updated Github Action macos runner to 13. Runner images are deprecated since 10/7/24 and will be unsupported by 12/3/24. See https://github.com/actions/runner-images/issues/10721
