### PR TITLE
qt/linux: don't bundle libwayland-client.so.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Reduced support for BitBox01
 - Fix a bug that would prevent the app to perform firmware upgrade when offline.
 
+# v4.47.2
+- Linux: fix compatiblity with some versions of Mesa that are incompatible with the bundled wayland libraries
+
 # 4.47.1
 - Linux: fix support for Wayland
 - Linux: release device upon app close, enabling other apps to connect to the BitBox after the BitBoxApp closes

--- a/backend/update.go
+++ b/backend/update.go
@@ -27,7 +27,7 @@ const updateFileURL = "https://bitboxapp.shiftcrypto.io/desktop.json"
 
 var (
 	// Version of the backend as displayed to the user.
-	Version = semver.NewSemVer(4, 47, 1)
+	Version = semver.NewSemVer(4, 47, 2)
 )
 
 // UpdateFile is retrieved from the server.

--- a/frontends/qt/Makefile
+++ b/frontends/qt/Makefile
@@ -33,10 +33,15 @@ linux:
 	# Add Wayland libs so the app can run natively on Wayland too.
 	# The linuxdeployqt maintainer unfortunately refuses to support it automatically: https://github.com/probonopd/linuxdeployqt/issues/189
 	# The list of related plugins was found by: `find $(qmake -query QT_INSTALL_PLUGINS) | grep wayland`
+	#
+	# Exclude libwayland-client.so.0, see https://github.com/AppImageCommunity/pkg2appimage/commit/15a64c20dc23a0154622ba25829364323903b6b5,
+	# but that is yet in the default exclusion lib of linuxdeployqt.
+	# See also: https://github.com/probonopd/linuxdeployqt/issues/631 - we can remove the libwayland-client.so.0 exclusion once this is merged and we updated our linuxdeployqt binary.
 	cd build/linux-tmp && /opt/linuxdeployqt-continuous-x86_64.AppImage BitBox \
 		-bundle-non-qt-libs \
 		-unsupported-allow-new-glibc \
-		-extra-plugins=platforms/libqwayland-generic.so,platforms/libqwayland-egl.so,wayland-graphics-integration-client,wayland-decoration-client,wayland-shell-integration
+		-extra-plugins=platforms/libqwayland-generic.so,platforms/libqwayland-egl.so,wayland-graphics-integration-client,wayland-decoration-client,wayland-shell-integration \
+		-exclude-libs=libwayland-client.so.0
 	cp /usr/lib/x86_64-linux-gnu/nss/* build/linux-tmp/lib
 	# See https://github.com/probonopd/linuxdeployqt/issues/554#issuecomment-1761834180
 	cp "$(shell qmake -query QT_INSTALL_DATA)/resources/v8_context_snapshot.bin" build/linux-tmp/resources
@@ -45,8 +50,8 @@ linux:
 	cp resources/linux/usr/share/icons/hicolor/128x128/apps/bitbox.png build/linux-tmp
 	mkdir build/tmp-deb/opt/
 	cp -aR build/linux-tmp build/tmp-deb/opt/bitbox
-	cd build/linux && fpm --after-install ../../resources/deb-afterinstall.sh -s dir -t deb -n bitbox -v 4.47.1 -C ../tmp-deb/
-	cd build/linux && fpm --after-install ../../resources/deb-afterinstall.sh -s dir -t rpm -n bitbox -v 4.47.1 -C ../tmp-deb/
+	cd build/linux && fpm --after-install ../../resources/deb-afterinstall.sh -s dir -t deb -n bitbox -v 4.47.2 -C ../tmp-deb/
+	cd build/linux && fpm --after-install ../../resources/deb-afterinstall.sh -s dir -t rpm -n bitbox -v 4.47.2 -C ../tmp-deb/
 	# create AppImage
 	cd build/linux-tmp && /opt/linuxdeployqt-continuous-x86_64.AppImage BitBox -appimage -unsupported-allow-new-glibc
 	mv build/linux-tmp/BitBoxApp-*-x86_64.AppImage build/linux/


### PR DESCRIPTION
This fixes this crash:

```
BitBox: symbol lookup error: /lib/x86_64-linux-gnu/libEGL_mesa.so.0:
undefined symbol: wl_display_create_queue_with_name
```

which is likely caused by the target system having a newer version of Mesa that is incompatible with the verison of libwayland-client.so.0 that we bundled.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
