### PR TITLE
frontend: update frontend build target to chorme 94

### DIFF
--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -48,7 +48,7 @@
   },
   "browserslist": {
     "production": [
-      "chrome >= 83"
+      "chrome >= 94"
     ],
     "development": [
       "last 1 chrome version",


### PR DESCRIPTION
With Qt-6.2 the BitBoxApp gets a newer QtWebEngine

https://wiki.qt.io/QtWebEngine/ChromiumVersions