### PR TITLE
qt: force text/html as the mimetype for index.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 # 4.46.1
 - Fix Android app crash on old Android versions
+- Fix Linux blank screen issue related to the local mimetype database
 
 # 4.46.0
 - Android: enable export logs feature


### PR DESCRIPTION
Fixes #3061.

Without this, on linux the local mimetype database (influenced by various packages installed on the system) can mess with the mimetype resolution of our .html file served locally, resulting in a blank page. Notably, FireFox on linux sets application/x-extension-html as the mimetype for .html files when made the default browser.

This problem is new in Qt 6, on Qt 5.15 it worked fine for some reason.

The general solution is to hardcode mime-types in a custom url scheme handler, but that requires using a different scheme to `qrc:`, which we can't do right now as Moonpay whitelisted only `qrc:`.