### PR TITLE
backend: allow firmware upgrade when app is offline.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix a bug that would prevent the app to perform firmware upgrade when offline.
+
 # 4.47.0
 - Bundle BitBox02 firmware version v9.22.0
 - Fix long transaction notes to show fully on multiple lines when necessary

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -42,7 +42,6 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/locker"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable/action"
-	electrumTypes "github.com/BitBoxSwiss/block-client-go/electrum/types"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -352,8 +351,8 @@ func (account *Account) Initialize() error {
 
 		account.subaccounts = append(account.subaccounts, subacc)
 	}
-	account.ensureAddresses()
-	account.coin.Blockchain().HeadersSubscribe(account.onNewHeader)
+
+	go account.ensureAddresses()
 
 	return account.BaseAccount.Initialize(accountIdentifier)
 }
@@ -422,14 +421,6 @@ func (account *Account) Info() *accounts.Info {
 	return &accounts.Info{
 		SigningConfigurations: signingConfigurations,
 	}
-}
-
-func (account *Account) onNewHeader(header *electrumTypes.Header) {
-	if account.isClosed() {
-		account.log.Debug("Ignoring new header after the account was closed")
-		return
-	}
-	account.log.WithField("block-height", header.Height).Debug("Received new header")
 }
 
 // FatalError returns true if the account had a fatal error.

--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	accountsTypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
@@ -110,7 +111,7 @@ func TestAccount(t *testing.T) {
 	account := mockAccount(t, nil)
 	require.False(t, account.Synced())
 	require.NoError(t, account.Initialize())
-	require.True(t, account.Synced())
+	require.Eventually(t, func() bool { return account.Synced() }, time.Second, time.Millisecond*200)
 
 	balance, err := account.Balance()
 	require.NoError(t, err)
@@ -201,7 +202,7 @@ func TestSignAddress(t *testing.T) {
 func TestIsChange(t *testing.T) {
 	account := mockAccount(t, nil)
 	require.NoError(t, account.Initialize())
-	require.True(t, account.Synced())
+	require.Eventually(t, func() bool { return account.Synced() }, time.Second, time.Millisecond*200)
 	account.ensureAddresses()
 	for _, subaccunt := range account.subaccounts {
 		unusedReceiveAddresses, err := subaccunt.receiveAddresses.GetUnused()


### PR DESCRIPTION
Run ensureAddresses in a separate goroutine.
This way the call is not blocking and the initializeLock can be released, which allows the device to be restarted in bootloader mode and the firmware upgrade process to start.

This way, `ensureAddresses` will keep running in the background and if connection is restored later, it will terminate correctly.


This has been tested on MacOS with Qt: note that if running this in webdev mode it won't work, as when the app is offline there is no way to reach the "manage device" option as it will hang forever.

The following in a screen recording that shows the correct behaviour.

https://github.com/user-attachments/assets/3818a8b1-2730-4e6e-a14f-b00632f720da


Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
