### PR TITLE
frontend: hide estimated symbol for send-to-self transactions

### DIFF
--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -189,7 +189,7 @@ const Amounts = ({
             <Arrow type="send_to_self" />
           </span>
         )}
-        {conversionPrefix && (
+        {(conversionPrefix && !sendToSelf) && (
           <span className={styles.txPrefix}>
             {conversionPrefix}
             {' '}


### PR DESCRIPTION
As the send-to-self amount is in coins there is no need to show an estimate symbol in front of the amount.