### PR TITLE
build: fix clean error if file does not exist

### DIFF
--- a/frontends/qt/server/Makefile.linux
+++ b/frontends/qt/server/Makefile.linux
@@ -15,5 +15,5 @@ linux:
 		-extldflags="${GOLNXEXTLDFLAGS}" -o ${LIBNAME}.so
 
 clean:
-	-rm ${LIBNAME}.so
-	-rm ${LIBNAME}.h
+	-rm -f ${LIBNAME}.so
+	-rm -f ${LIBNAME}.h

--- a/frontends/qt/server/Makefile.windows
+++ b/frontends/qt/server/Makefile.windows
@@ -29,7 +29,7 @@ windows-legacy:
 		-o libserver.dll -Wl,--out-implib,libserver.lib
 
 clean:
-	-rm ${LIBNAME}.dll
-	-rm ${LIBNAME}.h
-	-rm ${LIBNAME}.a
-	-rm ${LIBNAME}.lib
+	-rm -f ${LIBNAME}.dll
+	-rm -f ${LIBNAME}.h
+	-rm -f ${LIBNAME}.a
+	-rm -f ${LIBNAME}.lib


### PR DESCRIPTION
Fix Makefile.linux and Makefile.windows clean target so it does not error if files are absent. Add -f to the rm command in make clean to avoid failure when files do not exist.