### PR TITLE
frontend: remove custom scrollbar styling

### DIFF
--- a/frontends/web/src/components/terms/terms.module.css
+++ b/frontends/web/src/components/terms/terms.module.css
@@ -30,10 +30,6 @@
   padding: var(--space-quarter) 1em 1em 1em;
 }
 
-.disclaimer::-webkit-scrollbar-track {
-  background-color: #fff;
-}
-
 .disclaimer .title {
   font-size: .875rem;
   font-weight: bold;

--- a/frontends/web/src/style/base.css
+++ b/frontends/web/src/style/base.css
@@ -37,20 +37,6 @@ h1, h2, h3, h4, h5 {
     line-height: 1.25;
 }
 
-::-webkit-scrollbar-track {
-    background-color: #F5F5F5;
-}
-
-::-webkit-scrollbar {
-    width: 4px;
-    background-color: #F5F5F5;
-}
-
-::-webkit-scrollbar-thumb {
-    background-color: var(--color-gray);
-    /* border: 2px solid #555555; */
-}
-
 p {
     font-weight: 400;
     font-size: var(--size-default);


### PR DESCRIPTION
Removing the custom scrollbar styling so that we get native styled scrollbars depending on the platform.

The style may vary some OS have no more scrollbars i.e. Android 14