### PR TITLE
frontend: fix account action buttons alignment regression

### DIFF
--- a/frontends/web/src/routes/account/account.module.css
+++ b/frontends/web/src/routes/account/account.module.css
@@ -28,9 +28,9 @@
     flex-grow: 1;
     flex-shrink: 0;
     flex-wrap: nowrap;
-    justify-content: end;
+    justify-content: flex-end;
     margin-top: var(--space-half);
-    padding-bottom: 24px;
+    padding-bottom: 0;
 }
 
 .exchange,


### PR DESCRIPTION
The action buttons are not aligned with the right edge of the content area, but instead just follow the total balance.

This happens also in Qt6.2.
