### PR TITLE
frontend: check for strict equal eslint rule

### DIFF
--- a/frontends/web/.eslintrc.json
+++ b/frontends/web/.eslintrc.json
@@ -20,6 +20,7 @@
     "jsx-a11y/alt-text" : 0,
     "jsx-quotes": ["error", "prefer-double"],
     "keyword-spacing": "error",
+    "eqeqeq": "error",
     "no-multi-spaces": "error",
     "no-trailing-spaces": "error",
     "object-curly-spacing": ["error", "always"],

--- a/frontends/web/src/components/transactions/components/details-dialog.tsx
+++ b/frontends/web/src/components/transactions/components/details-dialog.tsx
@@ -115,7 +115,7 @@ export const TxDetailsDialog = ({
           </TxDetail>
           <TxDetail label={t('transaction.details.fiatAtTime')}>
             <span className={styles.fiat}>
-              {transactionInfo.amountAtTime?.estimated == false ?
+              {transactionInfo.amountAtTime?.estimated === false ?
                 <FiatConversion amount={transactionInfo.amountAtTime} sign={sign} noAction />
                 :
                 <FiatConversion noAction />

--- a/frontends/web/src/routes/account/send/components/confirm/dialogs/confirm-wait-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/dialogs/confirm-wait-dialog.tsx
@@ -47,7 +47,7 @@ export const ConfirmingWaitDialog = ({
 
   // Reset the signProgress state every time the dialog was closed (after send/abort).
   const [prevIsConfirming, setPrevIsConfirming] = useState(isConfirming);
-  if (prevIsConfirming != isConfirming) {
+  if (prevIsConfirming !== isConfirming) {
     setPrevIsConfirming(isConfirming);
     if (!isConfirming) {
       setSignProgress(undefined);


### PR DESCRIPTION
It is considered good practice to use the type-safe equality operators === and !== instead of their regular counterparts
 == and !=.

https://eslint.org/docs/latest/rules/eqeqeq