### PR TITLE
frontend use default scrollbars on macOS, iOS and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Fix long transaction notes to show fully on multiple lines when necessary
 - Improve send-to-self transactions in account overview
+- Use native scrollbars on macOS, iOS and Android
 
 # 4.46.3
 - Fix camera access on linux

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -22,6 +22,7 @@ import { useSync } from './hooks/api';
 import { useDefault } from './hooks/default';
 import { usePrevious } from './hooks/previous';
 import { useIgnoreDrop } from './hooks/drop';
+import { usePlatformClass } from './hooks/platform';
 import { AppRouter } from './routes/router';
 import { Wizard as BitBox02Wizard } from './routes/device/bitbox02/wizard';
 import { getAccounts } from './api/account';
@@ -44,6 +45,7 @@ import { Providers } from './contexts/providers';
 import styles from './app.module.css';
 
 export const App = () => {
+  usePlatformClass();
   const { t } = useTranslation();
   const navigate = useNavigate();
   useIgnoreDrop();

--- a/frontends/web/src/components/guide/guide.module.css
+++ b/frontends/web/src/components/guide/guide.module.css
@@ -40,10 +40,11 @@
     will-change: margin-right, transform;
 }
 
-.guide::-webkit-scrollbar-thumb {
+:global(.os-linux) .guide::-webkit-scrollbar-thumb,
+:global(.os-windows) .guide::-webkit-scrollbar-thumb {
+    /* the guide is always blue regardless of darkmode so we can hardcode the scroll-thumb to white */
     background-color: white;
 }
-
 
 .header {
     background-color: var(--color-blue);

--- a/frontends/web/src/components/layout/main.module.css
+++ b/frontends/web/src/components/layout/main.module.css
@@ -1,4 +1,6 @@
 .main {
+    /* define background color so macOS renders native scrollbars with correct color */
+    background-color: var(--background);
     display: flex;
     flex-direction: column;
     flex-grow: 1;

--- a/frontends/web/src/hooks/platform.ts
+++ b/frontends/web/src/hooks/platform.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from 'react';
+
+const getPlatformFromUA = (userAgent: string) => {
+  if (userAgent.includes('win')) {
+    return 'windows';
+  } else if (userAgent.includes('mac')) {
+    // IOS userAgents will include Mac
+    if (
+      userAgent.includes('iphone') || userAgent.includes('ipad') || userAgent.includes('ipod')
+    ) {
+      return 'ios';
+    }
+    return 'macos';
+  } else if (userAgent.includes('linux')) {
+    // Android userAgent will also include Linux.
+    if (userAgent.includes('android')
+      || userAgent.includes('samsungbrowser')
+    ) {
+      return 'android';
+    }
+    return 'linux';
+  } else if (userAgent.includes('cros') || userAgent.includes('chromebook')) {
+    return 'chromeos';
+  } else if (
+    userAgent.includes('bsd')
+    || userAgent.includes('freebsd')
+    || userAgent.includes('openbsd')
+    || userAgent.includes('netbsd')
+  ) {
+    return 'bsd';
+  } else {
+    return null;
+  }
+};
+
+/**
+ * usePlatformClass adds a CSS class to target a specific platform in CSS
+ * CSS class that is added is one of:
+ * - os-windows
+ * - os-macos
+ * - os-ios
+ * - os-andoird
+ * - os-linux
+ * - os-chromeos
+ * - os-bsd
+ */
+export const usePlatformClass = () => {
+  const userAgent = navigator.userAgent.toLowerCase();
+
+  useEffect(() => {
+    const platform = getPlatformFromUA(userAgent);
+    if (platform) {
+      document.body.classList.add(`os-${platform}`);
+    }
+  }, [userAgent]);
+
+};

--- a/frontends/web/src/style/base.css
+++ b/frontends/web/src/style/base.css
@@ -37,15 +37,19 @@ h1, h2, h3, h4, h5 {
     line-height: 1.25;
 }
 
-::-webkit-scrollbar {
+.os-linux ::-webkit-scrollbar,
+.os-windows ::-webkit-scrollbar {
     background-color: transparent;
     width: 4px;
 }
-::-webkit-scrollbar-track {
+
+.os-linux ::-webkit-scrollbar-track,
+.os-windows ::-webkit-scrollbar-track {
     background-color: transparent;
 }
 
-::-webkit-scrollbar-thumb {
+.os-linux ::-webkit-scrollbar-thumb,
+.os-windows ::-webkit-scrollbar-thumb {
     background-color: var(--color-secondary);
 }
 


### PR DESCRIPTION
Changed to use native scrollbars on macOS, iOS and Android.

Only keep custom scrollbar CSS for Linux and Windows.