### PR TITLE
frontend: ignore files dropped into the app window

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from 'react-i18next';
 import { useSync } from './hooks/api';
 import { useDefault } from './hooks/default';
 import { usePrevious } from './hooks/previous';
+import { useIgnoreDrop } from './hooks/drop';
 import { AppRouter } from './routes/router';
 import { Wizard as BitBox02Wizard } from './routes/device/bitbox02/wizard';
 import { getAccounts } from './api/account';
@@ -45,6 +46,7 @@ import styles from './app.module.css';
 export const App = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  useIgnoreDrop();
 
   const accounts = useDefault(useSync(getAccounts, syncAccountsList), []);
   const devices = useDefault(useSync(getDeviceList, syncDeviceList), {});

--- a/frontends/web/src/hooks/drop.ts
+++ b/frontends/web/src/hooks/drop.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const onDrop = (event: DragEvent) => {
+  event.preventDefault();
+  event.stopPropagation();
+  if (event.dataTransfer) {
+    // surpress cursor icon
+    event.dataTransfer.dropEffect = 'none';
+  }
+};
+
+/**
+ * Ignore files that are dropped into the window
+ */
+export const useIgnoreDrop = () => {
+  document.addEventListener('dragover', onDrop);
+  document.addEventListener('drop', onDrop);
+  return () => {
+    document.removeEventListener('dragover', onDrop);
+    document.removeEventListener('drop', onDrop);
+  };
+};


### PR DESCRIPTION
The app currently accepts dropping files into the app window and tries to render those. This will error with a blocked error without any way to go back making the app unusable.

Added a hook to globally ignore dropped files.