### PR TITLE
frontends: add vite preview npm task

### DIFF
--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -62,6 +62,7 @@
     "build": "npm run typescript && vite build",
     "lint": "npm run typescript && eslint --ext .jsx,.js,.ts,.tsx ./src",
     "typescript": "tsc -p tsconfig.json",
-    "test": "vitest"
+    "test": "vitest",
+    "preview": "vite preview --port 8080"
   }
 }


### PR DESCRIPTION
This is useful to test the production build of the web frontend locally in the browser.

First do a production build, either by:
- `make buildweb`
- `cd frontends/web && npm ci && npm run build`

Then run the frontend build with:
- `cd frontends/web && npm run preview`