### PR TITLE
Ios screenlock

### DIFF
--- a/frontends/ios/BitBoxApp/BitBoxApp/Info.plist
+++ b/frontends/ios/BitBoxApp/BitBoxApp/Info.plist
@@ -10,5 +10,7 @@
 	<string>This app uses Bluetooth to connect to devices.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Bluetooth is needed for communication with devices.</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Authenticate to access your BitBoxApp.</string>
 </dict>
 </plist>


### PR DESCRIPTION
@bznein fyi:

Cancelling an authentication normally should show the 'Authenticate' button to try again, but cancelling the auth when enabling the screen lock in the advanced settings should do nothing (just cancel the screen lock setup). Before this PR, cancelling the setup was buggy.