### PR TITLE
backend/exchanges: add btcDirect support

### DIFF
--- a/backend/exchanges/btcdirect.go
+++ b/backend/exchanges/btcdirect.go
@@ -1,0 +1,44 @@
+// Copyright 2024 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exchanges
+
+import (
+	"slices"
+
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+)
+
+var regions = []string{
+	"AD", "AT", "BE", "BG", "CH", "CZ", "DE", "DK", "EE", "ES", "FI", "FR", "GR",
+	"HR", "HU", "IS", "IT", "LI", "LT", "LU", "LV", "MD", "ME", "MK", "NL", "NO",
+	"PL", "PT", "RO", "RS", "SE", "SI", "SK", "SM"}
+
+// GetBtcDirectSupportedRegions reutrn a string slice of the regions where BTC direct services
+// are available.
+func GetBtcDirectSupportedRegions() []string {
+	return regions
+}
+
+// IsBtcDirectSupported is true if coin.Code and region are supported by BtcDirect.
+func IsBtcDirectSupported(coinCode coin.Code, region string) bool {
+	supportedCoins := []coin.Code{
+		coin.CodeBTC, coin.CodeTBTC, coin.CodeETH, coin.CodeSEPETH,
+		"eth-erc20-usdt", "eth-erc20-usdc", "eth-erc20-link"}
+
+	coinSupported := slices.Contains(supportedCoins, coinCode)
+	regionSupported := len(region) == 0 || slices.Contains(regions, region)
+
+	return coinSupported && regionSupported
+}

--- a/frontends/web/src/api/exchanges.ts
+++ b/frontends/web/src/api/exchanges.ts
@@ -106,3 +106,16 @@ export const getExchangeSupported = (code: AccountCode) => {
     return apiGet(`exchange/supported/${code}`);
   };
 };
+
+export type TBtcDirectResponse = {
+  success: true;
+  supported: boolean;
+} | {
+  success: false;
+};
+
+export const getBtcDirectSupported = (code: AccountCode, region: ExchangeRegion['code']) => {
+  return (): Promise<TBtcDirectResponse> => {
+    return apiGet(`exchange/btcdirect/supported/${code}?region=${region}`);
+  };
+};

--- a/frontends/web/src/routes/exchange/components/buysell.tsx
+++ b/frontends/web/src/routes/exchange/components/buysell.tsx
@@ -77,6 +77,7 @@ export const BuySell = ({
   const { isDarkMode } = useDarkmode();
 
   const exchangeDealsResponse = useLoad(() => exchangesAPI.getExchangeDeals(action, accountCode, selectedRegion), [action, selectedRegion]);
+  const btcDirectSupported = useLoad(exchangesAPI.getBtcDirectSupported(accountCode, selectedRegion), [selectedRegion]);
   const hasPaymentRequestResponse = useLoad(() => hasPaymentRequest(accountCode));
   const [paymentRequestError, setPaymentRequestError] = useState(false);
   const [agreedTerms, setAgreedTerms] = useState(false);
@@ -161,28 +162,28 @@ export const BuySell = ({
                 onClickInfoButton={() => setInfo(buildInfo(exchange))}
               />
             ))}
-            {exchangeDealsResponse?.exchanges.some(exchange => exchange.exchangeName === 'pocket') && (
-              <div className={style.infoContainer}>
-                <Message type="info" icon={<Businessman/>}>
-                  {t('buy.exchange.infoContent.btcdirect.title')}
-                  <p>{t('buy.exchange.infoContent.btcdirect.info')}</p>
-                  <p>
-                    {!agreedTerms ? (
-                      <Link to={'/exchange/btcdirect'} className={style.link}>
-                        {t('buy.exchange.infoContent.btcdirect.link')}
-                      </Link>
-                    ) : (
-                      <A href={getBTCDirectLink()} className={style.link}>
-                        {t('buy.exchange.infoContent.btcdirect.link')}
-                      </A>
-                    )}
+          </div>
+        )}
+        {btcDirectSupported?.success && btcDirectSupported?.supported && (
+          <div className={style.infoContainer}>
+            <Message type="info" icon={<Businessman/>}>
+              {t('buy.exchange.infoContent.btcdirect.title')}
+              <p>{t('buy.exchange.infoContent.btcdirect.info')}</p>
+              <p>
+                {!agreedTerms ? (
+                  <Link to={'/exchange/btcdirect'} className={style.link}>
+                    {t('buy.exchange.infoContent.btcdirect.link')}
+                  </Link>
+                ) : (
+                  <A href={getBTCDirectLink()} className={style.link}>
+                    {t('buy.exchange.infoContent.btcdirect.link')}
+                  </A>
+                )}
                     &nbsp;
-                    {isDarkMode ? <ExternalLinkWhite className={style.textIcon}/> : <ExternalLinkBlack className={style.textIcon}/>}
-                  </p>
-                </Message>
-                <InfoButton onClick={() => setInfo({ info: 'btcdirect' })} />
-              </div>
-            )}
+                {isDarkMode ? <ExternalLinkWhite className={style.textIcon}/> : <ExternalLinkBlack className={style.textIcon}/>}
+              </p>
+            </Message>
+            <InfoButton onClick={() => setInfo({ info: 'btcdirect' })} />
           </div>
         )}
       </div>


### PR DESCRIPTION
3d1603c9b added frontend support for BtCDirect integration, but that was relying on pocket bitcoin regional availabilities to display the BtcDirect informative panel. This commit adds proper backend support.

The BtcDirect panel is now also shown in case of failure of the `getExchangeDeals` call or payment request errors.