### PR TITLE
backend: show deducted amount only for non-erc20.

### DIFF
--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -151,7 +151,7 @@ type Transaction struct {
 	Status                   accounts.TxStatus `json:"status"`
 	Amount                   FormattedAmount   `json:"amount"`
 	AmountAtTime             FormattedAmount   `json:"amountAtTime"`
-	DeductedAmount           FormattedAmount   `json:"deductedAmount"`
+	DeductedAmountAtTime     FormattedAmount   `json:"deductedAmountAtTime"`
 	Fee                      FormattedAmount   `json:"fee"`
 	Time                     *string           `json:"time"`
 	Addresses                []string          `json:"addresses"`
@@ -190,18 +190,17 @@ func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail
 		Unit:   amount.Unit,
 	}
 	var formattedTime *string
-	var deductedAmount FormattedAmount
 	timestamp := txInfo.Timestamp
 	if timestamp == nil {
 		timestamp = txInfo.CreatedTimestamp
 	}
+
+	var deductedAmountAtTime FormattedAmount
 	if timestamp != nil {
 		t := timestamp.Format(time.RFC3339)
 		formattedTime = &t
 		amountAtTime = handlers.formatAmountAtTimeAsJSON(txInfo.Amount, timestamp)
-		if txInfo.Fee != nil && txInfo.Type == accounts.TxTypeSend {
-			deductedAmount = handlers.formatAmountAtTimeAsJSON(coin.SumAmounts(txInfo.Amount, *txInfo.Fee), timestamp)
-		}
+		deductedAmountAtTime = handlers.formatAmountAtTimeAsJSON(txInfo.DeductedAmount, timestamp)
 	}
 
 	addresses := []string{}
@@ -218,14 +217,14 @@ func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail
 			accounts.TxTypeSend:     "send",
 			accounts.TxTypeSendSelf: "send_to_self",
 		}[txInfo.Type],
-		Status:         txInfo.Status,
-		Amount:         amount,
-		AmountAtTime:   amountAtTime,
-		DeductedAmount: deductedAmount,
-		Time:           formattedTime,
-		Addresses:      addresses,
-		Note:           handlers.account.TxNote(txInfo.InternalID),
-		Fee:            feeString,
+		Status:               txInfo.Status,
+		Amount:               amount,
+		AmountAtTime:         amountAtTime,
+		DeductedAmountAtTime: deductedAmountAtTime,
+		Time:                 formattedTime,
+		Addresses:            addresses,
+		Note:                 handlers.account.TxNote(txInfo.InternalID),
+		Fee:                  feeString,
 	}
 
 	if detail {

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -246,7 +246,7 @@ export interface ITransaction {
     amountAtTime: IAmount;
     fee: IAmount;
     feeRatePerKb: IAmount;
-    deductedAmount: IAmount;
+    deductedAmountAtTime: IAmount;
     gas: number;
     nonce: number | null;
     internalID: string;

--- a/frontends/web/src/components/amount/conversion-amount.tsx
+++ b/frontends/web/src/components/amount/conversion-amount.tsx
@@ -24,6 +24,7 @@ import styles from './conversion-amount.module.css';
 
 type TConversionAmountProps = {
   amount: IAmount;
+  deductedAmount: IAmount;
   type: TTransactionType;
 }
 
@@ -34,6 +35,7 @@ const btcUnits: Readonly<string[]> = ['BTC', 'TBTC', 'sat', 'tsat'];
  */
 export const ConversionAmount = ({
   amount,
+  deductedAmount,
   type,
 }: TConversionAmountProps) => {
   const { defaultCurrency } = useContext(RatesContext);
@@ -41,10 +43,12 @@ export const ConversionAmount = ({
   const sign = getTxSign(type);
   const estimatedPrefix = '\u2248'; // ≈
   const sendToSelf = type === 'send_to_self';
-  const conversionUnit = sendToSelf ? amount.unit : defaultCurrency;
+  const recv = type === 'receive';
+  const amountToShow = recv || sendToSelf ? amount : deductedAmount;
+  const conversionUnit = sendToSelf ? amountToShow.unit : defaultCurrency;
 
   // we skip the estimated conversion prefix when the Tx is send to self, or both coin and conversion are in BTC units.
-  const skipEstimatedPrefix = sendToSelf || (btcUnits.includes(conversionUnit) && btcUnits.includes(amount.unit));
+  const skipEstimatedPrefix = sendToSelf || (btcUnits.includes(conversionUnit) && btcUnits.includes(amountToShow.unit));
 
   return (
     <span className={styles.txConversionAmount}>
@@ -53,7 +57,7 @@ export const ConversionAmount = ({
           <Arrow type="send_to_self" />
         </span>
       )}
-      {amount.estimated && !skipEstimatedPrefix && (
+      {amountToShow.estimated && !skipEstimatedPrefix && (
         <span className={styles.txPrefix}>
           {estimatedPrefix}
           {' '}
@@ -61,7 +65,7 @@ export const ConversionAmount = ({
       )}
       {conversion && !sendToSelf ? sign : null}
       <Amount
-        amount={sendToSelf ? amount.amount : conversion || ''}
+        amount={sendToSelf ? amountToShow.amount : conversion || ''}
         unit={conversionUnit}
       />
       <span className={styles.txUnit}>

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -33,8 +33,7 @@ type TTransactionProps = ITransaction & {
 export const Transaction = ({
   addresses,
   amountAtTime,
-  fee,
-  deductedAmount,
+  deductedAmountAtTime,
   onShowDetail,
   internalID,
   note,
@@ -67,8 +66,8 @@ export const Transaction = ({
           type={type}
         />
         <Amounts
-          amount={type === 'send' ? deductedAmount : amountAtTime}
-          fee={fee}
+          amount={amountAtTime}
+          deductedAmount={deductedAmountAtTime}
           type={type}
         />
         <button
@@ -151,18 +150,18 @@ const Status = ({
 
 type TAmountsProps = {
   amount: IAmount;
-  fee: IAmount;
+  deductedAmount: IAmount,
   type: TTransactionType;
 }
 
 const Amounts = ({
   amount,
-  fee,
+  deductedAmount,
   type,
 }: TAmountsProps) => {
   const txTypeClass = `txAmount-${type}`;
-  const sendToSelf = type === 'send_to_self';
   const sign = getTxSign(type);
+  const recv = type === 'receive';
 
   return (
     <span className={`${styles.txAmountsColumn} ${styles[txTypeClass]}`}>
@@ -170,16 +169,16 @@ const Amounts = ({
       <span className={styles.txAmount}>
         {sign}
         <Amount
-          amount={sendToSelf ? fee.amount : amount.amount}
-          unit={amount.unit}
+          amount={recv ? amount.amount : deductedAmount.amount}
+          unit={recv ? amount.unit : deductedAmount.unit}
         />
         <span className={styles.txUnit}>
           {' '}
-          {sendToSelf ? fee.unit : amount.unit}
+          {deductedAmount.unit}
         </span>
       </span>
       {/* </data> */}
-      <ConversionAmount amount={amount} type={type} />
+      <ConversionAmount amount={amount} deductedAmount={deductedAmount} type={type} />
     </span>
   );
 };


### PR DESCRIPTION
Move the logic to compute the deducted amount out of the handlers exclude erc20 tokens from the computation.