### PR TITLE
Moonpay

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -129,26 +129,26 @@ public:
         bool onExchangePage = currentUrl.contains(QRegularExpression("^qrc:/exchange/.*$"));
         bool onBitsurancePage = currentUrl.contains(QRegularExpression("^qrc:/bitsurance/.*$"));
         if (onExchangePage || onBitsurancePage) {
-          if (info.firstPartyUrl().toString() == info.requestUrl().toString()) {
-            // A link with target=_blank was clicked.
-            systemOpen(info.requestUrl().toString().toUtf8().constData());
-            // No need to also load it in our page.
-            info.block(true);
-          }
-          return;
+            if (info.firstPartyUrl().toString() == info.requestUrl().toString()) {
+                // A link with target=_blank was clicked.
+                systemOpen(info.requestUrl().toString().toUtf8().constData());
+                // No need to also load it in our page.
+                info.block(true);
+            }
+            return;
         }
 
         // All the requests originated in the wallet-connect section are allowed, as they are needed to
         // load the Dapp logos and it is not easy to filter out non-images requests.
         bool onWCPage = currentUrl.contains(QRegularExpression(R"(^qrc:/account/[^\/]+/wallet-connect/.*$)"));
         if (onWCPage) {
-          return;
+            return;
         }
 
         // Needed for the wallet connect workflow.
         bool verifyWCRequest = requestedUrl.contains(QRegularExpression(R"(^https://verify\.walletconnect\.com/.*$)"));
         if (verifyWCRequest) {
-          return;
+            return;
         }
 
         std::cerr << "Blocked: " << info.requestUrl().toString().toStdString() << std::endl;
@@ -204,23 +204,23 @@ int main(int argc, char *argv[])
     // This might only be needed for Qt 5.15.2, should revisit this when updating Qt.
     qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--blink-settings=preferredColorScheme=1");
 
-// QT configuration parameters which change the attack surface for memory
-// corruption vulnerabilities
+    // QT configuration parameters which change the attack surface for memory
+    // corruption vulnerabilities
 #if QT_VERSION >= QT_VERSION_CHECK(5,8,0)
     qputenv("QT_ENABLE_REGEXP_JIT", "0");
     qputenv("QV4_FORCE_INTERPRETER", "1");
     qputenv("DRAW_USE_LLVM", "0");
 #endif
 
-// The QtWebEngine may make a clone3 syscall introduced in glibc v2.34.
-// The syscall is missing from the Chromium sandbox whitelist in Qt versions 5.15.2
-// and earlier which visually results in a blank app screen.
-// Disabling the sandbox allows all syscalls.
-//
-// See the following for more details.
-// https://github.com/BitBoxSwiss/bitbox-wallet-app/issues/1447
-// https://bugreports.qt.io/browse/QTBUG-96214
-// https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1944468
+    // The QtWebEngine may make a clone3 syscall introduced in glibc v2.34.
+    // The syscall is missing from the Chromium sandbox whitelist in Qt versions 5.15.2
+    // and earlier which visually results in a blank app screen.
+    // Disabling the sandbox allows all syscalls.
+    //
+    // See the following for more details.
+    // https://github.com/BitBoxSwiss/bitbox-wallet-app/issues/1447
+    // https://bugreports.qt.io/browse/QTBUG-96214
+    // https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1944468
 #if defined(Q_OS_LINUX)
     const static char* kDisableWebSandbox = "QTWEBENGINE_DISABLE_SANDBOX";
     if (!qEnvironmentVariableIsSet(kDisableWebSandbox)) {
@@ -391,16 +391,16 @@ int main(int argc, char *argv[])
     }
 
     QObject::connect(&a, &QApplication::aboutToQuit, [&]() {
-            webClassMutex.lock();
-            channel.deregisterObject(webClass);
-            delete webClass;
-            webClass = nullptr;
-            delete view;
-            view = nullptr;
-            webClassMutex.unlock();
-            workerThread.quit();
-            workerThread.wait();
-        });
+        webClassMutex.lock();
+        channel.deregisterObject(webClass);
+        delete webClass;
+        webClass = nullptr;
+        delete view;
+        view = nullptr;
+        webClassMutex.unlock();
+        workerThread.quit();
+        workerThread.wait();
+    });
 
 #if defined(_WIN32)
     // Allow existing app to be brought to the foreground. See `view->activateWindow()` above.

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -130,6 +130,16 @@ public:
         bool onBitsurancePage = currentUrl.contains(QRegularExpression("^qrc:/bitsurance/.*$"));
         if (onExchangePage || onBitsurancePage) {
             if (info.firstPartyUrl().toString() == info.requestUrl().toString()) {
+                // Ignore requests for certain file types (e.g., .js, .css) Somehow Moonpay loads
+                // https://buy.moonpay.com/serviceWorker.js in a way where `info.navigationType()`
+                // is Link (link clicked, see
+                // https://doc.qt.io/qt-6/qwebengineurlrequestinfo.html#NavigationType-enum). We
+                // can't figure out why that happens or how to easily identify the case other than
+                // to exclude such files from being handled here.
+                if (requestedUrl.endsWith(".js") || requestedUrl.endsWith(".css")) {
+                    return;
+                }
+
                 // A link with target=_blank was clicked.
                 systemOpen(info.requestUrl().toString().toUtf8().constData());
                 // No need to also load it in our page.


### PR DESCRIPTION
Somehow since Qt 6, https://buy.moonpay.com/serviceWorker.js is loaded
in the external browser when loading the moonpay widget, as if it was
a link clicked by the user.

I can't see a way to identify this as being different to a link click.

I tried:

- acceptNavigationRequest(), but that is only called once a page is
being loaded (the main app index, or the iframe)
- interceptRequest info.navigationtype() is "link clicked" even for
the JS file

Maybe we could make it work by having our createWindow()
implementation actually create a new hidden window and intercept
requests on it to open in a new browser, but that seems as if it might
be unreliable too and too much effort to implement and test.