### PR TITLE
backend/frontend: add option to restart in testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix the copy buttons in the Pocket order confirmation page
 - Android: handle device disconnect while the app is in the background
 - Improve send result view show relevant infos and options to make a new transaction or go back
+- Added an option in advanced settings to allow the app to start in testnet at the next restart.
 
 # 4.46.3
 - Fix camera access on linux

--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -1196,7 +1196,7 @@ outer:
 // a user-facing setting. Now we simply use it for migration to decide which coins to add by
 // default.
 func (backend *Backend) persistDefaultAccountConfigs(keystore keystore.Keystore, accountsConfig *config.AccountsConfig) error {
-	if backend.arguments.Testing() {
+	if backend.Testing() {
 		if backend.arguments.Regtest() {
 			if backend.config.AppConfig().Backend.DeprecatedCoinActive(coinpkg.CodeRBTC) {
 				if _, err := backend.createAndPersistAccountConfig(
@@ -1458,7 +1458,7 @@ func (backend *Backend) maybeAddHiddenUnusedAccounts() {
 	switch {
 	case backend.arguments.Regtest():
 		coinCodes = []coinpkg.Code{coinpkg.CodeRBTC}
-	case backend.arguments.Testing():
+	case backend.Testing():
 		coinCodes = []coinpkg.Code{coinpkg.CodeTBTC, coinpkg.CodeTLTC}
 	default:
 		coinCodes = []coinpkg.Code{coinpkg.CodeBTC, coinpkg.CodeLTC}

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -102,6 +102,10 @@ type Backend struct {
 
 	// BtcUnit is the unit used to represent Bitcoin amounts. See `coin.BtcUnit` for details.
 	BtcUnit coin.BtcUnit `json:"btcUnit"`
+
+	// StartInTestnet represents whether the app should launch in testnet on the next start.
+	// It resets to `false` after the app starts.
+	StartInTestnet bool `json:"startInTestnet"`
 }
 
 // DeprecatedCoinActive returns the Active setting for a coin by code.  This call is should not be

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1318,6 +1318,9 @@
       "customFees": {
         "description": "Lets you enter your own fee when sending."
       },
+      "restartInTestnet": {
+        "description": "Explore and test features by using testnet."
+      },
       "torProxy": {
         "description": "Connect over Tor for better privacy."
       }
@@ -1725,6 +1728,7 @@
         "title": "Export logs"
       },
       "fee": "Enable custom fees",
+      "restartInTestnet": "Testnet mode",
       "setProxyAddress": "Set proxy address",
       "title": "Expert settings",
       "useProxy": "Enable tor proxy",

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -25,6 +25,7 @@ import { EnableCustomFeesToggleSetting } from './components/advanced-settings/en
 import { EnableCoinControlSetting } from './components/advanced-settings/enable-coin-control-setting';
 import { ConnectFullNodeSetting } from './components/advanced-settings/connect-full-node-setting';
 import { EnableTorProxySetting } from './components/advanced-settings/enable-tor-proxy-setting';
+import { RestartInTestnetSetting } from './components/advanced-settings/restart-in-testnet-setting';
 import { ExportLogSetting } from './components/advanced-settings/export-log-setting';
 import { getConfig } from '@/utils/config';
 import { MobileHeader } from './components/mobile-header';
@@ -47,7 +48,7 @@ export type TFrontendConfig = {
 export type TBackendConfig = {
   proxy?: TProxyConfig
   authentication?: boolean;
-
+  restartInTestnet?: boolean;
 }
 
 export type TConfig = {
@@ -94,6 +95,7 @@ export const AdvancedSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSetti
                 <EnableCoinControlSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
                 <EnableAuthSetting backendConfig={backendConfig} onChangeConfig={setConfig} />
                 <EnableTorProxySetting proxyConfig={proxyConfig} onChangeConfig={setConfig} />
+                <RestartInTestnetSetting backendConfig={backendConfig} onChangeConfig={setConfig} />
                 <ConnectFullNodeSetting />
                 <ExportLogSetting />
               </WithSettingsTabs>

--- a/frontends/web/src/routes/settings/components/advanced-settings/restart-in-testnet-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/restart-in-testnet-setting.tsx
@@ -1,0 +1,69 @@
+
+/**
+ * Copyright 2025 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChangeEvent, Dispatch } from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
+import { Toggle } from '@/components/toggle/toggle';
+import { TConfig, TBackendConfig } from '@/routes/settings/advanced-settings';
+import { Message } from '@/components/message/message';
+import { setConfig } from '@/utils/config';
+import styles from './enable-tor-proxy-setting.module.css';
+
+type TProps = {
+  backendConfig?: TBackendConfig;
+  onChangeConfig: Dispatch<TConfig>;
+}
+
+export const RestartInTestnetSetting = ({ backendConfig, onChangeConfig }: TProps) => {
+  const { t } = useTranslation();
+  const [showRestartMessage, setShowRestartMessage] = useState(false);
+
+
+  const handleToggleRestartInTestnet = async (e: ChangeEvent<HTMLInputElement>) => {
+    setShowRestartMessage(e.target.checked);
+    const config = await setConfig({
+      backend: {
+        'restartInTestnet': e.target.checked
+      },
+    }) as TConfig;
+    onChangeConfig(config);
+  };
+  return (
+    <>
+      { showRestartMessage ? (
+        <Message type="warning">
+          {t('settings.restart')}
+        </Message>
+      ) : null }
+      <SettingsItem
+        className={styles.settingItem}
+        settingName={t('settings.expert.restartInTestnet')}
+        secondaryText={t('newSettings.advancedSettings.restartInTestnet.description')}
+        extraComponent={
+          backendConfig !== undefined ? (
+            <Toggle
+              checked={backendConfig?.restartInTestnet || false}
+              onChange={handleToggleRestartInTestnet}
+            />
+          ) : null
+        }
+      />
+    </>
+  );
+};


### PR DESCRIPTION
Adds a button in the advanced settings that enables the app to start in testnet automatically on the next start. The setting is only valid for the next start, and it gets reset after that.

![image](https://github.com/user-attachments/assets/d775ded6-eb7f-43c7-b6f0-462d79ef2037)

(note: the "enabled" text near the option has been removed, this is a slightly older screenshot)

Note that this PR does not automatically restart the application. This would require a lot more investigation on how to do it properly on all platforms.