### PR TITLE
frontend: enable clipboard read/write for android/qt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Restrict selection to text files when importing notes
 - Display the hide amount button by default and remove its settings
 - Linux: add support for Wayland
+- Fix the copy buttons in the Pocket order confirmation page
 
 # 4.46.3
 - Fix camera access on linux

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/ClipboardHandler.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/ClipboardHandler.java
@@ -1,0 +1,26 @@
+package ch.shiftcrypto.bitboxapp;
+
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.webkit.JavascriptInterface;
+
+public class ClipboardHandler {
+    private final Context context;
+
+    public ClipboardHandler(Context context) {
+        this.context = context;
+    }
+
+    @JavascriptInterface
+    public String readFromClipboard() {
+        ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+        if (clipboard.hasPrimaryClip()) {
+            ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
+            if (item != null) {
+                return item.getText().toString();
+            }
+        }
+        return "";
+    }
+}

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -224,6 +224,17 @@ public class MainActivity extends AppCompatActivity {
 
         vw.setWebViewClient(new WebViewClient() {
             @Override
+            public void onPageFinished(WebView view, String url) {
+                super.onPageFinished(view, url);
+                // override the default readText method, that doesn't work
+                // because of read permission denied.
+                view.evaluateJavascript(
+                        "navigator.clipboard.readText = () => {" +
+                        "    return androidClipboard.readFromClipboard();" +
+                        "};", null);
+            }
+
+            @Override
             public WebResourceResponse shouldInterceptRequest(final WebView view, WebResourceRequest request) {
                 if (request != null && request.getUrl() != null) {
                     String url = request.getUrl().toString();
@@ -349,7 +360,7 @@ public class MainActivity extends AppCompatActivity {
 
         final String javascriptVariableName = "android";
         vw.addJavascriptInterface(new JavascriptBridge(this), javascriptVariableName);
-
+        vw.addJavascriptInterface(new ClipboardHandler(this), "androidClipboard");
         vw.loadUrl(BASE_URL + "index.html");
 
         // We call updateDevice() here in case the app was started while the device was already connected.

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -23,6 +23,7 @@
 #include <QWebEngineUrlScheme>
 #include <QWebEngineUrlSchemeHandler>
 #include <QWebEngineUrlRequestJob>
+#include <QWebEngineSettings>
 #include <QMimeDatabase>
 #include <QFile>
 #include <QContextMenuEvent>
@@ -453,6 +454,8 @@ int main(int argc, char *argv[])
     QWebChannel channel;
     channel.registerObject("backend", webClass);
     view->page()->setWebChannel(&channel);
+    view->settings()->setAttribute(QWebEngineSettings::JavascriptCanAccessClipboard, true);
+    view->settings()->setAttribute(QWebEngineSettings::JavascriptCanPaste, true);
     view->show();
     view->load(QUrl(QString("%1:/index.html").arg(scheme)));
 

--- a/frontends/web/src/components/copy/Copy.tsx
+++ b/frontends/web/src/components/copy/Copy.tsx
@@ -62,8 +62,8 @@ export const CopyableInput = ({ alignLeft, alignRight, borderLess, value, classN
   };
 
   const copy = () => {
-    textAreaRef.current?.select();
-    if (document.execCommand('copy')) {
+    if (textAreaRef.current) {
+      navigator.clipboard.writeText(textAreaRef.current.value);
       setSuccess(true);
     }
   };

--- a/frontends/web/src/routes/exchange/pocket.tsx
+++ b/frontends/web/src/routes/exchange/pocket.tsx
@@ -301,7 +301,7 @@ export const Pocket = ({ code, action }: TProps) => {
                 height={height}
                 frameBorder="0"
                 className={style.iframe}
-                allow="camera; payment"
+                allow="camera; payment; clipboard-write;"
                 src={iframeURL}>
               </iframe>
             </div>


### PR DESCRIPTION
This enables the use of the `navigator.clipboard` JS api to read/write the clipboard on both Qt and Android and in particular:
- fixes the copy buttons in the Pocket order confirmation page
- updates the api of the CopyableInput component