### PR TITLE
frontend/android: fix moonpay widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Android: fix stuck back button after closing a dialog
 - Fix authentication view glitch at startup
 - Remove "No priority" from fee options
+- Fix Moonpay widget loading issues
 
 # 4.45.0
 - Bundle BitBox02 firmware version v9.21.0

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -217,7 +217,9 @@ public class MainActivity extends AppCompatActivity {
         vw.getSettings().setJavaScriptEnabled(true);
         vw.getSettings().setAllowUniversalAccessFromFileURLs(true);
         vw.getSettings().setAllowFileAccess(true);
-        // For MoonPay WebRTC camera access.
+
+        // For Moonpay widget: DOM storage and WebRTC camera access required.
+        vw.getSettings().setDomStorageEnabled(true);
         vw.getSettings().setMediaPlaybackRequiresUserGesture(false);
 
         vw.setWebViewClient(new WebViewClient() {


### PR DESCRIPTION
Moonpay recently released a new widget update that requires the webview to access the DOM storage, causing our iframe integration to fail loading the widget on Android. This fixes the DOM access issue.