### PR TITLE
ios: add initial bluetooth functionality

### DIFF
--- a/frontends/ios/BitBoxApp/BitBoxApp.xcodeproj/project.pbxproj
+++ b/frontends/ios/BitBoxApp/BitBoxApp.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		D700B6032CA2FFAF000496D4 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D765160F2B1F3B1500DC03A9 /* Preview Assets.xcassets */; };
 		D700B6042CA2FFAF000496D4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D765160C2B1F3B1500DC03A9 /* Assets.xcassets */; };
 		D700B6062CA2FFAF000496D4 /* Mobileserver.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D76518BB2B1F8F7400DC03A9 /* Mobileserver.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D721B20D2D369EC100767080 /* Bluetooth.swift in Sources */ = {isa = PBXBuildFile; fileRef = D721B20C2D369EC100767080 /* Bluetooth.swift */; };
+		D721B20E2D36A00000767080 /* Bluetooth.swift in Sources */ = {isa = PBXBuildFile; fileRef = D721B20C2D369EC100767080 /* Bluetooth.swift */; };
 		D76516092B1F3B1300DC03A9 /* BitBoxAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76516082B1F3B1300DC03A9 /* BitBoxAppApp.swift */; };
 		D765160D2B1F3B1500DC03A9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D765160C2B1F3B1500DC03A9 /* Assets.xcassets */; };
 		D76516102B1F3B1500DC03A9 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D765160F2B1F3B1500DC03A9 /* Preview Assets.xcassets */; };
@@ -72,6 +74,7 @@
 		D700B5F82C888CB9000496D4 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		D700B5F92C986A3C000496D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D700B60A2CA2FFAF000496D4 /* BitBoxApp Testnet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "BitBoxApp Testnet.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D721B20C2D369EC100767080 /* Bluetooth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bluetooth.swift; sourceTree = "<group>"; };
 		D76516052B1F3B1300DC03A9 /* BitBoxApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BitBoxApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D76516082B1F3B1300DC03A9 /* BitBoxAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitBoxAppApp.swift; sourceTree = "<group>"; };
 		D765160C2B1F3B1500DC03A9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -154,6 +157,7 @@
 				D76516322B1F3D1A00DC03A9 /* WebView.swift */,
 				D765160C2B1F3B1500DC03A9 /* Assets.xcassets */,
 				D765160E2B1F3B1500DC03A9 /* Preview Content */,
+				D721B20C2D369EC100767080 /* Bluetooth.swift */,
 			);
 			path = BitBoxApp;
 			sourceTree = "<group>";
@@ -396,6 +400,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D700B5FD2CA2FFAF000496D4 /* WebView.swift in Sources */,
+				D721B20E2D36A00000767080 /* Bluetooth.swift in Sources */,
 				D700B5FE2CA2FFAF000496D4 /* BitBoxAppApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -405,6 +410,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D76516332B1F3D1B00DC03A9 /* WebView.swift in Sources */,
