### PR TITLE
frontend: fix missing base currency in btc-direct widget

### DIFF
--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -25,7 +25,7 @@ import { UseDisableBackButton } from '@/hooks/backbutton';
 import { getConfig } from '@/utils/config';
 import { Header } from '@/components/layout';
 import { Spinner } from '@/components/spinner/Spinner';
-import { findAccount, getCoinCode, isBitcoinOnly } from '@/routes/account/utils';
+import { findAccount, isBitcoinOnly } from '@/routes/account/utils';
 import { BTCDirectTerms } from '@/components/terms/btcdirect-terms';
 import { ExchangeGuide } from './guide';
 import style from './iframe.module.css';
@@ -115,7 +115,7 @@ export const BTCDirect = ({ accounts, code }: TProps) => {
         address: btcdirectInfo.address,
         locale,
         theme: isDarkMode ? 'dark' : 'light',
-        baseCurrency: getCoinCode(account.coinCode),
+        baseCurrency: account.coinUnit,
         quoteCurrency: 'EUR', // BTC Direct currently only accepts EURO
         mode: isDevServers ? 'debug' : 'production',
         apiKey: btcdirectInfo.apiKey,


### PR DESCRIPTION
Instead of deriving the coin/token unit from coinCode somehow,
the app can just pass account.coinUnit.

Fixes missing baseCurrency error when using ERC20 tokens, with the
drawback that in testnet the app now passes TBTC. BTC Direct does
not support testnet addresses nor testnet coins and will fallback
to just BTC.