### PR TITLE
backend: show estimated conversions for unconfirmed ETH txs and remove skeleton when conversions are missing.

### DIFF
--- a/frontends/web/src/components/amount/conversion-amount.tsx
+++ b/frontends/web/src/components/amount/conversion-amount.tsx
@@ -21,7 +21,6 @@ import { Arrow } from '@/components/transactions/components/arrows';
 import { Amount } from '@/components/amount/amount';
 import { getTxSign } from '@/utils/transaction';
 import styles from './conversion-amount.module.css';
-import { Skeleton } from '@/components/skeleton/skeleton';
 
 type TConversionAmountProps = {
   amount: IAmount;
@@ -69,13 +68,12 @@ export const ConversionAmount = ({
             amount={sendToSelf ? amountToShow.amount : conversion || ''}
             unit={conversionUnit}
           />
+          <span className={styles.txUnit}>
+            {' '}
+            {conversionUnit}
+          </span>
         </>
-      ) : (
-        <div className={styles.skeletonContainer}>
-          <Skeleton />
-        </div>
-      )}
-      <span className={styles.txUnit}>{' '}{conversionUnit}</span>
+      ) : null }
     </span>
   );
 };


### PR DESCRIPTION
ETH transactions do not have a "Created" timestamp we can't provide an estimated conversion based on that. We use real-time conversion instead. 

We also remove the skeleton for the cases in which a conversion is still not available: 
![image](https://github.com/user-attachments/assets/54917a9e-c205-4418-a6cd-f92362ebff36)


Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
