### PR TITLE
test: ensure that account is eventually synced.

### DIFF
--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -111,7 +111,7 @@ func TestAccount(t *testing.T) {
 	account := mockAccount(t, nil)
 	require.False(t, account.Synced())
 	require.NoError(t, account.Initialize())
-	require.Eventually(t, func() bool { return account.Synced() }, time.Second, time.Millisecond*200)
+	require.Eventually(t, account.Synced, time.Second, time.Millisecond*200)
 
 	balance, err := account.Balance()
 	require.NoError(t, err)
@@ -162,6 +162,7 @@ func TestInsuredAccountAddresses(t *testing.T) {
 		SigningConfigurations: signingConfigurations,
 	})
 	require.NoError(t, account.Initialize())
+	require.Eventually(t, account.Synced, time.Second, time.Millisecond*200)
 
 	// check the number of available addresses for native and wrapped segwit.
 	require.Len(t, account.GetUnusedReceiveAddresses()[0].Addresses, 20)
@@ -178,6 +179,7 @@ func TestInsuredAccountAddresses(t *testing.T) {
 	})
 
 	require.NoError(t, account2.Initialize())
+	require.Eventually(t, account2.Synced, time.Second, time.Millisecond*200)
 
 	// native segwit is the only address type available.
 	require.Len(t, account2.GetUnusedReceiveAddresses(), 1)
@@ -189,6 +191,7 @@ func TestInsuredAccountAddresses(t *testing.T) {
 func TestSignAddress(t *testing.T) {
 	account := mockAccount(t, nil)
 	require.NoError(t, account.Initialize())
+	require.Eventually(t, account.Synced, time.Second, time.Millisecond*200)
 	// pt2r is not an available script type in the mocked account.
 	_, _, err := SignBTCAddress(account, "Hello there", signing.ScriptTypeP2TR)
 	require.Error(t, err)
@@ -202,7 +205,7 @@ func TestSignAddress(t *testing.T) {
 func TestIsChange(t *testing.T) {
 	account := mockAccount(t, nil)
 	require.NoError(t, account.Initialize())
-	require.Eventually(t, func() bool { return account.Synced() }, time.Second, time.Millisecond*200)
+	require.Eventually(t, account.Synced, time.Second, time.Millisecond*200)
 	account.ensureAddresses()
 	for _, subaccunt := range account.subaccounts {
 		unusedReceiveAddresses, err := subaccunt.receiveAddresses.GetUnused()


### PR DESCRIPTION
With ensureAddresses running in a separate goroutine, it might happen that after a call to account.Initialize() we perform checks that fail because the ensureAddresses goroutine hasn't completed yet.

By adding a call to require.Eventually we ensure that the account gets eventually synced (within a second) before proceeding with the rest of the test.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
