### PR TITLE
ios: listen on our product characteristic

### DIFF
--- a/frontends/ios/BitBoxApp/BitBoxApp/BitBoxAppApp.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/BitBoxAppApp.swift
@@ -67,6 +67,14 @@ class GoEnvironment: NSObject, MobileserverGoEnvironmentInterfaceProtocol, UIDoc
         if !bluetoothManager.isConnected() {
             return nil
         }
+        print("Bluetooth product string: \(bluetoothManager.productStr())")
+
+        let productStr = bluetoothManager.productStr();
+        if productStr == "" || productStr == "no connection" {
+            // Not ready or explicitly not connected (waiting for the device to enter
+            // firmware or bootloader)
+            return nil
+        }
         return BluetoothDeviceInfo(bluetoothManager: bluetoothManager)
     }
 


### PR DESCRIPTION
- Similar to the USB HID descriptor product string
- Empty `""` means the device has not set it yet
- "no connection" is defined by the bluetooth firmware as not connected to either firmware/bootloader yet
- The bluetooth firmware updates it dynamically, as the device can reboot into bootloader/firwmware without bluetooth disconnecting. The app listens on the change and connects/disconnects the right device accordingly.
- For now we map to "BitBox02BTC" to get a connection going, later we will modify bitbox02-api-go to extend it with the official new product strings so the backend can identify them