### PR TITLE
frontend: reset percentage diff on chart

### DIFF
--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -483,6 +483,11 @@ export const Chart = ({
     formattedChartTotal,
   } = data;
 
+  if (!hasData && chartIsUpToDate && difference) {
+    setDiffSince('');
+    setDifference(0);
+  }
+
   const {
     toolTipVisible,
     toolTipValue,


### PR DESCRIPTION
In some situation the percentage difference did not update.

Test:
- have 1 empty remembered wallet with no history
- unlock a wallet with a history so the chart loads
- remove the wallet
- expected result: total should be 0 with no percentage difference