### PR TITLE
frontend/widget: fix loosing iframe ref on screen rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix long transaction notes to show fully on multiple lines when necessary
 - Improve send-to-self transactions in account overview
 - Use native scrollbars on macOS, iOS and Android
+- Fix address signing fail on screen rotation for Pocket and Bitsurance
 
 # 4.46.3
 - Fix camera access on linux

--- a/frontends/web/src/routes/bitsurance/widget.tsx
+++ b/frontends/web/src/routes/bitsurance/widget.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, createRef } from 'react';
+import { useState, useEffect, createRef, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { RequestAddressV0Message, MessageVersion, parseMessage, serializeMessage, V0MessageType } from 'request-address';
@@ -49,7 +49,7 @@ export const BitsuranceWidget = ({ code }: TProps) => {
   const accountInfo = useLoad(getInfo(code));
 
   const ref = createRef<HTMLDivElement>();
-  const iframeRef = createRef<HTMLIFrameElement>();
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
   let signing = false;
   let resizeTimerID: any = undefined;
 

--- a/frontends/web/src/routes/exchange/pocket.tsx
+++ b/frontends/web/src/routes/exchange/pocket.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { useState, useEffect, createRef } from 'react';
+import { useState, useEffect, createRef, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { RequestAddressV0Message, MessageVersion, parseMessage, serializeMessage, V0MessageType, PaymentRequestV0Message } from 'request-address';
 import { getConfig } from '@/utils/config';
@@ -53,7 +53,7 @@ export const Pocket = ({ code, action }: TProps) => {
   const accountInfo = useLoad(getInfo(code));
 
   const ref = createRef<HTMLDivElement>();
-  const iframeRef = createRef<HTMLIFrameElement>();
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
   let signing = false;
   let resizeTimerID: any = undefined;
 


### PR DESCRIPTION
Pocket and Bitsurance integrations both feature an address signing request in their widgets. With the previous implementation any re-rendering of the component (e.g. because of screen rotation on phone) caused the loss of the widget reference and the fail of the request. This commit fixes the bug.