### PR TITLE
frontend: use postmessage to communicate with the iframe

### DIFF
--- a/backend/arguments/arguments.go
+++ b/backend/arguments/arguments.go
@@ -49,8 +49,9 @@ type Arguments struct {
 	regtest bool
 
 	// devservers stores wether the app should connect to the dev servers.
-	// This also applies to the Pocket widget environment: if devserver is true, the widget
-	// will be loaded from the staging environment, otherwise from production.
+	// This also applies to the Pocket and BTCDirect widget environments:
+	// if devserver is true, the widgets will be loaded from the staging environment,
+	// otherwise from production.
 	// The devservers configuration is not persisted when switching back to production.
 	devservers bool
 

--- a/backend/exchanges/btcdirect.go
+++ b/backend/exchanges/btcdirect.go
@@ -17,13 +17,28 @@ package exchanges
 import (
 	"slices"
 
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 )
 
 const (
 	// BTCDirectName is the name of the exchange, it is unique among all the supported exchanges.
 	BTCDirectName = "btcdirect"
+
+	btcDirectTestApiKey = "6ed4d42bd02eeac1776a6bb54fa3126f779c04d5c228fe5128bb74e89ef61f83"
+
+	btcDirectProdAPiKey = "7d71f633626901d5c4d06d91f7d0db2c15cdf524ddd0ebcd36f4d9c4e04694cd"
+
+	btcDirectUrlTesting = "/btcdirect/fiat-to-coin.html"
+
+	btcDirectUrlProd = "https://bitboxapp.shiftcrypto.io/widgets/btcdirect/v1/fiat-to-coin.html"
 )
+
+type btcDirectInfo struct {
+	Url     string
+	ApiKey  string
+	Address *string
+}
 
 var regions = []string{
 	"AT", "BE", "BG", "CH", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FR", "GR",
@@ -75,4 +90,24 @@ func BtcDirectDeals() *ExchangeDealsList {
 			},
 		},
 	}
+}
+
+// BtcDirectInfo returns the information needed to interact with BtcDirect.
+// If `devServers` is true, it returns testing URL and ApiKey.
+func BtcDirectInfo(action ExchangeAction, acct accounts.Interface, devServers bool) btcDirectInfo {
+	res := btcDirectInfo{
+		Url:    btcDirectUrlProd,
+		ApiKey: btcDirectProdAPiKey,
+	}
+
+	if devServers {
+		res.Url = btcDirectUrlTesting
+		res.ApiKey = btcDirectTestApiKey
+	}
+
+	if action == BuyAction {
+		addr := acct.GetUnusedReceiveAddresses()[0].Addresses[0].EncodeForHumans()
+		res.Address = &addr
+	}
+	return res
 }

