### PR TITLE
android: handle device disconnect while the app is in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Display the hide amount button by default and remove its settings
 - Linux: add support for Wayland
 - Fix the copy buttons in the Pocket order confirmation page
+- Android: handle device disconnect while the app is in the background
 
 # 4.46.3
 - Fix camera access on linux

--- a/backend/bridgecommon/bridgecommon.go
+++ b/backend/bridgecommon/bridgecommon.go
@@ -359,3 +359,13 @@ func Shutdown() {
 		log.Info("Shutdown called, but backend not running")
 	}
 }
+
+// UsbUpdate wraps backend.UsbUpdate.
+func UsbUpdate() {
+	mu.RLock()
+	defer mu.RUnlock()
+	if globalBackend == nil {
+		return
+	}
+	globalBackend.UsbUpdate()
+}

--- a/backend/mobileserver/mobileserver.go
+++ b/backend/mobileserver/mobileserver.go
@@ -155,6 +155,11 @@ func UsingMobileDataChanged() {
 	bridgecommon.UsingMobileDataChanged()
 }
 
+// UsbUpdate exposes `bridgecommon.UsbUpdate` to Java/Kotlin.
+func UsbUpdate() {
+	bridgecommon.UsbUpdate()
+}
+
 type goLogHook struct {
 }
 

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -88,6 +88,7 @@ public class MainActivity extends AppCompatActivity {
                                        IBinder service) {
             GoService.GoServiceBinder binder = (GoService.GoServiceBinder) service;
             goService = binder.getService();
+            goService.setViewModelStoreOwner(MainActivity.this);
             Util.log("Bind connection completed!");
             startServer();
         }


### PR DESCRIPTION
The ACTION_USB_DEVICE_DETACHED intent in MainActivity was not handled by the app while it was in the background.

Resulting bug:
- when you disconnect an unlocked device while the app is in the background, and bring the app to the foreground again, the previous unlocked keystore is visible, as the backend didn't register the disconnet.
- same when the user disconnects the device while the app is in the background, and reconnects it before bringing it to the foreground. Ths is a special case, simply calling `updateDevice()` in `onResume()` would not handle this correctly, as a device would be connected, and an intermediate disconnect could not be detected.

To fix this, we detect the DETACH intent in the service, and trigger the backend to handle it.