### PR TITLE
frontend/auth: fix auth screen glitch on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Show fiat amount at the time of the transaction in transaction history
 - Add BTC Direct private trading desk information
 - Android: fix stuck back button after closing a dialog
+- Fix authentication view glitch at startup
 
 # 4.45.0
 - Bundle BitBox02 firmware version v9.21.0

--- a/frontends/web/src/components/auth/authrequired.tsx
+++ b/frontends/web/src/components/auth/authrequired.tsx
@@ -89,18 +89,21 @@ export const AuthRequired = () => {
         textCenter
         verticallyCentered
         withBottomBar>
-        <ViewHeader small title={t('auth.title')} />
-        <ViewContent children={undefined} minHeight="0" />
-        <ViewButtons>
-          <Button
-            autoFocus
-            primary
-            hidden={authForced.current}
-            disabled={authenticating}
-            onClick={newAuthentication}>
-            {t('auth.authButton')}
-          </Button>
-        </ViewButtons>
+        { !authenticating && (
+          <>
+            <ViewHeader small title={t('auth.title')} />
+            <ViewContent children={undefined} minHeight="0" />
+            <ViewButtons>
+              <Button
+                autoFocus
+                primary
+                hidden={authForced.current}
+                onClick={newAuthentication}>
+                {t('auth.authButton')}
+              </Button>
+            </ViewButtons>
+          </>
+        )}
       </View>
     </div>
   );


### PR DESCRIPTION
The auth screen was sometimes showed for a very short time at startup even when it was disabled. This fixes the glitch, hiding the auth screen details while the backend checks if the auth config is enabled.