### PR TITLE
frontend: fix back button with UseBackButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - macOS: create a universal build that runs natively on arm64 and amd64
 - Show fiat amount at the time of the transaction in transaction history
 - Add BTC Direct private trading desk information
+- Android: fix stuck back button after closing a dialog
 
 # 4.45.0
 - Bundle BitBox02 firmware version v9.21.0

--- a/frontends/web/src/contexts/BackButtonContext.tsx
+++ b/frontends/web/src/contexts/BackButtonContext.tsx
@@ -41,7 +41,7 @@ type TProviderProps = {
 }
 
 export const BackButtonProvider = ({ children }: TProviderProps) => {
-  const [handlers, sethandlers] = useState<THandler[]>([]);
+  const [handlers, setHandlers] = useState<THandler[]>([]);
   const { guideShown, toggleGuide } = useContext(AppContext);
 
   const callTopHandler = useCallback(() => {
@@ -61,17 +61,18 @@ export const BackButtonProvider = ({ children }: TProviderProps) => {
   }, [handlers, guideShown, toggleGuide]);
 
   const pushHandler = useCallback((handler: THandler) => {
-    sethandlers((prevStack) => [...prevStack, handler]);
+    setHandlers((prevStack) => [...prevStack, handler]);
   }, []);
 
   const popHandler = useCallback((handler: THandler) => {
-    sethandlers((prevStack) => {
+    setHandlers((prevStack) => {
       const index = prevStack.indexOf(handler);
       if (index === -1) {
         // Should never happen.
         return prevStack;
       }
-      return prevStack.slice(index, 1);
+      const res = prevStack.slice(0, index).concat(prevStack.slice(index + 1));
+      return res;
     });
   }, []);
 


### PR DESCRIPTION
The Android back button stopped working after the back button was used to close a dialog. The reason is that the backbutton pop handler did not remove the handler, as `slice(index, 1)` does not remove the element at `index`, it in fact keeps it. When properly removing the handler, back button behavior works as expected again.