### PR TITLE
backend: fix restart in testnet

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -645,7 +645,7 @@ func (backend *Backend) Start() <-chan interface{} {
 
 	backend.environment.OnAuthSettingChanged(backend.config.AppConfig().Backend.Authentication)
 
-	if backend.DefaultAppConfig().Backend.StartInTestnet {
+	if backend.config.AppConfig().Backend.StartInTestnet {
 		if err := backend.config.ModifyAppConfig(func(c *config.AppConfig) error { c.Backend.StartInTestnet = false; return nil }); err != nil {
 			backend.log.WithError(err).Error("Can't set StartInTestnet to false")
 		}

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -48,7 +48,7 @@ export type TFrontendConfig = {
 export type TBackendConfig = {
   proxy?: TProxyConfig
   authentication?: boolean;
-  restartInTestnet?: boolean;
+  startInTestnet?: boolean;
 }
 
 export type TConfig = {

--- a/frontends/web/src/routes/settings/components/advanced-settings/restart-in-testnet-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/restart-in-testnet-setting.tsx
@@ -39,7 +39,7 @@ export const RestartInTestnetSetting = ({ backendConfig, onChangeConfig }: TProp
     setShowRestartMessage(e.target.checked);
     const config = await setConfig({
       backend: {
-        'restartInTestnet': e.target.checked
+        'startInTestnet': e.target.checked
       },
     }) as TConfig;
     onChangeConfig(config);
@@ -58,7 +58,7 @@ export const RestartInTestnetSetting = ({ backendConfig, onChangeConfig }: TProp
         extraComponent={
           backendConfig !== undefined ? (
             <Toggle
-              checked={backendConfig?.restartInTestnet || false}
+              checked={backendConfig?.startInTestnet || false}
               onChange={handleToggleRestartInTestnet}
             />
           ) : null


### PR DESCRIPTION
Typo in config var, and the flag was never reset.
