### PR TITLE
frontend: fix actionbuttons for eth

### DIFF
--- a/frontends/web/src/components/balance/balance.module.css
+++ b/frontends/web/src/components/balance/balance.module.css
@@ -27,11 +27,13 @@
 .balanceTable .availableAmount {
     padding-right: var(--space-quarter);
     text-align: right;
+    white-space: nowrap;
 }
 
 .balanceTable .availableUnit {
     color: var(--color-secondary);
     padding-right: var(--space-half);
+    white-space: nowrap;
 }
 
 .pendingBalance {

--- a/frontends/web/src/routes/account/account.module.css
+++ b/frontends/web/src/routes/account/account.module.css
@@ -15,12 +15,22 @@
     }
 }
 
+.balanceHeader {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    margin-bottom: var(--space-half);
+}
+
 .actionsContainer {
     display: flex;
+    flex-grow: 1;
+    flex-shrink: 0;
     flex-wrap: nowrap;
-    transform: translateY(-36%);
-    margin-top: calc(var(--space-quarter) * 2);
-    padding-bottom: 14px;
+    justify-content: end;
+    margin-top: var(--space-half);
+    padding-bottom: 24px;
 }
 
 .exchange,
@@ -34,8 +44,7 @@
     display: inline-flex;
     font-size: var(--size-default);
     justify-content: center;
-    margin-bottom: var(--space-quarter);
-    margin-left: var(--space-quarter);
+    margin: 0 0 var(--space-quarter) var(--space-quarter);
     min-height: calc(var(--item-height) / 1.5);
     min-width: calc(var(--item-height) * 2);
     padding: var(--space-quarter) var(--space-half);
@@ -119,14 +128,17 @@
 
     .actionsContainer {
         justify-content: space-between;
-        margin-bottom: var(--space-default);
+        margin-bottom: var(--space-half);
         padding-bottom: 0;
-        transform: none;
         width: 100%;
     }
 
     .withWalletConnect.actionsContainer {
         justify-content: center;
+    }
+
+    .balanceHeader {
+        margin-bottom: 0;
     }
 
     .withWalletConnect .buy,
@@ -153,7 +165,6 @@
     .receive,
     .walletConnect {
         font-size: var(--size-small);
-        margin-bottom: 0;
         width: auto;
     }
 

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -323,7 +323,7 @@ export const Account = ({
                 <label className="labelXLarge">
                   {t('accountSummary.availableBalance')}
                 </label>
-                <div className="flex flex-row flex-between flex-item-center flex-column-mobile">
+                <div className={style.balanceHeader}>
                   <Balance balance={balance} />
                   {!isAccountEmpty && <ActionButtons {...actionButtonsProps} />}
                 </div>


### PR DESCRIPTION
ETH can have long decimals (up to 18) and usually shows 4 action buttons: buy, send, receive and walletconnect.

Fixed that the balance is not covered by the action buttons.

Tested with `make servewallet-mainnet-prodservers` to see all action buttons including buy&sell