### PR TITLE
frontend: fix export to CSV for ERC20 Tokens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Improve send result view show relevant infos and options to make a new transaction or go back
 - Added an option in advanced settings to allow the app to start in testnet at the next restart.
 - Improve the UI of buy & sell page for mobile devices
+- Fixed export to CSV for ERC20 tokens.
 
 # 4.46.3
 - Fix camera access on linux


### PR DESCRIPTION
ERC20 tokens are now exported with the correct value for "unit" Added a new column "FeeUnit" as the fee is displayed in ETH/wei for ERC20 tokens.


