### PR TITLE
backend: re-enable copyloopvar linter and refactor code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,7 +86,7 @@ linters:
     - wsl
     - execinquery
     - ireturn
-    - copyloopvar
+    - exportloopref
     - intrange
     - wrapcheck
     - varnamelen

--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -1151,7 +1151,6 @@ func (backend *Backend) initPersistedAccounts() {
 	// will not be loaded, unless they have been marked as watch-only.
 outer:
 	for _, account := range backend.filterAccounts(&persistedAccounts, keystoreConnectedOrWatch) {
-		account := account
 		coin, err := backend.Coin(account.CoinCode)
 		if err != nil {
 			backend.log.Errorf("skipping persisted account %s/%s, could not find coin",
@@ -1338,7 +1337,6 @@ func (backend *Backend) ReinitializeAccounts() {
 func (backend *Backend) uninitAccounts(force bool) {
 	keep := []accounts.Interface{}
 	for _, account := range backend.accounts {
-		account := account
 
 		belongsToKeystore := false
 		if backend.keystore != nil {

--- a/backend/aopp_test.go
+++ b/backend/aopp_test.go
@@ -153,7 +153,6 @@ func TestAOPPSuccess(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run("", func(t *testing.T) {
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, "POST", r.Method)

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -336,7 +336,6 @@ func (account *Account) Initialize() error {
 		account.coin.Blockchain(), account.notifier, account.log)
 
 	for _, signingConfiguration := range signingConfigurations {
-		signingConfiguration := signingConfiguration
 
 		var subacc subaccount
 		subacc.signingConfiguration = signingConfiguration

--- a/backend/coins/btc/db/transactionsdb/transactionsdb_test.go
+++ b/backend/coins/btc/db/transactionsdb/transactionsdb_test.go
@@ -201,12 +201,10 @@ func TestTxQuick(t *testing.T) {
 		) bool {
 			txInRefs := make([]*wire.TxIn, len(txIns))
 			for k, v := range txIns {
-				v := v
 				txInRefs[k] = &v
 			}
 			txOutRefs := make([]*wire.TxOut, len(txOuts))
 			for k, v := range txOuts {
-				v := v
 				txOutRefs[k] = &v
 			}
 			expectedTx := &wire.MsgTx{
@@ -248,7 +246,6 @@ func TestTxQuick(t *testing.T) {
 		require.NoError(t, quick.Check(f, nil))
 
 		for txHash := range allUnverifiedTxHashes {
-			txHash := txHash
 			t.Run("", func(t *testing.T) {
 				expectedHeaderTimestamp := time.Unix(time.Now().Unix(), 123)
 				require.NoError(t, tx.MarkTxVerified(txHash, expectedHeaderTimestamp))
@@ -348,7 +345,6 @@ func TestInputQuick(t *testing.T) {
 		require.NoError(t, quick.Check(f, nil))
 
 		for _, outPoint := range allOutpoints {
-			outPoint := outPoint
 			t.Run("", func(t *testing.T) {
 				tx.DeleteInput(outPoint)
 				txHash, err := tx.Input(outPoint)
@@ -447,7 +443,6 @@ func TestOutputsQuick(t *testing.T) {
 
 		// Test deletion
 		for outPoint := range allOutputs {
-			outPoint := outPoint
 			t.Run("", func(t *testing.T) {
 				delete(allOutputs, outPoint)
 				tx.DeleteOutput(outPoint)

--- a/backend/coins/btc/electrum/electrum.go
+++ b/backend/coins/btc/electrum/electrum.go
@@ -152,7 +152,6 @@ func NewElectrumConnection(serverInfos []*config.ServerInfo, log *logrus.Entry, 
 	retryTimeout := 30 * time.Second
 
 	for _, serverInfo := range serverInfos {
-		serverInfo := serverInfo
 		servers = append(servers, &failover.Server[*client]{
 			Name: serverInfo.Server,
 			Connect: func() (*client, error) {

--- a/backend/coins/btc/electrum/electrum_test.go
+++ b/backend/coins/btc/electrum/electrum_test.go
@@ -34,7 +34,6 @@ func TestDownloadCert(t *testing.T) {
 		{"1.2.3.4:123", ""},
 	}
 	for _, testcase := range tt {
-		testcase := testcase
 		t.Run(testcase.targetServer, func(t *testing.T) {
 			// Set up a fake ElectrumX node.
 			var didHandshake bool
@@ -84,7 +83,6 @@ func TestEstablishConnectionTLS(t *testing.T) {
 		{"1.2.3.4:123", ""},
 	}
 	for _, testcase := range tt {
-		testcase := testcase
 		t.Run(testcase.targetServer, func(t *testing.T) {
 			// Set up a fake ElectrumX node.
 			var didHandshake bool

--- a/backend/coins/btc/maketx/maketx.go
+++ b/backend/coins/btc/maketx/maketx.go
@@ -185,7 +185,6 @@ func NewTxSpendAll(
 	previousOutputs := make(PreviousOutputs, len(spendableOutputs))
 	outputsSum := btcutil.Amount(0)
 	for outPoint, output := range spendableOutputs {
-		outPoint := outPoint // avoid reference reuse due to range loop
 		selectedOutPoints = append(selectedOutPoints, outPoint)
 		outputsSum += btcutil.Amount(output.TxOut.Value)
 		inputs = append(inputs, wire.NewTxIn(&outPoint, nil, nil))
@@ -272,7 +271,6 @@ func NewTx(
 		inputs := make([]*wire.TxIn, len(selectedOutPoints))
 		previousOutputs := make(PreviousOutputs, len(selectedOutPoints))
 		for i, outPoint := range selectedOutPoints {
-			outPoint := outPoint // avoids referencing the same variable across loop iterations
 			inputs[i] = wire.NewTxIn(&outPoint, nil, nil)
 			previousOutputs[outPoint] = &transactions.SpendableOutput{
 				TxOut: spendableOutputs[outPoint].TxOut,

--- a/backend/coins/btc/maketx/txsize_internal_test.go
+++ b/backend/coins/btc/maketx/txsize_internal_test.go
@@ -141,14 +141,11 @@ func TestEstimateTxSize(t *testing.T) {
 	}
 
 	for _, useSegwit := range []bool{false, true} {
-		useSegwit := useSegwit
 		for _, outputScriptType := range scriptTypes {
-			outputScriptType := outputScriptType
 			t.Run(fmt.Sprintf("output=%s,noChange,segwit=%v", outputScriptType, useSegwit), func(t *testing.T) {
 				testEstimateTxSize(t, useSegwit, outputScriptType, "")
 			})
 			for _, changeScriptType := range scriptTypes {
-				changeScriptType := changeScriptType
 				t.Run(fmt.Sprintf("output=%s,change=%s,segwit=%v", outputScriptType, changeScriptType, useSegwit), func(t *testing.T) {
 					testEstimateTxSize(t, useSegwit, outputScriptType, changeScriptType)
 				})

--- a/backend/coins/coin/amount_test.go
+++ b/backend/coins/coin/amount_test.go
@@ -27,7 +27,6 @@ import (
 
 func TestNewAmountFromString(t *testing.T) {
 	for decimals := 0; decimals <= 20; decimals++ {
-		decimals := decimals // avoids referencing the same variable across loop iterations
 		unit := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil)
 		t.Run(fmt.Sprintf("decimals=%d", decimals), func(t *testing.T) {
 			require.NoError(t, quick.Check(func(amount int64) bool {
@@ -46,7 +45,6 @@ func TestNewAmountFromString(t *testing.T) {
 		"1/1000",
 		"0.123456789", // only up to 8 decimals allowed
 	} {
-		fail := fail // avoids referencing the same variable across loop iterations
 		t.Run(fail, func(t *testing.T) {
 			_, err := coin.NewAmountFromString(fail, big.NewInt(1e8))
 			require.Error(t, err)

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -200,7 +200,6 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 		panic("number of signatures doesn't match number of inputs")
 	}
 	for i, signature := range signatures {
-		signature := signature
 		btcProposedTx.Signatures[i] = &signature.Signature
 	}
 	return nil

--- a/backend/devices/bitbox/pairing_test.go
+++ b/backend/devices/bitbox/pairing_test.go
@@ -81,7 +81,6 @@ func TestFinishPairing(t *testing.T) {
 		{"\x00", EventPairingError, false}, // assumes never writable; reconsider if flaky
 	}
 	for i, test := range tt {
-		test := test // avoids referencing the same variable across loop iterations
 		t.Run(fmt.Sprintf("%d: %s", i, test.wantEvent), func(t *testing.T) {
 			communicationMock := &mocks.CommunicationInterface{}
 			dbb := &Device{


### PR DESCRIPTION
Since Go 1.22, the issue of the loop variable being reused in closures has been fixed, so the `copyloopvar` workaround is no longer needed. This commit re-enables the `copyloopvar` linter, disables exportloopref linter (deprecated and replaced by copyloopvar) and refactors the code to remove redundant assignments. See also: https://go.dev/doc/go1.22