### PR TITLE
backend: add argument to force highest fee rate in tx proposal

### DIFF
--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -54,7 +54,9 @@ type TxProposalArgs struct {
 	Amount           coin.SendAmount
 	FeeTargetCode    FeeTargetCode
 	// Only applies if FeeTargetCode == Custom. It is provided in sat/vB for BTC/LTC and Gwei for ETH.
-	CustomFee      string
+	CustomFee string
+	// Option to always use the highest fee rate without specifying FeeTargetCode or CustomFee
+	UseHighestFee  bool
 	SelectedUTXOs  map[wire.OutPoint]struct{}
 	Note           string
 	PaymentRequest *PaymentRequest

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -454,6 +454,7 @@ func (input *sendTxInput) UnmarshalJSON(jsonBytes []byte) error {
 		Note           string         `json:"note"`
 		Counter        int            `json:"counter"`
 		PaymentRequest *slip24Request `json:"paymentRequest"`
+		UseHighestFee  bool           `json:"useHighestFee"`
 	}{}
 	if err := json.Unmarshal(jsonBytes, &jsonBody); err != nil {
 		return errp.WithStack(err)
@@ -488,6 +489,7 @@ func (input *sendTxInput) UnmarshalJSON(jsonBytes []byte) error {
 		}
 		input.PaymentRequest = paymentRequest
 	}
+	input.UseHighestFee = jsonBody.UseHighestFee
 	return nil
 }
 

--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -39,8 +39,7 @@ const unitSatoshi = 1e8
 // fee target (priority) if one is given, or the provided args.FeePerKb if the fee taret is
 // `FeeTargetCodeCustom`.
 func (account *Account) getFeePerKb(args *accounts.TxProposalArgs) (btcutil.Amount, error) {
-	isPaymentRequest := args.PaymentRequest != nil
-	if args.FeeTargetCode == accounts.FeeTargetCodeCustom && !isPaymentRequest {
+	if args.FeeTargetCode == accounts.FeeTargetCodeCustom && !args.UseHighestFee {
 		float, err := strconv.ParseFloat(args.CustomFee, 64)
 		if err != nil {
 			return 0, err
@@ -60,7 +59,7 @@ func (account *Account) getFeePerKb(args *accounts.TxProposalArgs) (btcutil.Amou
 	}
 
 	var feeTarget *FeeTarget
-	if isPaymentRequest {
+	if args.UseHighestFee {
 		feeTarget = account.feeTargets().highest()
 	} else {
 		for _, target := range account.feeTargets() {

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -320,12 +320,18 @@ export const getReceiveAddressList = (code: AccountCode) => {
 export type TTxInput = {
   address: string;
   amount: string;
-  feeTarget: FeeTargetCode;
-  customFee: string;
   sendAll: 'yes' | 'no';
   selectedUTXOs: string[];
   paymentRequest: Slip24 | null;
-};
+} & (
+  {
+    useHighestFee: false;
+    customFee: string;
+    feeTarget: FeeTargetCode;
+  } | {
+    useHighestFee: true;
+  }
+);
 
 export type TTxProposalResult = {
   amount: IAmount;

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -165,6 +165,7 @@ class Send extends Component<Props, State> {
       sendAll: (this.state.sendAll ? 'yes' : 'no'),
       selectedUTXOs: Object.keys(this.selectedUTXOs),
       paymentRequest: null,
+      useHighestFee: false
     };
   };
 

--- a/frontends/web/src/routes/exchange/pocket.tsx
+++ b/frontends/web/src/routes/exchange/pocket.tsx
@@ -206,12 +206,11 @@ export const Pocket = ({ code, action }: TProps) => {
     const txInput: TTxInput = {
       address: message.bitcoinAddress,
       amount: parsedAmount.amount,
-      // feeTarget will be automatically set on the highest in the BE.
-      feeTarget: 'custom',
-      customFee: '',
+      // Always use the highest fee rate for Pocket sell
+      useHighestFee: true,
       sendAll: 'no',
       selectedUTXOs: [],
-      paymentRequest: message.slip24,
+      paymentRequest: message.slip24
     };
 
     let result = await proposeTx(code, txInput);


### PR DESCRIPTION
Previously, the highest fee rate was automatically applied to all transaction proposals with a SLIP-24 payment request. For selling and spending integrations that do not use SLIP-24 payment requests, there should also be an option to trigger this same behaviour.

This commit replaces the previous conditioning on payment requests with a general boolean field that is set independently and can be used for other integrations. This also allows setting a custom fee rate for transaction proposals with payment requests, if needed.


