### PR TITLE
frontend: allow frontend to run not on port 8080

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"os"
 	"runtime/debug"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend"
@@ -1195,7 +1196,11 @@ func (handlers *Handlers) apiMiddleware(devMode bool, h func(*http.Request) (int
 		if devMode {
 			// This enables us to run a server on a different port serving just the UI, while still
 			// allowing it to access the API.
-			w.Header().Set("Access-Control-Allow-Origin", "http://localhost:8080")
+			vitePort, ok := os.LookupEnv("VITE_PORT")
+			if !ok {
+				vitePort = "8080"
+			}
+			w.Header().Set("Access-Control-Allow-Origin", fmt.Sprintf("http://localhost:%s", vitePort))
 		}
 		value, err := h(r)
 		if err != nil {

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -58,7 +58,7 @@
   },
   "scripts": {
     "dev": "npm run start",
-    "start": "vite --port 8080 --cors",
+    "start": "vite --cors",
     "build": "npm run typescript && vite build",
     "lint": "npm run typescript && eslint --ext .jsx,.js,.ts,.tsx ./src",
     "typescript": "tsc -p tsconfig.json",

--- a/frontends/web/vite.config.mjs
+++ b/frontends/web/vite.config.mjs
@@ -1,10 +1,12 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import checker from 'vite-plugin-checker';
 import eslint from 'vite-plugin-eslint';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig((env) => {
+  const envVars = loadEnv(env.mode, process.cwd(), '')
+  const port = envVars.VITE_PORT
   return {
     // Relative base path so the js/css files are referenced with `./index-...js` instead of
     // `/index-...js`. This makes it easier to find these files in iOS.
@@ -29,5 +31,9 @@ export default defineConfig((env) => {
       pool: 'forks',
       setupFiles: './vite.setup-tests.mjs',
     },
+    server: {
+      port: typeof port !== 'undefined' ? port : 8080,
+      strictPort: true,
+    }
   };
 });


### PR DESCRIPTION
This PR makes it possible to run the frontend on a port different from 8080.

There are 2 main changes:

1) Vite config is changed by adding `strictPort = true`
2) The port can be specified by an env var `VITE_PORT`. If not specified, it will default to 8080.

I feel 1 is the "mandatory" part of the PR. It makes no sense to allow the frontend to try different ports as it won't be able to connect to the backend anyway.

part 2 is optional, I think it's nice to allow to use another port. But if people object, I'd happily remove it and just leave 1.