### PR TITLE
frontend/notes: filter text files on notes import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improve send-to-self transactions in account overview
 - Use native scrollbars on macOS, iOS and Android
 - Fix address signing fail on screen rotation for Pocket and Bitsurance
+- Restrict selection to text files when importing notes
 
 # 4.46.3
 - Fix camera access on linux

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -332,7 +332,17 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public boolean onShowFileChooser(WebView webView, ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams) {
                 MainActivity.this.filePathCallback = filePathCallback;
-                mGetContent.launch("*/*");
+                String[] mimeTypes = fileChooserParams.getAcceptTypes();
+                String fileType = "*/*";
+                if (mimeTypes.length == 1) {
+                    // import notes form uses .txt file type, but is not supported here.
+                    if (".txt".equals(mimeTypes[0])) {
+                        fileType = "text/plain";
+                    } else if (MimeTypeMap.getSingleton().hasMimeType(mimeTypes[0])) {
+                        fileType = mimeTypes[0];
+                    }
+                }
+                mGetContent.launch(fileType);
                 return true;
             }
         });

--- a/frontends/web/src/routes/settings/components/appearance/notesImport.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/notesImport.tsx
@@ -33,7 +33,7 @@ export const NotesImport = () => {
         type="file"
         className={style.fileInput}
         ref={fileInputRef}
-        accept="text/*,.txt"
+        accept=".txt"
         onChange={async (e: React.ChangeEvent<HTMLInputElement>) => {
           setImportDisabled(e.target.files === null || e.target.files.length === 0);
           if (fileInputRef.current === null) {


### PR DESCRIPTION
and add mime type handling in Android filepicker.

Before this, the file picker was allowing the user to select non-text files for notes import. Now this choice is restricted to *.txt files on Qt and text/plain files on Android and iOS (as it is not possible to filter single file extensions with the default file picker).