+				D721B20D2D369EC100767080 /* Bluetooth.swift in Sources */,
 				D76516092B1F3B1300DC03A9 /* BitBoxAppApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/frontends/ios/BitBoxApp/BitBoxApp/Bluetooth.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/Bluetooth.swift
@@ -1,0 +1,234 @@
+//
+//  Bluetooth.swift
+//  BitBoxApp
+//
+//  Created by dev on 14.01.2025.
+//
+
+import CoreBluetooth
+import Mobileserver
+
+
+class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeripheralDelegate {
+    var centralManager: CBCentralManager!
+    var discoveredPeripheral: CBPeripheral?
+    var pWriter: CBCharacteristic?
+    var pReader: CBCharacteristic?
+
+    private var readBuffer = Data()
+    private let readBufferLock = NSLock() // Ensure thread-safe buffer access
+    private let semaphore = DispatchSemaphore(value: 0)
+
+    override init() {
+        super.init()
+        centralManager = CBCentralManager(delegate: self, queue: nil)
+    }
+
+    func isConnected() -> Bool {
+        return discoveredPeripheral != nil && pReader != nil && pWriter != nil;
+    }
+
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        switch central.state {
+        case .poweredOn:
+            print("Bluetooth on")
+            centralManager.scanForPeripherals(
+                withServices: [CBUUID(string: "e1511a45-f3db-44c0-82b8-6c880790d1f1")],
+                options: nil)
+        case .poweredOff, .unauthorized, .unsupported, .resetting, .unknown:
+            print("Bluetooth unavailable or not supported")
+            discoveredPeripheral = nil
+            pReader = nil
+            pWriter = nil
+        @unknown default:
+            print("Unknown Bluetooth state")
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber) {
+        print("Bluetooth: discovered \(peripheral.name ?? "unknown device")")
+        discoveredPeripheral = peripheral
+        centralManager.stopScan()
+        centralManager.connect(peripheral, options: nil)
+    }
+
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        print("Connected to \(peripheral.name ?? "unknown device")")
+
+        peripheral.delegate = self
+        peripheral.discoverServices(nil)
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        if let error = error {
+            print("Error discovering services: \(error.localizedDescription)")
+            return
+        }
+
+        if let services = peripheral.services {
+            for service in services {
+                print("Discovered service: \(service.uuid)")
+                peripheral.discoverCharacteristics(nil, for: service)
+            }
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        if let error = error {
+            print("Error discovering characteristics: \(error.localizedDescription)")
+            return
+        }
+        if let characteristics = service.characteristics {
+            for c in characteristics {
+                print("Discovered characteristic: \(c.uuid)")
+                if c.uuid == CBUUID(string: "0001") {
+                    pWriter = c
+                    let max_len = peripheral.maximumWriteValueLength(for: CBCharacteristicWriteType.withoutResponse)
+                    print("Found writer service with max length \(max_len) - \(c.properties.contains(.write))")
+                }
+                if c.uuid == CBUUID(string: "0002") {
+                    pReader = c
+                }
+            }
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        if let error = error {
+            print("Bluetooth error writing data: \(error)")
+            return
+        }
+        print("Blluetooth write ok")
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        if let error = error {
+            print("Error receiving data: \(error)")
+            return
+        }
+
+        if characteristic == pReader, let data = characteristic.value {
+            print("Bluetooth received data: \(data.hexEncodedString())")
+            readBufferLock.lock()
+            readBuffer.append(data)
+            readBufferLock.unlock()
+
+            // Signal the semaphore to unblock `readBlocking`
+            semaphore.signal()
+        }
+    }
+
+    // This method gets called if the peripheral disconnects
+    func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        print("Bluetooth disconnected")
+        discoveredPeripheral = nil;
+        pReader = nil;
+        pWriter = nil;
+
+        // TODO: start scanning again.
+    }
+
+    func readBlocking(length: Int) -> Data? {
+        guard let pReader = pReader else {
+            print("pReader is not set")
+            return nil
+        }
+        guard let peripheral = discoveredPeripheral else {
+            print("discoveredPeripheral is not set")
+            return nil
+        }
+        print("Bluetooth wants to read \(length)")
+        readBufferLock.lock()
+        readBuffer.removeAll() // Clear buffer before starting
+        readBufferLock.unlock()
+
+        // Loop until we've read the required amount of data
+        while readBuffer.count < length {
+            // Trigger a read request
+            peripheral.readValue(for: pReader)
+            // Block until the delegate signals
+            semaphore.wait()
+        }
+        print("Bluetooth read: need \(length), got \(readBuffer.count)")
+        readBufferLock.lock()
+        let data = readBuffer.prefix(length)
+        readBufferLock.unlock()
+
+        return data
+    }
+}
+
+// The interface is currently geared towards USB. For now we pretend to be a USB BitBox02 device.
+// TODO: change interface to be more generic, and use data from the characteristics to determine the
+// product, version, etc.
+class BluetoothDeviceInfo: NSObject, MobileserverGoDeviceInfoInterfaceProtocol {
+    private let bluetoothManager: BluetoothManager
+
+    init(bluetoothManager: BluetoothManager) {
+        self.bluetoothManager = bluetoothManager
+    }
+
+    func identifier() -> String {
+        return bluetoothManager.discoveredPeripheral!.identifier.uuidString
+    }
+
+    func interface() -> Int {
+        return 0
+    }
+
+    func open() throws -> MobileserverGoReadWriteCloserInterfaceProtocol {
+       return BluetoothReadWriteCloser(bluetoothManager: bluetoothManager)
+    }
+
+    func product() -> String {
+        return "BitBox02BTC"
+    }
+
+    func vendorID() -> Int {
+        return 0x03eb
+    }
+
+    func productID() -> Int {
+        return 0x2403
+    }
+
+    func serial() -> String {
+        return "v9.21.0"
+    }
+
+    func usagePage() -> Int {
+        return 0
+    }
+}
+
+class BluetoothReadWriteCloser: NSObject, MobileserverGoReadWriteCloserInterfaceProtocol {
+    private let bluetoothManager: BluetoothManager
+
+    init(bluetoothManager: BluetoothManager) {
+        self.bluetoothManager = bluetoothManager
+    }
+
+    func close() throws {
+    }
+
+    func read(_ n: Int) throws -> Data {
+        return bluetoothManager.readBlocking(length: n)!
+    }
+
+    func write(_ data: Data?, n: UnsafeMutablePointer<Int>?) throws {
+        guard let pWriter = bluetoothManager.pWriter else {
+            return
+        }
+
+        print("Bluetooth write data: \(data!.hexEncodedString())")
+
+        bluetoothManager.discoveredPeripheral!.writeValue(data!, for: pWriter, type: .withResponse)
+        n!.pointee = data!.count;
+    }
+}
+
+extension Data {
+    func hexEncodedString() -> String {
+        return map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/frontends/ios/BitBoxApp/BitBoxApp/Info.plist
+++ b/frontends/ios/BitBoxApp/BitBoxApp/Info.plist
@@ -6,5 +6,9 @@
 	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>We need access to the camera to scan QR codes.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>This app uses Bluetooth to connect to devices.</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Bluetooth is needed for communication with devices.</string>
 </dict>
 </plist>


### PR DESCRIPTION
In this initial prototype, the app connects to the bluetooth dev-kit and wires up communication so the BitBoxApp can talk to it as if it was a BitBox02. In the future we want to enumerate BitBoxes in the UI,
but for now we simply connect to the devkit immediately.

The backend environment DeviceInfo function is used by the backend to recognize if a device is connected. We use it to recognize a bluetooth device. The interface is geared for USB HID devices, so for now we simply pretend to be a USB device. In a future PR we should change the DeviceInfo to be more generic, or have a separate method for Bluetooth devices.