### PR TITLE
container: fix bug in make dockerdev

### DIFF
--- a/scripts/dockerdev.sh
+++ b/scripts/dockerdev.sh
@@ -41,7 +41,7 @@ dockerdev () {
     fi
 
     # A container based on a different image version is running. Let's stop and remove it.
-    if $RUNTIME ps | grep -q $container_name; then
+    if $RUNTIME ps -a | grep -q $container_name; then
       $RUNTIME stop $container_name
       $RUNTIME rm $container_name
     fi


### PR DESCRIPTION
Recent commit ace02fe8aeb23c4ad2b49ec9c144397d32a6d383 introduced versioning for the app container. The commit introduced a bug that causes `make dockerdev` to fail when there is a stopped container that matches the current version. This fixes the bug.