### PR TITLE
backend: allow opening checkout.btcdirect.eu

### DIFF
--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -275,6 +275,7 @@ public class MainActivity extends AppCompatActivity {
                     patterns.add(Pattern.compile("^(.*\\.)?pocketbitcoin\\.com$"));
                     patterns.add(Pattern.compile("^(.*\\.)?moonpay\\.com$"));
                     patterns.add(Pattern.compile("^(.*\\.)?bitsurance\\.eu$"));
+                    patterns.add(Pattern.compile("^(.*\\.)?btcdirect\\.eu$"));
 
                     for (Pattern pattern : patterns) {
                         if (pattern.matcher(request.getUrl().getHost()).matches()) {


### PR DESCRIPTION
Some payment providers such as iDEAL or SOFORT need to breakout the BitBoxApp and be continued in a native browser.

From https://checkout.btcdirect.eu/ the user fills in the bank they are using and will get redirected to their banking environment.

On mobile the bank may use intent links to automatically open and continue in the banking app.