### PR TITLE
frontend/btcdirect: use correct private trading desk link

### DIFF
--- a/frontends/web/src/routes/exchange/btcdirect-otc.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect-otc.tsx
@@ -17,7 +17,7 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { BTCDirectOTCTerms } from '@/components/terms/btcdirect-otc-terms';
-import { getBTCDirectAboutUsLink } from './components/infocontent';
+import { getBTCDirectOTCLink } from './components/infocontent';
 import { Header } from '@/components/layout';
 import { open } from '@/api/system';
 import style from './iframe.module.css';
@@ -27,7 +27,7 @@ export const BTCDirectOTC = () => {
   const navigate = useNavigate();
 
   const openBTCDirect = () => {
-    open(getBTCDirectAboutUsLink());
+    open(getBTCDirectOTCLink());
     navigate(-1);
   };
 

--- a/frontends/web/src/routes/exchange/components/buysell.tsx
+++ b/frontends/web/src/routes/exchange/components/buysell.tsx
@@ -21,7 +21,7 @@ import { useLoad } from '@/hooks/api';
 import * as exchangesAPI from '@/api/exchanges';
 import { Button } from '@/components/forms/button';
 import { AppContext } from '@/contexts/AppContext';
-import { getBTCDirectAboutUsLink, TInfoContentProps, TPaymentFee } from './infocontent';
+import { getBTCDirectOTCLink, TInfoContentProps, TPaymentFee } from './infocontent';
 import { Skeleton } from '@/components/skeleton/skeleton';
 import { hasPaymentRequest } from '@/api/account';
 import { Message } from '@/components/message/message';
@@ -156,7 +156,7 @@ export const BuySell = ({
                     {t('buy.exchange.infoContent.btcdirect.link')}
                   </Link>
                 ) : (
-                  <A href={getBTCDirectAboutUsLink()} className={style.link}>
+                  <A href={getBTCDirectOTCLink()} className={style.link}>
                     {t('buy.exchange.infoContent.btcdirect.link')}
                   </A>
                 )}


### PR DESCRIPTION
Changes back to the correct link to the BTC Direct OTC desk.