### PR TITLE
frontend: enable btcdirect dca option

### DIFF
--- a/frontends/web/public/btcdirect/fiat-to-coin.html
+++ b/frontends/web/public/btcdirect/fiat-to-coin.html
@@ -96,6 +96,10 @@
           }
         });
 
+        btcdirect('include-dca', {
+          include: true
+        });
+
         btcdirect('set-parameters',
           mode === 'production' ? {
             baseCurrency: currency,


### PR DESCRIPTION
The feature below adds an additional tab to the Fiat to Coin widget, which includes the full Dollar Cost Averaging (DCA) widget.

![Screenshot 2025-02-11 at 07 07 59](https://github.com/user-attachments/assets/7f25555e-8456-486b-b51e-173741418bdf)
