### PR TITLE
frontend: fix shown amount for unconfirmed ETH txs

### DIFF
--- a/backend/accounts/transaction_test.go
+++ b/backend/accounts/transaction_test.go
@@ -277,6 +277,14 @@ func TestOrderedTransactionsDeductedAmount(t *testing.T) {
 			Amount:             amount,
 			Fee:                &fee,
 		},
+		{
+			// timestamp is nil, deductedAmount is still set
+			Timestamp: nil,
+			Height:    15,
+			Type:      TxTypeSend,
+			Amount:    amount,
+			Fee:       &fee,
+		},
 	}
 
 	orderedTxs := NewOrderedTransactions(txs)
@@ -285,4 +293,5 @@ func TestOrderedTransactionsDeductedAmount(t *testing.T) {
 	requireAmountIsEqualTo(t, orderedTxs[1].DeductedAmount, 10)
 	requireAmountIsEqualTo(t, orderedTxs[2].DeductedAmount, 0)
 	requireAmountIsEqualTo(t, orderedTxs[3].DeductedAmount, 100)
+	requireAmountIsEqualTo(t, orderedTxs[4].DeductedAmount, 110)
 }

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -121,14 +121,18 @@ func (handlers *Handlers) formatAmountAsJSON(amount coin.Amount, isFee bool) For
 
 func (handlers *Handlers) formatAmountAtTimeAsJSON(amount coin.Amount, timeStamp *time.Time) FormattedAmount {
 	accountCoin := handlers.account.Coin()
-	conversions, estimated := coin.ConversionsAtTime(
-		amount,
-		handlers.account.Coin(),
-		false,
-		handlers.account.Config().RateUpdater,
-		util.FormatBtcAsSat(handlers.account.Config().BtcCurrencyUnit),
-		timeStamp,
-	)
+	conversions := map[string]string{}
+	estimated := false
+	if timeStamp != nil {
+		conversions, estimated = coin.ConversionsAtTime(
+			amount,
+			handlers.account.Coin(),
+			false,
+			handlers.account.Config().RateUpdater,
+			util.FormatBtcAsSat(handlers.account.Config().BtcCurrencyUnit),
+			timeStamp,
+		)
+	}
 	return FormattedAmount{
 		Amount:      accountCoin.FormatAmount(amount, false),
 		Unit:        accountCoin.GetFormatUnit(false),
@@ -195,12 +199,12 @@ func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail
 		timestamp = txInfo.CreatedTimestamp
 	}
 
-	var deductedAmountAtTime FormattedAmount
+	deductedAmountAtTime := handlers.formatAmountAtTimeAsJSON(txInfo.DeductedAmount, timestamp)
+
 	if timestamp != nil {
 		t := timestamp.Format(time.RFC3339)
 		formattedTime = &t
 		amountAtTime = handlers.formatAmountAtTimeAsJSON(txInfo.Amount, timestamp)
-		deductedAmountAtTime = handlers.formatAmountAtTimeAsJSON(txInfo.DeductedAmount, timestamp)
 	}
 
 	addresses := []string{}

--- a/frontends/web/src/components/amount/conversion-amount.tsx
+++ b/frontends/web/src/components/amount/conversion-amount.tsx
@@ -54,7 +54,7 @@ export const ConversionAmount = ({
 
   return (
     <span className={styles.txConversionAmount}>
-      {conversion && amountToShow ? (
+      {(conversion || sendToSelf) && amountToShow ? (
         <>
           {sendToSelf && (
             <span className={styles.txSmallInlineIcon}>


### PR DESCRIPTION
Fixes the shown amount by allowing `formatJSONAmountAtTime` to work with a nil timestamp

<img width="1010" alt="image" src="https://github.com/user-attachments/assets/2440b9e5-8d73-4f31-99f6-a8cc1d0af911" />


Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
