### PR TITLE
backend/bitbox02: add some logging

### DIFF
--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -437,8 +437,10 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 	// Provide the previous transaction for each input if needed.
 	if firmware.BTCSignNeedsPrevTxs(scriptConfigs) {
 		for inputIndex, txIn := range tx.TxIn {
+			keystore.log.Infof("getting prevTx of input %d/%d", inputIndex+1, len(tx.TxIn))
 			prevTx, err := btcProposedTx.GetPrevTx(txIn.PreviousOutPoint.Hash)
 			if err != nil {
+				keystore.log.WithError(err).Errorf("getting prevTx of input failed for input %d/%d", inputIndex+1, len(tx.TxIn))
 				return err
 			}
 			inputs[inputIndex].PrevTx = firmware.NewBTCPrevTxFromBtcd(prevTx)


### PR DESCRIPTION
If downloading prevTx fails, it would be useful to see it in the logs.
