### PR TITLE
frontend: btcdirect allow to navigate back to accounts

### DIFF
--- a/frontends/web/public/btcdirect/back-to-app.html
+++ b/frontends/web/public/btcdirect/back-to-app.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BTC Direct - Back to app</title>
+
+<script>
+  if (window.top === window) {
+    showError('Unexpected error');
+    return;
+  }
+
+  // Request the app to navigate away from the iframe and back to the app
+  window.parent.postMessage({
+    action: 'back-to-app'
+  }, '*');
+
+  function showError(message) {
+    document.body.append(
+      Object.assign(document.createElement('h1'), {
+        style: 'color: red; padding: 1rem;',
+        textContent: message,
+      })
+    );
+  }
+</script>

--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useState, useEffect, createRef, useContext, useRef, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { getBTCDirectInfo } from '@/api/exchanges';
 import { AppContext } from '@/contexts/AppContext';
@@ -56,6 +57,7 @@ export const BTCDirect = ({ accounts, code }: TProps) => {
   const { i18n, t } = useTranslation();
   const { isDevServers } = useContext(AppContext);
   const { isDarkMode } = useDarkmode();
+  const navigate = useNavigate();
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const btcdirectInfo = useLoad(() => getBTCDirectInfo('buy', code));
@@ -123,9 +125,12 @@ export const BTCDirect = ({ accounts, code }: TProps) => {
         targetOrigin: event.origin
       });
       break;
+    case 'back-to-app':
+      navigate(`/account/${code}`);
+      break;
     }
 
-  }, [account, btcdirectInfo, locale, isDarkMode, isDevServers]);
+  }, [account, btcdirectInfo, code, isDarkMode, isDevServers, locale, navigate]);
 
   useEffect(() => {
     window.addEventListener('message', onMessage);


### PR DESCRIPTION
Added support to navigate back to the accounts view.

Added a 'back-to-app' message that routes to accounts, the widget will need to send this message once the user clicks 'Back to app'.