### PR TITLE
btcdirect: update private trading desk links

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -89,6 +89,7 @@ var fixedURLWhitelist = []string{
 	"https://pocketbitcoin.com/",
 	// BTCDirect
 	"https://btcdirect.eu/",
+	"https://start.btcdirect.eu/",
 	// Bitsurance
 	"https://www.bitsurance.eu/",
 	"https://get.bitsurance.eu/",

--- a/frontends/web/src/routes/exchange/components/infocontent.tsx
+++ b/frontends/web/src/routes/exchange/components/infocontent.tsx
@@ -25,15 +25,15 @@ import style from './infocontent.module.css';
 export const getBTCDirectOTCLink = () => {
   switch (i18n.resolvedLanguage) {
   case 'de':
-    return 'https://btcdirect.eu/de-at/private-trading-contact?BitBox';
+    return 'https://start.btcdirect.eu/de/private-trading-bitbox';
   case 'nl':
-    return 'https://btcdirect.eu/nl-nl/private-trading-contact?BitBox';
+    return 'https://start.btcdirect.eu/nl/private-trading-bitbox';
   case 'es':
-    return 'https://btcdirect.eu/es-es/private-trading-contactanos?BitBox';
+    return 'https://start.btcdirect.eu/es/private-trading-bitbox';
   case 'fr':
-    return 'https://btcdirect.eu/fr-fr/private-trading-contact?BitBox';
+    return 'https://start.btcdirect.eu/fr/private-trading-bitbox';
   default:
-    return 'https://btcdirect.eu/en-eu/private-trading-contact?BitBox';
+    return 'https://start.btcdirect.eu/private-trading-bitbox';
   }
 };
 


### PR DESCRIPTION
BTC Direct updated their private trading desk links and asked us to change them.