### PR TITLE
backend/bitbox02: give simulator test more time to connect

### DIFF
--- a/backend/devices/bitbox02/keystore_simulator_test.go
+++ b/backend/devices/bitbox02/keystore_simulator_test.go
@@ -114,7 +114,7 @@ func runSimulator(filename string) (func() error, *Device, *bytes.Buffer, error)
 		if err == nil {
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 	}
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
CI often fails in this step, this is an attempt to fix that.
