### PR TITLE
backend: add BtcDirect to exchange deals.

### DIFF
--- a/backend/exchanges/btcdirect.go
+++ b/backend/exchanges/btcdirect.go
@@ -20,25 +20,59 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 )
 
+const (
+	// BTCDirectName is the name of the exchange, it is unique among all the supported exchanges.
+	BTCDirectName = "btcdirect"
+)
+
 var regions = []string{
 	"AD", "AT", "BE", "BG", "CH", "CZ", "DE", "DK", "EE", "ES", "FI", "FR", "GR",
 	"HR", "HU", "IS", "IT", "LI", "LT", "LU", "LV", "MD", "ME", "MK", "NL", "NO",
 	"PL", "PT", "RO", "RS", "SE", "SI", "SK", "SM"}
 
-// GetBtcDirectSupportedRegions reutrn a string slice of the regions where BTC direct services
+// GetBtcDirectSupportedRegions returns a string slice of the regions where BTC direct services
 // are available.
 func GetBtcDirectSupportedRegions() []string {
 	return regions
 }
 
-// IsBtcDirectSupported is true if coin.Code and region are supported by BtcDirect.
-func IsBtcDirectSupported(coinCode coin.Code, region string) bool {
+// isRegionSupportedBtcDirect returns whether a specific region (or an empty one
+// for "unspecified") is supported by BtcDirect.
+func isRegionSupportedBtcDirect(region string) bool {
+	return len(region) == 0 || slices.Contains(regions, region)
+}
+
+// IsBtcDirectSupported is true if coin.Code is supported by BtcDirect.
+func IsBtcDirectSupported(coinCode coin.Code) bool {
 	supportedCoins := []coin.Code{
 		coin.CodeBTC, coin.CodeTBTC, coin.CodeLTC, coin.CodeTLTC, coin.CodeETH, coin.CodeSEPETH,
 		"eth-erc20-usdt", "eth-erc20-usdc", "eth-erc20-link"}
 
 	coinSupported := slices.Contains(supportedCoins, coinCode)
-	regionSupported := len(region) == 0 || slices.Contains(regions, region)
 
-	return coinSupported && regionSupported
+	return coinSupported
+}
+
+// IsBtcDirectOTCSupportedForCoinInRegion returns whether Btc Direct OTC is supported for the specific
+// combination of coin and region.
+func IsBtcDirectOTCSupportedForCoinInRegion(coinCode coin.Code, region string) bool {
+	return IsBtcDirectSupported(coinCode) && isRegionSupportedBtcDirect(region)
+}
+
+// BtcDirectDeals returns the purchase conditions (fee and payment methods) offered by BTCDirect.
+func BtcDirectDeals() *ExchangeDealsList {
+	return &ExchangeDealsList{
+		ExchangeName: BTCDirectName,
+		Deals: []*ExchangeDeal{
+			{
+				Fee:     3,
+				Payment: CardPayment,
+				IsFast:  true,
+			},
+			{
+				Fee:     2,
+				Payment: BankTransferPayment,
+			},
+		},
+	}
 }

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -241,7 +241,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/exchange/by-region/{code}", handlers.getExchangesByRegion).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/exchange/deals/{action}/{code}", handlers.getExchangeDeals).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/exchange/supported/{code}", handlers.getExchangeSupported).Methods("GET")
-	getAPIRouterNoError(apiRouter)("/exchange/btcdirect/supported/{code}", handlers.getBtcDirectSupported).Methods("GET")
+	getAPIRouterNoError(apiRouter)("/exchange/btcdirect-otc/supported/{code}", handlers.getExchangeBtcDirectOTCSupported).Methods("GET")
 	getAPIRouter(apiRouter)("/exchange/moonpay/buy-info/{code}", handlers.getExchangeMoonpayBuyInfo).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/exchange/pocket/api-url/{action}", handlers.getExchangePocketURL).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/exchange/pocket/verify-address", handlers.postPocketWidgetVerifyAddress).Methods("POST")
@@ -1346,7 +1346,7 @@ func (handlers *Handlers) getExchangeDeals(r *http.Request) interface{} {
 	}
 }
 
-func (handlers *Handlers) getBtcDirectSupported(r *http.Request) interface{} {
+func (handlers *Handlers) getExchangeBtcDirectOTCSupported(r *http.Request) interface{} {
 	type Result struct {
 		Supported bool `json:"supported"`
 		Success   bool `json:"success"`
@@ -1370,7 +1370,7 @@ func (handlers *Handlers) getBtcDirectSupported(r *http.Request) interface{} {
 	regionCode := r.URL.Query().Get("region")
 	return Result{
 		Success:   true,
-		Supported: exchanges.IsBtcDirectSupported(acct.Coin().Code(), regionCode),
+		Supported: exchanges.IsBtcDirectOTCSupportedForCoinInRegion(acct.Coin().Code(), regionCode),
 	}
 }
 
@@ -1395,6 +1395,9 @@ func (handlers *Handlers) getExchangeSupported(r *http.Request) interface{} {
 	}
 	if exchanges.IsPocketSupported(acct.Coin().Code()) {
 		supported.Exchanges = append(supported.Exchanges, exchanges.PocketName)
+	}
+	if exchanges.IsBtcDirectSupported(acct.Coin().Code()) {
+		supported.Exchanges = append(supported.Exchanges, exchanges.BTCDirectName)
 	}
 
 	return supported

--- a/frontends/web/src/api/exchanges.ts
+++ b/frontends/web/src/api/exchanges.ts
@@ -118,6 +118,6 @@ export type TBtcDirectResponse = {
 
 export const getBtcDirectOTCSupported = (code: AccountCode, region: ExchangeRegion['code']) => {
   return (): Promise<TBtcDirectResponse> => {
-    return apiGet(`exchange/btcdirect/supported/${code}?region=${region}`);
+    return apiGet(`exchange/btcdirect-otc/supported/${code}?region=${region}`);
   };
 };

--- a/frontends/web/src/routes/exchange/components/buysell.tsx
+++ b/frontends/web/src/routes/exchange/components/buysell.tsx
@@ -162,38 +162,6 @@ export const BuySell = ({
                 onClickInfoButton={() => setInfo(buildInfo(exchange))}
               />
             ))}
-            {/* TODO: 'BTC Direct' should come from exchangeDealsResponse */}
-            { action === 'buy' && (
-              <ExchangeSelectionRadio
-                key={'btcdirect'}
-                id={'BTC Direct'}
-                exchangeName={'btcdirect'}
-                deals={[{
-                  fee: 2,
-                  payment: 'card',
-                  isFast: true,
-                  isBest: false,
-                }, {
-                  fee: 2,
-                  payment: 'bank-transfer',
-                  isFast: false,
-                  isBest: false,
-                }]}
-                checked={selectedExchange === 'btcdirect'}
-                onChange={() => {
-                  onSelectExchange('btcdirect');
-                }}
-                onClickInfoButton={() => setInfo(buildInfo({
-                  exchangeName: 'btcdirect',
-                  deals: [{
-                    fee: 2,
-                    payment: 'card',
-                    isFast: true,
-                    isBest: false,
-                  }],
-                }))}
-              />
-            )}
           </div>
         )}
         {btcDirectOTCSupported?.success && btcDirectOTCSupported?.supported && (


### PR DESCRIPTION
Remove the hardcoded BtcDirect widget from the frontend code, ad instead add it to the returned list of exchange deals in the backend.


