### PR TITLE
qt: force mime type resolution by filename extension only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 # 4.46.1
 - Fix Android app crash on old Android versions
+- Fix Linux blank screen issue related to the local mimetype database
 
 # 4.46.0
 - Android: enable export logs feature


### PR DESCRIPTION
Fixes #2684 and hopefully #3061.

Without this, on linux the local mimetype database (influenced by
various packages installed on the system) can mess with the mimetype
resolution of our .html/.js/.css files served locally, resulting in a
blank page.

This manually intercepts local requests and forces mimetype resolution
by filename extension only, to avoid the system mimetype database from
breaking the app.
