### PR TITLE
frontend: hide estimate sign if conversion is btc or sat

### DIFF
--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -167,6 +167,7 @@ const Amounts = ({
   const conversionPrefix = amount.estimated ? '\u2248' : null; // ≈
   const sendToSelf = type === 'send_to_self';
   const conversionUnit = sendToSelf ? amount.unit : defaultCurrency;
+  const conversionIsFiat = conversionUnit !== 'BTC' && conversionUnit !== 'sat';
 
   return (
     <span className={`${styles.txAmountsColumn} ${styles[txTypeClass]}`}>
@@ -189,7 +190,7 @@ const Amounts = ({
             <Arrow type="send_to_self" />
           </span>
         )}
-        {(conversionPrefix && !sendToSelf) && (
+        {(conversionPrefix && !sendToSelf && conversionIsFiat) && (
           <span className={styles.txPrefix}>
             {conversionPrefix}
             {' '}


### PR DESCRIPTION
Until a transaction has 6 confirmations we do show a estimation sign for the conversion amount as the exact time is still not final.

The user can optionally choose BTC or sat as conversion unit in these cases no estimation sign is needed.