### PR TITLE
frontend: use postmessage to communicate with the iframe

### DIFF
--- a/frontends/web/public/btcdirect/fiat-to-coin.html
+++ b/frontends/web/public/btcdirect/fiat-to-coin.html
@@ -10,104 +10,119 @@
 
 <script lang="js">
   ;(() => {
-    const {
-      address,
-      apiKey,
-      baseCurrency,
-      mode,
-      quoteCurrency,
-    } = window.frameElement?.dataset;
 
-    if (mode === 'debug') {
-      console.info(window.frameElement?.dataset);
-    }
-
-    if ( // this should never happen, but if it does we stop here
-      !address
-      || !baseCurrency
-      || !quoteCurrency
-    ) {
-      document.body.append(
-        Object.assign(document.createElement('h1'), {
-          style: 'color: red; padding: 1rem;',
-          textContent: `Unexpected error:
-            ${!address ? 'Address missing' : ''}
-            ${!baseCurrency ? 'BaseCurrency missing' : ''}
-            ${!quoteCurrency ? 'QuoteCurrency missing' : ''}
-          `
-        })
-      );
+    if (window.top === window) {
+      showError('Unexpected error');
       return;
     }
 
-    const currency = baseCurrency.toUpperCase();
+    const onMessage = (event) => {
+      switch (event.data?.action) {
+      case 'configuration':
+        const {
+          address,
+          apiKey,
+          baseCurrency,
+          locale,
+          mode,
+          quoteCurrency,
+          theme,
+        } = event.data || {};
 
-    // add the btcdirect CSS
-    document.head.appendChild(
-      Object.assign(document.createElement('link'), {
-        href: (
+        if ( // this should never happen, but if it does we stop here
+          !address
+          || !baseCurrency
+          || !quoteCurrency
+        ) {
+          showError(`Unexpected error:
+            ${!address ? 'Address missing' : ''}
+            ${!baseCurrency ? 'BaseCurrency missing' : ''}
+            ${!quoteCurrency ? 'QuoteCurrency missing' : ''}
+          `);
+          return;
+        }
+        const currency = baseCurrency.toUpperCase();
+
+        // add the btcdirect CSS
+        document.head.appendChild(
+          Object.assign(document.createElement('link'), {
+            href: (
+              mode === 'production'
+              ? 'https://cdn.btcdirect.eu/fiat-to-coin/fiat-to-coin.css'
+              : 'https://cdn-sandbox.btcdirect.eu/fiat-to-coin/fiat-to-coin.css'
+            ),
+            rel: 'stylesheet',
+          })
+        );
+
+        // add the btcdirect script
+        (function (btc, d, i, r, e, c, t) {
+          btc[r] = btc[r] || function () {
+            (btc[r].q = btc[r].q || []).push(arguments)
+          };
+          c = d.createElement(i);
+          c.id = r; c.src = e; c.async = true;
+          c.type = 'module'; c.dataset.btcdirect = '';
+          t = d.getElementsByTagName(i)[0];
+          t.parentNode.insertBefore(c, t);
+        })(window, document, 'script', 'btcdirect',
           mode === 'production'
-          ? 'https://cdn.btcdirect.eu/fiat-to-coin/fiat-to-coin.css'
-          : 'https://cdn-sandbox.btcdirect.eu/fiat-to-coin/fiat-to-coin.css'
-        ),
-        rel: 'stylesheet',
-      })
-    );
+          ? 'https://cdn.btcdirect.eu/fiat-to-coin/fiat-to-coin.js'
+          : 'https://cdn-sandbox.btcdirect.eu/fiat-to-coin/fiat-to-coin.js'
+        );
 
-    // add the btcdirect script
-    (function (btc, d, i, r, e, c, t) {
-      btc[r] = btc[r] || function () {
-        (btc[r].q = btc[r].q || []).push(arguments)
-      };
-      c = d.createElement(i);
-      c.id = r; c.src = e; c.async = true;
-      c.type = 'module'; c.dataset.btcdirect = '';
-      t = d.getElementsByTagName(i)[0];
-      t.parentNode.insertBefore(c, t);
-    })(window, document, 'script', 'btcdirect',
-      mode === 'production'
-      ? 'https://cdn.btcdirect.eu/fiat-to-coin/fiat-to-coin.js'
-      : 'https://cdn-sandbox.btcdirect.eu/fiat-to-coin/fiat-to-coin.js'
-    );
+        btcdirect('init', {
+          token: apiKey,
+          debug: mode === 'debug',
+          locale: locale || 'en-GB',
+          theme: theme || 'light',
+        });
 
-    btcdirect('init', {
-      token: apiKey,
-      debug: mode === 'debug',
-      locale: window.frameElement?.dataset.locale || 'en-US',
-      theme: window.frameElement?.dataset.theme || 'light',
-    });
+        // fiat to coin order
+        btcdirect('wallet-addresses', {
+          addresses: {
+            address,
+            currency,
+            id: 'BitBox',
+            walletName: 'BitBox'
+          }
+        });
 
-    // fiat to coin order
-    btcdirect('wallet-addresses', {
-      addresses: {
-        address,
-        currency,
-        id: 'BitBox',
-        walletName: 'BitBox'
+        btcdirect('set-parameters',
+          mode === 'production' ? {
+            baseCurrency: currency,
+            fixedCurrency: true,
+            quoteCurrency,
+            // paymentMethod: any of 'bancontact', 'bankTransfer', 'creditCard', 'giropay', 'iDeal', 'sofort', 'applepay'
+            showWalletAddress: false,
+          } : {
+            baseCurrency: currency,
+            fixedCurrency: true,
+            paymentMethod: 'sofort', // sandbox currently only supports sofort payment method
+            quoteCurrency,
+            showWalletAddress: false,
+          }
+        );
+
+        break;
       }
-    });
+    };
 
-    btcdirect('set-parameters',
-      mode === 'production' ? {
-        baseCurrency: currency,
-        fixedCurrency: true,
-        quoteCurrency,
-        // paymentMethod: any of 'bancontact', 'bankTransfer', 'creditCard', 'giropay', 'iDeal', 'sofort', 'applepay'
-        showWalletAddress: false,
-      } : {
-        baseCurrency: currency,
-        fixedCurrency: true,
-        paymentMethod: 'sofort', // sandbox currently only supports sofort payment method
-        quoteCurrency,
-        showWalletAddress: false,
-      }
-    );
+    window.addEventListener('message', onMessage);
 
-    window.addEventListener('btcdirect-embeddable-fiat-to-coin-order-confirmed', (event) => {
-      console.log('btcdirect-embeddable-fiat-to-coin-order-confirmed', event);
-      // Handle the event
-      // Note that the sent information from the widget is found inside event.detail
-    });
+    // Request the parent to send attributes
+    window.parent.postMessage({
+      action: 'request-configuration'
+    }, '*');
+
+    function showError(message) {
+      document.body.append(
+        Object.assign(document.createElement('h1'), {
+          style: 'color: red; padding: 1rem;',
+          textContent: message,
+        })
+      );
+    }
 
   })();
 </script>

--- a/frontends/web/public/btcdirect/fiat-to-coin.html
+++ b/frontends/web/public/btcdirect/fiat-to-coin.html
@@ -6,7 +6,6 @@
 <link href="./btcdirect.css" rel="stylesheet">
 
 <div class="btcdirect-widget"></div>
-<script src="./polyfill.js"></script>
 
 <script lang="js">
   ;(() => {
@@ -14,6 +13,15 @@
     if (window.top === window) {
       showError('Unexpected error');
       return;
+    }
+
+    // polyfill if crypto.randomUUID is not available, i.e. in Qt WebEngine
+    if (!crypto.randomUUID) {
+      crypto.randomUUID = function () {
+        return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+          (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+        );
+      };
     }
 
     const onMessage = (event) => {

--- a/frontends/web/public/btcdirect/polyfill.js
+++ b/frontends/web/public/btcdirect/polyfill.js
@@ -1,8 +1,0 @@
-// polyfill if crypto.randomUUID is not available, i.e. in Qt WebEngine
-if (!crypto.randomUUID) {
-  crypto.randomUUID = function () {
-    return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
-      (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-    );
-  };
-}

--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, createRef, useContext, useRef } from 'react';
+import { useState, useEffect, createRef, useContext, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getBTCDirectInfo } from '@/api/exchanges';
 import { AppContext } from '@/contexts/AppContext';
@@ -87,14 +87,46 @@ export const BTCDirect = ({ accounts, code }: TProps) => {
     }, 200);
   };
 
+  const locale = i18n.resolvedLanguage ? localeMapping[i18n.resolvedLanguage] : 'en-GB';
+
+  const onMessage = useCallback((event: MessageEvent) => {
+    if (
+      !account
+      || !btcdirectInfo?.success
+      || (!isDevServers && event.origin !== 'https://bitboxapp.shiftcrypto.io')
+    ) {
+      return;
+    }
+    switch (event.data.action) {
+    case 'request-configuration':
+      event.source?.postMessage({
+        action: 'configuration',
+        address: btcdirectInfo.address,
+        locale,
+        theme: isDarkMode ? 'dark' : 'light',
+        baseCurrency: getCoinCode(account.coinCode),
+        quoteCurrency: 'EUR', // BTC Direct currently only accepts EURO
+        mode: isDevServers ? 'debug' : 'production',
+        apiKey: btcdirectInfo.apiKey,
+      }, {
+        targetOrigin: event.origin
+      });
+      break;
+    }
+
+  }, [account, btcdirectInfo, locale, isDarkMode, isDevServers]);
+
+  useEffect(() => {
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  });
+
   if (!account || !config) {
     return null;
   }
 
   const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
   const translationContext = hasOnlyBTCAccounts ? 'bitcoin' : 'crypto';
-
-  const locale = i18n.resolvedLanguage ? localeMapping[i18n.resolvedLanguage] : 'en-GB';
 
   return (
     <div className="contentWithGuide">
@@ -130,14 +162,6 @@ export const BTCDirect = ({ accounts, code }: TProps) => {
                     frameBorder="0"
                     className={`${style.iframe} ${!iframeLoaded ? style.hide : ''}`}
                     allow="camera"
-                    data-locale={locale}
-                    data-theme={isDarkMode ? 'dark' : 'light'}
-                    data-base-currency={getCoinCode(account.coinCode)}
-                    data-quote-currency={'EUR'}
-                    data-address={btcdirectInfo.address}
-                    data-mode={isDevServers ? 'debug' : 'production'
-                    }
-                    data-api-key={btcdirectInfo.apiKey}
                     src={btcdirectInfo.url}>
                   </iframe>
                 )}

--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -44,6 +44,14 @@ type TProps = {
   code: AccountCode;
 }
 
+const getURLOrigin = (uri: string): string | null => {
+  try {
+    return new URL(uri).origin;
+  } catch (e) {
+    return null;
+  }
+};
+
 export const BTCDirect = ({ accounts, code }: TProps) => {
   const { i18n, t } = useTranslation();
   const { isDevServers } = useContext(AppContext);
@@ -93,7 +101,10 @@ export const BTCDirect = ({ accounts, code }: TProps) => {
     if (
       !account
       || !btcdirectInfo?.success
-      || (!isDevServers && event.origin !== 'https://bitboxapp.shiftcrypto.io')
+      || (
+        !isDevServers // if prod check that event is from same origin as btcdirectInfo.url
+        && event.origin !== getURLOrigin(btcdirectInfo.url)
+      )
     ) {
       return;
     }


### PR DESCRIPTION
The previous approach depended on the iframe having access to the parent context, but this wont work when the iframe is hosted on a different domain.

Instead of relaxing webengine restrictions this change simply uses postMessage api to pass data from and to the iframe.