### PR TITLE
backend: add /dev-servers endpoint

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -213,6 +213,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/detect-dark-theme", handlers.getDetectDarkTheme).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/version", handlers.getVersion).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/testing", handlers.getTesting).Methods("GET")
+	getAPIRouterNoError(apiRouter)("/dev-servers", handlers.getDevServers).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/account-add", handlers.postAddAccount).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/keystores", handlers.getKeystores).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/accounts", handlers.getAccounts).Methods("GET")
@@ -539,6 +540,10 @@ func (handlers *Handlers) getVersion(*http.Request) interface{} {
 
 func (handlers *Handlers) getTesting(*http.Request) interface{} {
 	return handlers.backend.Testing()
+}
+
+func (handlers *Handlers) getDevServers(*http.Request) interface{} {
+	return handlers.backend.DevServers()
 }
 
 func (handlers *Handlers) postAddAccount(r *http.Request) interface{} {

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -60,6 +60,10 @@ export const getTesting = (): Promise<boolean> => {
   return apiGet('testing');
 };
 
+export const getDevServers = (): Promise<boolean> => {
+  return apiGet('dev-servers');
+};
+
 export type TQRCode = FailResponse | (SuccessResponse & { data: string; });
 
 export const getQRCode = (data: string) => {

--- a/frontends/web/src/contexts/AppContext.tsx
+++ b/frontends/web/src/contexts/AppContext.tsx
@@ -25,6 +25,7 @@ type AppContextProps = {
     guideExists: boolean;
     hideAmounts: boolean;
     isTesting: boolean;
+    isDevServers: boolean;
     nativeLocale: string;
     sidebarStatus: TSidebarStatus;
     firmwareUpdateDialogOpen: boolean;

--- a/frontends/web/src/contexts/AppProvider.tsx
+++ b/frontends/web/src/contexts/AppProvider.tsx
@@ -20,7 +20,7 @@ import { AppContext } from './AppContext';
 import { useLoad } from '@/hooks/api';
 import { useDefault } from '@/hooks/default';
 import { getNativeLocale } from '@/api/nativelocale';
-import { getTesting } from '@/api/backend';
+import { getDevServers, getTesting } from '@/api/backend';
 import { i18nextFormat } from '@/i18n/utils';
 import type { TChartDisplay, TSidebarStatus } from './AppContext';
 
@@ -31,6 +31,7 @@ type TProps = {
 export const AppProvider = ({ children }: TProps) => {
   const nativeLocale = i18nextFormat(useDefault(useLoad(getNativeLocale), 'de-CH'));
   const isTesting = useDefault(useLoad(getTesting), false);
+  const isDevServers = useDefault(useLoad(getDevServers), false);
   const [guideShown, setGuideShown] = useState(false);
   const [guideExists, setGuideExists] = useState(false);
   const [hideAmounts, setHideAmounts] = useState(false);
@@ -77,6 +78,7 @@ export const AppProvider = ({ children }: TProps) => {
         guideExists,
         hideAmounts,
         isTesting,
+        isDevServers,
         nativeLocale,
         sidebarStatus,
         chartDisplay,

--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -23,7 +23,6 @@ import { useLoad } from '@/hooks/api';
 import { useDarkmode } from '@/hooks/darkmode';
 import { UseDisableBackButton } from '@/hooks/backbutton';
 import { getConfig } from '@/utils/config';
-import { debug } from '@/utils/env';
 import { Header } from '@/components/layout';
 import { Spinner } from '@/components/spinner/Spinner';
 import { findAccount, getCoinCode, isBitcoinOnly } from '@/routes/account/utils';
@@ -47,7 +46,7 @@ type TProps = {
 
 export const BTCDirect = ({ accounts, code }: TProps) => {
   const { i18n, t } = useTranslation();
-  const { isTesting } = useContext(AppContext);
+  const { isDevServers } = useContext(AppContext);
   const { isDarkMode } = useDarkmode();
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -136,8 +135,7 @@ export const BTCDirect = ({ accounts, code }: TProps) => {
                     data-base-currency={getCoinCode(account.coinCode)}
                     data-quote-currency={'EUR'}
                     data-address={btcdirectInfo.address}
-                    data-mode={
-                      isTesting || debug ? 'debug' : 'production'
+                    data-mode={isDevServers ? 'debug' : 'production'
                     }
                     data-api-key={btcdirectInfo.apiKey}
                     src={btcdirectInfo.url}>


### PR DESCRIPTION
and use it in the frontend to correctly set the BTCDirect widget params.