### PR TITLE
backend: add isHidden property in exchange deals

### DIFF
--- a/backend/exchanges/btcdirect.go
+++ b/backend/exchanges/btcdirect.go
@@ -89,12 +89,14 @@ func BtcDirectDeals() *ExchangeDealsList {
 				Payment: BankTransferPayment,
 			},
 			{
-				Fee:     4.9, // 4.9%
-				Payment: SOFORTPayment,
+				Fee:      4.9, // 4.9%
+				Payment:  SOFORTPayment,
+				IsHidden: true,
 			},
 			{
-				Fee:     3.6, // 3.6%
-				Payment: BancontactPayment,
+				Fee:      3.6, // 3.6%
+				Payment:  BancontactPayment,
+				IsHidden: true,
 			},
 		},
 	}

--- a/backend/exchanges/exchanges.go
+++ b/backend/exchanges/exchanges.go
@@ -108,14 +108,17 @@ const (
 )
 
 // ExchangeDeal represents a specific purchase option of an exchange.
-// - Fee that goes to the exchange in percentage.
-// - Payment is the payment method offered in the deal (usually different payment methods bring different fees).
-// - IsFast is usually associated with card payments. It is used by the frontend to display the `fast` tag in deals list.
 type ExchangeDeal struct {
-	Fee     float32       `json:"fee"`
+	// Fee that goes to the exchange in percentage.
+	Fee float32 `json:"fee"`
+	// Payment is the payment method offered in the deal (usually different payment methods bring different fees).
 	Payment PaymentMethod `json:"payment"`
-	IsFast  bool          `json:"isFast"`
-	IsBest  bool          `json:"isBest"`
+	// IsFast is usually associated with card payments. It is used by the frontend to display the `fast` badge in deals list.
+	IsFast bool `json:"isFast"`
+	// IsBest is assigned to the deal with the lowest fee, it is used to show the `best deal` badge in the frontend.
+	IsBest bool `json:"isBest"`
+	// IsHidden deals are not explicitly listed in the frontend deals list.
+	IsHidden bool `json:"isHidden"`
 }
 
 // ExchangeDealsList list the name of a specific exchange and the list of available deals offered by that exchange.
@@ -236,7 +239,7 @@ func GetExchangeDeals(account accounts.Interface, regionCode string, action Exch
 		bestDealIndex := 0
 		for i, deal := range deals {
 			oldBestDeal := deals[bestDealIndex]
-			if deal.Fee < oldBestDeal.Fee {
+			if !deal.IsHidden && deal.Fee < oldBestDeal.Fee {
 				bestDealIndex = i
 			}
 		}

--- a/frontends/web/src/api/exchanges.ts
+++ b/frontends/web/src/api/exchanges.ts
@@ -38,6 +38,7 @@ export type ExchangeDeal = {
   payment: 'card' | 'bank-transfer' | 'sofort' | 'bancontact';
   isFast: boolean;
   isBest: boolean;
+  isHidden: boolean;
 }
 
 export type TExchangeName = 'moonpay' | 'pocket' | 'btcdirect' | 'btcdirect-otc';

--- a/frontends/web/src/routes/exchange/components/buysell.tsx
+++ b/frontends/web/src/routes/exchange/components/buysell.tsx
@@ -129,22 +129,25 @@ export const BuySell = ({
           </div>
         ) : (
           <div className={style.exchangeProvidersContainer}>
-            {exchangeDealsResponse?.exchanges.map(exchange => (
-              <div key={exchange.exchangeName} className={style.actionableItemContainer}>
-                <ActionableItem
-                  key={exchange.exchangeName}
-                  onClick={() => {
-                    goToExchange(exchange.exchangeName);
-                  }}>
-                  <ExchangeProviders
-                    deals={exchange.deals}
-                    exchangeName={exchange.exchangeName}
-                  />
-                </ActionableItem>
+            {exchangeDealsResponse?.exchanges
+              // skip the exchanges that have only hidden deals.
+              .filter(exchange => (exchange.deals.some(deal => !deal.isHidden)))
+              .map(exchange => (
+                <div key={exchange.exchangeName} className={style.actionableItemContainer}>
+                  <ActionableItem
+                    key={exchange.exchangeName}
+                    onClick={() => {
+                      goToExchange(exchange.exchangeName);
+                    }}>
+                    <ExchangeProviders
+                      deals={exchange.deals}
+                      exchangeName={exchange.exchangeName}
+                    />
+                  </ActionableItem>
 
-                <InfoButton onClick={() => setInfo(buildInfo(exchange))} />
-              </div>
-            ))}
+                  <InfoButton onClick={() => setInfo(buildInfo(exchange))} />
+                </div>
+              ))}
           </div>
         )}
         {btcDirectOTCSupported?.success && btcDirectOTCSupported?.supported && (

--- a/frontends/web/src/routes/exchange/components/exchange-providers.tsx
+++ b/frontends/web/src/routes/exchange/components/exchange-providers.tsx
@@ -49,8 +49,6 @@ const PaymentMethod = ({ methodName }: TPaymentMethodProps) => {
     );
   case 'sofort':
   case 'bancontact':
-    // hide these payment methods in the overview
-    return '';
   default:
     return <>{methodName}</>;
   }
@@ -85,7 +83,7 @@ export const ExchangeProviders = ({
           {getExchangeFormattedName(exchangeName)}
         </p>
         <div className={style.paymentMethodsContainer}>
-          {deals.map(deal => <Deal key={deal.payment} deal={deal}/>)}
+          {deals.map(deal => !deal.isHidden && <Deal key={deal.payment} deal={deal}/>)}
         </div>
       </div>
     </div>


### PR DESCRIPTION
This allows to hide specific deals in the frontend deals list. e.g. when the exchange offers several payment methods with different fees. The deals are still used to show all the payments and fees in the info box.