### PR TITLE
qt: create windows desktop shortcut during installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Improve the UI of buy & sell page for mobile devices
 - Fixed export to CSV for ERC20 tokens.
 - Added support for xpub_required in AOPP.
+- Create desktop shortcut by default on Windows during installation
 
 # 4.46.3
 - Fix camera access on linux

--- a/frontends/qt/setup.nsi
+++ b/frontends/qt/setup.nsi
@@ -103,6 +103,9 @@ Section -Main SEC0000
     #File /r /x Makefile* @abs_top_srcdir@/doc\*.*
     SetOutPath $INSTDIR
     WriteRegStr HKCU "${REGKEY}\Components" Main 1
+
+    # Create a shortcut on the desktop
+    CreateShortCut "$DESKTOP\$(^Name).lnk" "$INSTDIR\${APP_EXE}" "" "" 0
 SectionEnd
 
 Section -post SEC0001
@@ -164,8 +167,7 @@ Section -un.post UNSEC0001
     DeleteRegKey HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)"
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\Uninstall $(^Name).lnk"
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\$(^Name).lnk"
-    Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\BitBox.lnk"
-    Delete /REBOOTOK "$SMSTARTUP\Bitcoin.lnk"
+    Delete /REBOOTOK "$DESKTOP\$(^Name).lnk"
     Delete /REBOOTOK $INSTDIR\uninstall.exe
     Delete /REBOOTOK $INSTDIR\debug.log
     Delete /REBOOTOK $INSTDIR\db.log


### PR DESCRIPTION
Currently, Windows users need to manually create a desktop shortcut. 
This PR creates a desktop shortcut during the installation process.