### PR TITLE
frontend/transactions: show historical fiat value in txs list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Revamp transaction history in account overview to improve legibility
 - Fix qrscanner when rotating the device or resizing the window
 - macOS: create a universal build that runs natively on arm64 and amd64
+- Show fiat amount at the time of the transaction in transaction history
 
 # 4.45.0
 - Bundle BitBox02 firmware version v9.21.0

--- a/backend/chart.go
+++ b/backend/chart.go
@@ -120,7 +120,7 @@ func (backend *Backend) ChartData() (*Chart, error) {
 	fiat := backend.Config().AppConfig().Backend.MainFiat
 
 	// Chart data until this point in time.
-	until := backend.RatesUpdater().HistoryLatestTimestampAll(backend.allCoinCodes(), fiat)
+	until := backend.RatesUpdater().HistoryLatestTimestampFiat(backend.allCoinCodes(), fiat)
 	if until.IsZero() {
 		chartDataMissing = true
 		backend.log.Info("ChartDataMissing, until is zero")

--- a/backend/rates/history_test.go
+++ b/backend/rates/history_test.go
@@ -155,10 +155,10 @@ func TestHistoryEarliestLatest(t *testing.T) {
 
 	assert.Equal(t,
 		updater.history["ltcUSD"][1].timestamp,
-		updater.HistoryLatestTimestampAll([]string{"btc", "ltc"}, "USD"))
+		updater.HistoryLatestTimestampFiat([]string{"btc", "ltc"}, "USD"))
 
-	assert.Zero(t, updater.HistoryLatestTimestampAll([]string{"btc", "foo"}, "USD"))
-	assert.Zero(t, updater.HistoryLatestTimestampAll([]string{"foo", "btc"}, "USD"))
+	assert.Zero(t, updater.HistoryLatestTimestampFiat([]string{"btc", "foo"}, "USD"))
+	assert.Zero(t, updater.HistoryLatestTimestampFiat([]string{"foo", "btc"}, "USD"))
 }
 
 // TestLoadDumpUnusableDB ensures no panic when the RateUpdater.historyDB is unusable.
@@ -258,4 +258,26 @@ func BenchmarkLoadHistoryBucket(b *testing.B) {
 		require.NoError(b, err, "updater.loadHistoryBucket")
 		require.Len(b, rates, 5000, "len(rates)")
 	}
+}
+
+func TestHistoryLatestTimestampCoin(t *testing.T) {
+	updater := NewRateUpdater(nil, "/dev/null") // don't need to make HTTP requests or load DB
+	defer updater.Stop()
+	updater.history = map[string][]exchangeRate{
+		"btcUSD": {
+			{value: 2, timestamp: time.Date(2020, 9, 1, 0, 0, 0, 0, time.UTC)},
+			{value: 3, timestamp: time.Date(2020, 9, 2, 0, 0, 0, 0, time.UTC)},
+			{value: 5, timestamp: time.Date(2020, 9, 3, 0, 0, 0, 0, time.UTC)},
+			{value: 8, timestamp: time.Date(2020, 9, 4, 0, 0, 0, 0, time.UTC)},
+		},
+		"btcEUR": {
+			{value: 2, timestamp: time.Date(2020, 9, 1, 0, 0, 0, 0, time.UTC)},
+			{value: 3, timestamp: time.Date(2020, 9, 2, 0, 0, 0, 0, time.UTC)},
+			{value: 5, timestamp: time.Date(2020, 9, 3, 0, 0, 0, 0, time.UTC)},
+		},
+	}
+	assert.Equal(t, time.Time{}, updater.HistoryLatestTimestampCoin("eth"))
+	assert.Equal(t,
+		time.Date(2020, 9, 3, 0, 0, 0, 0, time.UTC),
+		updater.HistoryLatestTimestampCoin("btc"))
 }

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -223,6 +223,7 @@ export interface IAmount {
     amount: string;
     conversions?: Conversions;
     unit: CoinUnit;
+    estimated: boolean;
 }
 
 export interface IBalance {
@@ -242,7 +243,7 @@ export type TTransactionType = 'send' | 'receive' | 'send_to_self';
 export interface ITransaction {
     addresses: string[];
     amount: IAmount;
-    amountAtTime: IAmount | null;
+    amountAtTime: IAmount;
     fee: IAmount;
     feeRatePerKb: IAmount;
     gas: number;

--- a/frontends/web/src/components/amount/amount.tsx
+++ b/frontends/web/src/components/amount/amount.tsx
@@ -28,6 +28,7 @@ type TProps = {
   removeBtcTrailingZeroes?: boolean;
   alwaysShowAmounts?: boolean
   allowRotateCurrencyOnMobile?: boolean;
+  estimated?: boolean;
 };
 
 const formatSats = (amount: string): JSX.Element => {
@@ -97,7 +98,8 @@ export const Amount = ({
   unit,
   removeBtcTrailingZeroes,
   alwaysShowAmounts = false,
-  allowRotateCurrencyOnMobile = false
+  allowRotateCurrencyOnMobile = false,
+  estimated = false
 }: TProps) => {
   const { rotateDefaultCurrency } = useContext(RatesContext);
   const isMobile = useMediaQuery('(max-width: 768px)');
@@ -116,6 +118,7 @@ export const Amount = ({
         unit={unit}
         removeBtcTrailingZeroes={removeBtcTrailingZeroes}
         alwaysShowAmounts={alwaysShowAmounts}
+        estimated={estimated}
       />
     </span>
   );
@@ -126,9 +129,14 @@ export const FormattedAmount = ({
   unit,
   removeBtcTrailingZeroes,
   alwaysShowAmounts = false,
+  estimated = false,
 }: TProps) => {
   const { hideAmounts } = useContext(AppContext);
   const { decimal, group } = useContext(LocalizationContext);
+
+  if (!amount) {
+    return '---';
+  }
 
   if (hideAmounts && !alwaysShowAmounts) {
     return '***';
@@ -153,5 +161,9 @@ export const FormattedAmount = ({
     return formatSats(amount);
   }
 
-  return formatLocalizedAmount(amount, group, decimal);
+  let prefix = '';
+  if (estimated) {
+    prefix = '\u2248'; //≈
+  }
+  return prefix + formatLocalizedAmount(amount, group, decimal);
 };

--- a/frontends/web/src/components/balance/balance.test.tsx
+++ b/frontends/web/src/components/balance/balance.test.tsx
@@ -48,11 +48,13 @@ describe('components/balance/balance', () => {
       hasIncoming: true,
       available: {
         amount: '0.005',
-        unit: 'BTC'
+        unit: 'BTC',
+        estimated: false,
       },
       incoming: {
         amount: '0.003',
         unit: 'BTC',
+        estimated: false,
         conversions: {
           BTC: '0.003',
           AUD: '512',
@@ -98,11 +100,13 @@ describe('components/balance/balance', () => {
       hasIncoming: true,
       available: {
         amount: '0.005',
-        unit: 'BTC'
+        unit: 'BTC',
+        estimated: false,
       },
       incoming: {
         amount: '0.003',
         unit: 'BTC',
+        estimated: false,
         conversions: {
           BTC: '0.003',
           AUD: '512',

--- a/frontends/web/src/components/transactions/components/details-dialog.tsx
+++ b/frontends/web/src/components/transactions/components/details-dialog.tsx
@@ -115,7 +115,7 @@ export const TxDetailsDialog = ({
           </TxDetail>
           <TxDetail label={t('transaction.details.fiatAtTime')}>
             <span className={styles.fiat}>
-              {transactionInfo.amountAtTime ?
+              {transactionInfo.amountAtTime?.estimated == false ?
                 <FiatConversion amount={transactionInfo.amountAtTime} sign={sign} noAction />
                 :
                 <FiatConversion noAction />

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -33,7 +33,7 @@ type TTransactionProps = ITransaction & {
 
 export const Transaction = ({
   addresses,
-  amount,
+  amountAtTime,
   onShowDetail,
   internalID,
   note,
@@ -65,7 +65,7 @@ export const Transaction = ({
           time={time}
           type={type}
         />
-        <Amounts amount={amount} type={type} />
+        <Amounts amount={amountAtTime} type={type} />
         <button
           className={styles.txShowDetailBtn}
           onClick={() => !isMobile && onShowDetail(internalID)}
@@ -169,16 +169,14 @@ const Amounts = ({
         </span>
       </span>
       {/* </data> */}
-      { conversion ? (
-        <span className={styles.txConversionAmount}>
-          {sign}
-          <Amount amount={conversion} unit={defaultCurrency} />
-          <span className={styles.txUnit}>
-            {' '}
-            {defaultCurrency}
-          </span>
+      <span className={styles.txConversionAmount}>
+        {sign}
+        <Amount amount={conversion || ''} unit={defaultCurrency} estimated={amount.estimated}/>
+        <span className={styles.txUnit}>
+          {' '}
+          {defaultCurrency}
         </span>
-      ) : null }
+      </span>
     </span>
   );
 };

--- a/frontends/web/src/routes/account/send/feetargets.test.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.test.tsx
@@ -51,6 +51,7 @@ describe('routes/account/send/feetargets', () => {
         fiatUnit="USD"
         proposedFee={{
           amount: '1',
+          estimated: false,
           unit: 'ETH',
           conversions: {
             AUD: '0.02',


### PR DESCRIPTION
In the account transaction list we used to show the fiat equivalent of each tx amount, using the latest fiat rates. We decided that it was not the best option, and could confuse users looking at past txs.

This changes the behavior showing the historical fiat amount instead. If the historical amount is not available (e.g. tx not confirmed yet or historical rates not updated), and the tx is recent enough, it will make an estimation using the latest rates.

In case of estimation, the fiat conversion will have a `≈` char prefix.

If the historical fiat rates are not available and the tx is older, a `---` will be shown, as in the tx details popup.

NOTE: 
While testing please consider that historical fee rates lags behind the latest ones for about 45mins and that testnet tx timestamps are currently ~2h in the future :D This means that the fiat estimation prefix will be shown for a longer time than expected