### PR TITLE
config: add --host parameter to vite app npm start script

### DIFF
--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -58,7 +58,7 @@
   },
   "scripts": {
     "dev": "npm run start",
-    "start": "vite --cors",
+    "start": "vite --cors --host",
     "build": "npm run typescript && vite build",
     "lint": "npm run typescript && eslint --ext .jsx,.js,.ts,.tsx ./src",
     "typescript": "tsc -p tsconfig.json",


### PR DESCRIPTION
This makes the webdev app running inside docker accessible from the host