--- a/frontends/web/public/btcdirect/fiat-to-coin.html
+++ b/frontends/web/public/btcdirect/fiat-to-coin.html
@@ -10,104 +10,123 @@
 
 <script lang="js">
   ;(() => {
-    const {
-      address,
-      apiKey,
-      baseCurrency,
-      mode,
-      quoteCurrency,
-    } = window.frameElement?.dataset;
 
-    if (mode === 'debug') {
-      console.info(window.frameElement?.dataset);
-    }
-
-    if ( // this should never happen, but if it does we stop here
-      !address
-      || !baseCurrency
-      || !quoteCurrency
-    ) {
-      document.body.append(
-        Object.assign(document.createElement('h1'), {
-          style: 'color: red; padding: 1rem;',
-          textContent: `Unexpected error:
-            ${!address ? 'Address missing' : ''}
-            ${!baseCurrency ? 'BaseCurrency missing' : ''}
-            ${!quoteCurrency ? 'QuoteCurrency missing' : ''}
-          `
-        })
-      );
+    if (window.top === window) {
+      showError('Unexpected error');
       return;
     }
 
-    const currency = baseCurrency.toUpperCase();
+    const onMessage = (event) => {
+      switch (event.data?.action) {
+      case 'configuration':
+        const {
+          address,
+          apiKey,
+          baseCurrency,
+          mode,
+          quoteCurrency,
+        } = event.data || {};
 
-    // add the btcdirect CSS
-    document.head.appendChild(
-      Object.assign(document.createElement('link'), {
-        href: (
+        if ( // this should never happen, but if it does we stop here
+          !address
+          || !baseCurrency
+          || !quoteCurrency
+        ) {
+          showError(`Unexpected error:
+            ${!address ? 'Address missing' : ''}
+            ${!baseCurrency ? 'BaseCurrency missing' : ''}
+            ${!quoteCurrency ? 'QuoteCurrency missing' : ''}
+          `);
+          return;
+        }
+        const currency = baseCurrency.toUpperCase();
+
+        // add the btcdirect CSS
+        document.head.appendChild(
+          Object.assign(document.createElement('link'), {
+            href: (
+              mode === 'production'
+              ? 'https://cdn.btcdirect.eu/fiat-to-coin/fiat-to-coin.css'
+              : 'https://cdn-sandbox.btcdirect.eu/fiat-to-coin/fiat-to-coin.css'
+            ),
+            rel: 'stylesheet',
+          })
+        );
+
+        // add the btcdirect script
+        (function (btc, d, i, r, e, c, t) {
+          btc[r] = btc[r] || function () {
+            (btc[r].q = btc[r].q || []).push(arguments)
+          };
+          c = d.createElement(i);
+          c.id = r; c.src = e; c.async = true;
+          c.type = 'module'; c.dataset.btcdirect = '';
+          t = d.getElementsByTagName(i)[0];
+          t.parentNode.insertBefore(c, t);
+        })(window, document, 'script', 'btcdirect',
           mode === 'production'
-          ? 'https://cdn.btcdirect.eu/fiat-to-coin/fiat-to-coin.css'
-          : 'https://cdn-sandbox.btcdirect.eu/fiat-to-coin/fiat-to-coin.css'
-        ),
-        rel: 'stylesheet',
-      })
-    );
+          ? 'https://cdn.btcdirect.eu/fiat-to-coin/fiat-to-coin.js'
+          : 'https://cdn-sandbox.btcdirect.eu/fiat-to-coin/fiat-to-coin.js'
+        );
 
-    // add the btcdirect script
-    (function (btc, d, i, r, e, c, t) {
-      btc[r] = btc[r] || function () {
-        (btc[r].q = btc[r].q || []).push(arguments)
-      };
-      c = d.createElement(i);
-      c.id = r; c.src = e; c.async = true;
-      c.type = 'module'; c.dataset.btcdirect = '';
-      t = d.getElementsByTagName(i)[0];
-      t.parentNode.insertBefore(c, t);
-    })(window, document, 'script', 'btcdirect',
-      mode === 'production'
-      ? 'https://cdn.btcdirect.eu/fiat-to-coin/fiat-to-coin.js'
-      : 'https://cdn-sandbox.btcdirect.eu/fiat-to-coin/fiat-to-coin.js'
-    );
+        btcdirect('init', {
+          token: apiKey,
+          debug: mode === 'debug',
+          locale: window.frameElement?.dataset.locale || 'en-GB',
+          theme: window.frameElement?.dataset.theme || 'light',
+        });
 
-    btcdirect('init', {
-      token: apiKey,
-      debug: mode === 'debug',
-      locale: window.frameElement?.dataset.locale || 'en-US',
-      theme: window.frameElement?.dataset.theme || 'light',
-    });
+        // fiat to coin order
+        btcdirect('wallet-addresses', {
+          addresses: {
+            address,
+            currency,
+            id: 'BitBox',
+            walletName: 'BitBox'
+          }
+        });
 
-    // fiat to coin order
-    btcdirect('wallet-addresses', {
-      addresses: {
-        address,
-        currency,
-        id: 'BitBox',
-        walletName: 'BitBox'
+        btcdirect('set-parameters',
+          mode === 'production' ? {
+            baseCurrency: currency,
+            fixedCurrency: true,
+            quoteCurrency,
+            // paymentMethod: any of 'bancontact', 'bankTransfer', 'creditCard', 'giropay', 'iDeal', 'sofort', 'applepay'
+            showWalletAddress: false,
+          } : {
+            baseCurrency: currency,
+            fixedCurrency: true,
+            paymentMethod: 'sofort', // sandbox currently only supports sofort payment method
+            quoteCurrency,
+            showWalletAddress: false,
+          }
+        );
+
+        window.addEventListener('btcdirect-embeddable-fiat-to-coin-order-confirmed', (event) => {
+          console.log('btcdirect-embeddable-fiat-to-coin-order-confirmed', event);
+          // Handle the event
+          // Note that the sent information from the widget is found inside event.detail
+        });
+
+        break;
       }
-    });
+    };
 
-    btcdirect('set-parameters',
-      mode === 'production' ? {
-        baseCurrency: currency,
-        fixedCurrency: true,
-        quoteCurrency,
-        // paymentMethod: any of 'bancontact', 'bankTransfer', 'creditCard', 'giropay', 'iDeal', 'sofort', 'applepay'
-        showWalletAddress: false,
-      } : {
-        baseCurrency: currency,
-        fixedCurrency: true,
-        paymentMethod: 'sofort', // sandbox currently only supports sofort payment method
-        quoteCurrency,
-        showWalletAddress: false,
-      }
-    );
+    window.addEventListener('message', onMessage);
 
-    window.addEventListener('btcdirect-embeddable-fiat-to-coin-order-confirmed', (event) => {
-      console.log('btcdirect-embeddable-fiat-to-coin-order-confirmed', event);
-      // Handle the event
-      // Note that the sent information from the widget is found inside event.detail
-    });
+    // Request the parent to send attributes
+    window.parent.postMessage({
+      action: 'request-configuration'
+    }, '*');
+
+    function showError(message) {
+      document.body.append(
+        Object.assign(document.createElement('h1'), {
+          style: 'color: red; padding: 1rem;',
+          textContent: message,
+        })
+      );
+    }
 
   })();
 </script>

--- a/frontends/web/src/api/exchanges.ts
+++ b/frontends/web/src/api/exchanges.ts
@@ -103,6 +103,7 @@ export type TBTCDirectInfoResponse = {
   success: true;
   url: string;
   apiKey: string;
+  address?: string;
 } | {
   success: false;
   errorMessage: string;
@@ -110,15 +111,9 @@ export type TBTCDirectInfoResponse = {
 
 export const getBTCDirectInfo = (
   action: TExchangeAction,
+  code: string,
 ): Promise<TBTCDirectInfoResponse> => {
-  console.log(action);
-  // TODO: change to return apiGet(`exchange/btc-direct/info/${action}`); or similar
-  return Promise.resolve({
-    success: true,
-    url: '/btcdirect/fiat-to-coin.html', // local static file for testing
-    apiKey: '6ed4d42bd02eeac1776a6bb54fa3126f779c04d5c228fe5128bb74e89ef61f83', // debug
-    // apiKey: '7d71f633626901d5c4d06d91f7d0db2c15cdf524ddd0ebcd36f4d9c4e04694cd', // prod
-  });
+  return apiGet(`exchange/btcdirect/info/${action}/${code}`);
 };
 
 export type SupportedExchanges= {
@@ -140,6 +135,6 @@ export type TBtcDirectResponse = {
 
 export const getBtcDirectOTCSupported = (code: AccountCode, region: ExchangeRegion['code']) => {
   return (): Promise<TBtcDirectResponse> => {
-    return apiGet(`exchange/btcdirect-otc/supported/${code}?region=${region}`);
+    return apiGet(`exchange/btcdirect/supported/${code}?region=${region}`);
   };
 };

--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -51,7 +51,7 @@ export const BTCDirect = ({ accounts, code }: TProps) => {
   const { isDarkMode } = useDarkmode();
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const btcdirectInfo = useLoad(() => getBTCDirectInfo('buy'));
+  const btcdirectInfo = useLoad(() => getBTCDirectInfo('buy', code));
 
   const receiveAddresses = useLoad(getReceiveAddressList(code));
 


### PR DESCRIPTION
The previous approach depended on the iframe having access to the parent context, but this wont work when the iframe is hosted on a different domain.

Instead of relaxing webengine restrictions this change simply uses postMessage api to pass data from and to the iframe.