### PR TITLE
frontend: fix bb01 device-info type

### DIFF
--- a/frontends/web/src/api/bitbox01.ts
+++ b/frontends/web/src/api/bitbox01.ts
@@ -34,6 +34,6 @@ export type DeviceInfo = {
 
 export const getDeviceInfo = (
   deviceID: string,
-): Promise<DeviceInfo> => {
+): Promise<DeviceInfo | null> => {
   return apiGet(`devices/${deviceID}/info`);
 };

--- a/frontends/web/src/hooks/sdcard.ts
+++ b/frontends/web/src/hooks/sdcard.ts
@@ -37,7 +37,7 @@ export const useSDCard = (
       switch (devices[deviceID]) {
       case 'bitbox':
         return getBitBox01DeviceInfo(deviceID)
-          .then(({ sdcard }) => sdcard);
+          .then(deviceInfo => deviceInfo ? deviceInfo.sdcard : Promise.reject(`Could get device info for ${deviceID}`));
       case 'bitbox02':
         return checkSDCard(deviceID);
       default:

--- a/frontends/web/src/routes/account/send/send-wrapper.tsx
+++ b/frontends/web/src/routes/account/send/send-wrapper.tsx
@@ -46,9 +46,11 @@ export const SendWrapper = ({ accounts, code, deviceIDs, devices }: TSendProps) 
       const fetchData = async () => {
         try {
           const mobileChannel = await hasMobileChannel(deviceIDs[0])();
-          const { pairing } = await getDeviceInfo(deviceIDs[0]);
-          setBB01Paired(mobileChannel && pairing);
-          setNoMobileChannelError(pairing && !mobileChannel && isBitcoinBased(account.coinCode));
+          const deviceInfo = await getDeviceInfo(deviceIDs[0]);
+          if (deviceInfo) {
+            setBB01Paired(mobileChannel && deviceInfo.pairing);
+            setNoMobileChannelError(deviceInfo.pairing && !mobileChannel && isBitcoinBased(account.coinCode));
+          }
         } catch (error) {
           console.error(error);
         }

--- a/frontends/web/src/routes/device/bitbox01/backups.tsx
+++ b/frontends/web/src/routes/device/bitbox01/backups.tsx
@@ -64,7 +64,11 @@ class Backups extends Component<Props, State> {
 
   private refresh = () => {
     getDeviceInfo(this.props.deviceID)
-      .then(({ lock }) => this.setState({ lock }));
+      .then(deviceInfo => {
+        if (deviceInfo) {
+          this.setState({ lock: deviceInfo.lock });
+        }
+      });
     apiGet('devices/' + this.props.deviceID + '/backups/list').then(({ sdCardInserted, backupList, success, errorMessage }) => {
       if (success) {
         this.setState({

--- a/frontends/web/src/routes/device/bitbox01/settings/settings.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/settings.jsx
@@ -54,25 +54,29 @@ class Settings extends Component {
 
   componentDidMount() {
     getDeviceInfo(this.props.deviceID)
-      .then(({
-        lock,
-        name,
-        new_hidden_wallet,
-        pairing,
-        sdcard,
-        serial,
-        version,
-      }) => {
-        this.setState({
-          firmwareVersion: version.replace('v', ''),
-          lock,
-          name,
-          newHiddenWallet: new_hidden_wallet,
-          pairing,
-          sdcard,
-          serial,
-          spinner: false,
-        });
+      .then(deviceInfo => {
+        if (deviceInfo) {
+          const {
+            lock,
+            name,
+            new_hidden_wallet,
+            pairing,
+            sdcard,
+            serial,
+            version,
+          } = deviceInfo;
+
+          this.setState({
+            firmwareVersion: version.replace('v', ''),
+            lock,
+            name,
+            newHiddenWallet: new_hidden_wallet,
+            pairing,
+            sdcard,
+            serial,
+            spinner: false,
+          });
+        }
       });
 
     apiGet('devices/' + this.props.deviceID + '/has-mobile-channel').then(mobileChannel => {

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
@@ -110,8 +110,8 @@ class SeedCreateNew extends Component {
 
   checkSDcard = () => {
     getDeviceInfo(this.props.deviceID)
-      .then(({ sdcard }) => {
-        if (sdcard) {
+      .then((deviceInfo) => {
+        if (deviceInfo?.sdcard) {
           return this.setState({ status: STATUS.DEFAULT, error: '' });
         }
         this.setState({

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
@@ -48,8 +48,8 @@ class SeedRestore extends Component {
 
   checkSDcard = () => {
     getDeviceInfo(this.props.deviceID)
-      .then(({ sdcard }) => {
-        if (sdcard) {
+      .then((deviceInfo) => {
+        if (deviceInfo?.sdcard) {
           return this.setState({ status: STATUS.DEFAULT, error: '' });
         }
         this.setState({

--- a/frontends/web/src/routes/device/bitbox01/upgrade/require_upgrade.jsx
+++ b/frontends/web/src/routes/device/bitbox01/upgrade/require_upgrade.jsx
@@ -29,10 +29,12 @@ class RequireUpgrade extends Component {
 
   componentDidMount() {
     getDeviceInfo(this.props.deviceID)
-      .then(({ version }) => {
-        this.setState({
-          firmwareVersion: version.replace('v', ''),
-        });
+      .then(deviceInfo => {
+        if (deviceInfo) {
+          this.setState({
+            firmwareVersion: deviceInfo.version.replace('v', ''),
+          });
+        }
       });
   }
 


### PR DESCRIPTION
The device info endpoint can return null this can happen when a BB01 is plugged in but not yet unlocked.