### PR TITLE
backend: remove usdt from btcdirect

### DIFF
--- a/backend/exchanges/btcdirect.go
+++ b/backend/exchanges/btcdirect.go
@@ -61,7 +61,7 @@ func isRegionSupportedBtcDirect(region string) bool {
 func IsBtcDirectSupported(coinCode coin.Code) bool {
 	supportedCoins := []coin.Code{
 		coin.CodeBTC, coin.CodeTBTC, coin.CodeLTC, coin.CodeTLTC, coin.CodeETH, coin.CodeSEPETH,
-		"eth-erc20-usdt", "eth-erc20-usdc", "eth-erc20-link"}
+		"eth-erc20-usdc", "eth-erc20-link"}
 
 	coinSupported := slices.Contains(supportedCoins, coinCode)
 


### PR DESCRIPTION
BTC Direct has ceased supporting Tether (USDT)

- https://support.btcdirect.eu/hc/en-gb/articles/24592747089298-BTC-Direct-has-ceased-supporting-Tether-USDT