### PR TITLE
frontend/qt: add -dataDir cli flag

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1003,7 +1003,7 @@ func (backend *Backend) ExportLogs() error {
 		backend.log.WithError(err).Error("error creating new log file")
 		return err
 	}
-	logFilePath := filepath.Join(utilConfig.AppDir(), "log.txt")
+	logFilePath := filepath.Join(backend.arguments.MainDirectoryPath(), "log.txt")
 
 	existingLogFile, err := os.Open(logFilePath)
 	if err != nil {

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -303,7 +303,6 @@ int main(int argc, char *argv[])
         // issues were observed on Windows and the app crashes on some Linux systems.
         qputenv("QMLSCENE_DEVICE", "softwarecontext");
         qputenv("QT_QUICK_BACKEND", "software");
-        goLog("BITBOXAPP_RENDER=software");
     } else if (renderMode == "auto") {
         // Do nothing: leave it to Qt to decide the rendering backend, which is usually hardware
         // accelerated if available.
@@ -311,10 +310,8 @@ int main(int argc, char *argv[])
         // In rare cases, this can lead to rendering artefacts and crashes, which is why it is not
         // enabled by default.
         std::cerr << "Rendering mode: automatic (usually hardware accelerated)" << std::endl;
-        goLog("BITBOXAPP_RENDER=auto");
     } else {
         std::cerr << "Invalid value for BITBOXAPP_RENDER" << std::endl;
-        goLog("Invalid value for BITBOXAPP_RENDER");
         return 1;
     }
 
@@ -328,7 +325,7 @@ int main(int argc, char *argv[])
     a.setWindowIcon(QIcon(QCoreApplication::applicationDirPath() + "/bitbox.png"));
 
     if(a.isSecondary()) {
-        // The application is already running. If there is exactly one positional argument, we send
+        // The application is already running. If there is exactly one positional argument, we
         // assume it is an URI click and send it to the primary instance to parse, validate and
         // handle.
 
@@ -430,6 +427,10 @@ int main(int argc, char *argv[])
             memcpy(result, cString, strlen(cString)+1);
             return result;
         });
+
+    char renderLog[1000] = {0};
+    snprintf(renderLog, sizeof(renderLog), "BITBOXAPP_RENDER=%s", renderMode.toStdString().c_str());
+    goLog(renderLog);
 
     RequestInterceptor interceptor;
     view->page()->profile()->setUrlRequestInterceptor(&interceptor);

--- a/frontends/qt/server/server.go
+++ b/frontends/qt/server/server.go
@@ -69,6 +69,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/bridgecommon"
 	btctypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/types"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/usb"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/config"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/logging"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/system"
 )
@@ -112,8 +113,6 @@ func serve(
 	preferredLocale *C.cchar_t,
 	getSaveFilenameFn C.getSaveFilenameCallback,
 ) {
-	log := logging.Get().WithGroup("server")
-	log.WithField("args", os.Args).Info("Started Qt application")
 	testnet := flag.Bool("testnet", false, "activate testnets")
 
 	if runtime.GOOS == "darwin" {
@@ -129,8 +128,17 @@ func serve(
 
 	gapLimitsReceive := flag.Uint("gapLimitReceive", 0, "gap limit for receive addresses. Do not use this unless you know what this means.")
 	gapLimitsChange := flag.Uint("gapLimitChange", 0, "gap limit for change addresses. Do not use this unless you know what this means.")
+	var dataDir *string
+	dataDir = flag.String("dataDir", "", "location where BitBoxApp's data files are stored.")
 
 	flag.Parse()
+
+	if *dataDir != "" {
+		config.SetAppDir(*dataDir)
+	}
+
+	log := logging.Get().WithGroup("server")
+	log.WithField("args", os.Args).Info("Started Qt application")
 
 	var gapLimits *btctypes.GapLimits
 	if *gapLimitsReceive != 0 || *gapLimitsChange != 0 {


### PR DESCRIPTION
Allow users to specify where the app data files will be stored.

Any use of goLog is moved below the first call to serve() as goLog uses the data dir to write to the log, but the data dir is only determined in serve().