### PR TITLE
backend: remove blocking API calls.

### DIFF
--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -37,6 +37,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// ErrSyncInProgress is returned when the initial account sync is still in progress.
+	ErrSyncInProgress errp.ErrorCode = "syncInProgress"
+)
+
 // AccountConfig holds account configuration.
 type AccountConfig struct {
 	// Pointer to persisted config. Do not modify this directly. Use

--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -120,7 +120,9 @@ func TestAccount(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, accounts.OrderedTransactions{}, transactions)
 
-	require.Equal(t, []*SpendableOutput{}, account.SpendableOutputs())
+	spendableOutputs, err := account.SpendableOutputs()
+	require.NoError(t, err)
+	require.Equal(t, []*SpendableOutput{}, spendableOutputs)
 }
 
 func TestInsuredAccountAddresses(t *testing.T) {

--- a/backend/coins/btc/synchronizer/synchronizer.go
+++ b/backend/coins/btc/synchronizer/synchronizer.go
@@ -64,15 +64,3 @@ func (synchronizer *Synchronizer) decRequestsCounter() {
 		panic("request counter cannot be negative")
 	}
 }
-
-// WaitSynchronized blocks until all pending synchronization tasks are finished.
-func (synchronizer *Synchronizer) WaitSynchronized() {
-	unlock := synchronizer.waitLock.RLock()
-	n := synchronizer.requestsCounter
-	wait := synchronizer.wait
-	unlock()
-	if n == 0 {
-		return
-	}
-	<-wait
-}

--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -147,6 +147,10 @@ func (account *Account) newTx(args *accounts.TxProposalArgs) (
 		}
 		outputInfo = maketx.NewOutputInfo(pkScript)
 	}
+
+	if !account.Synced() {
+		return nil, nil, accounts.ErrSyncInProgress
+	}
 	utxo, err := account.transactions.SpendableOutputs()
 	if err != nil {
 		return nil, nil, err

--- a/backend/coins/btc/transactions/transactions.go
+++ b/backend/coins/btc/transactions/transactions.go
@@ -194,7 +194,6 @@ func (transactions *Transactions) allInputsOurs(dbTx DBTxInterface, transaction 
 // include all unspent outputs of confirmed transactions, and unconfirmed outputs that we created
 // ourselves.
 func (transactions *Transactions) SpendableOutputs() (map[wire.OutPoint]*SpendableOutput, error) {
-	transactions.synchronizer.WaitSynchronized()
 	return DBView(transactions.db, func(dbTx DBTxInterface) (map[wire.OutPoint]*SpendableOutput, error) {
 		outputs, err := dbTx.Outputs()
 		if err != nil {
@@ -337,7 +336,6 @@ func (transactions *Transactions) getTransactionCached(
 
 // Balance computes the confirmed and unconfirmed balance of the account.
 func (transactions *Transactions) Balance() (*accounts.Balance, error) {
-	transactions.synchronizer.WaitSynchronized()
 	return DBView(transactions.db, func(dbTx DBTxInterface) (*accounts.Balance, error) {
 		outputs, err := dbTx.Outputs()
 		if err != nil {
@@ -499,7 +497,6 @@ func (transactions *Transactions) txInfo(
 // Transactions returns an ordered list of transactions.
 func (transactions *Transactions) Transactions(
 	isChange func(blockchain.ScriptHashHex) bool) (accounts.OrderedTransactions, error) {
-	transactions.synchronizer.WaitSynchronized()
 	return DBView(transactions.db, func(dbTx DBTxInterface) (accounts.OrderedTransactions, error) {
 		txs := []*accounts.TransactionData{}
 		txHashes, err := dbTx.Transactions()

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -479,13 +479,23 @@ func (account *Account) Notifier() accounts.Notifier {
 
 // Transactions implements accounts.Interface.
 func (account *Account) Transactions() (accounts.OrderedTransactions, error) {
-	account.Synchronizer.WaitSynchronized()
+	if err := account.Offline(); err != nil {
+		return nil, err
+	}
+	if !account.Synced() {
+		return nil, accounts.ErrSyncInProgress
+	}
 	return accounts.NewOrderedTransactions(account.transactions), nil
 }
 
 // Balance implements accounts.Interface.
 func (account *Account) Balance() (*accounts.Balance, error) {
-	account.Synchronizer.WaitSynchronized()
+	if err := account.Offline(); err != nil {
+		return nil, err
+	}
+	if !account.Synced() {
+		return nil, accounts.ErrSyncInProgress
+	}
 	return accounts.NewBalance(account.balance, coin.NewAmountFromInt64(0)), nil
 }
 

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/errors"
@@ -113,7 +114,7 @@ func newAccount(t *testing.T) *Account {
 func TestTxProposal(t *testing.T) {
 	acct := newAccount(t)
 	defer acct.Close()
-	acct.Synchronizer.WaitSynchronized()
+	require.Eventually(t, acct.Synced, time.Second, time.Millisecond*200)
 
 	t.Run("valid", func(t *testing.T) {
 		value, fee, total, err := acct.TxProposal(&accounts.TxProposalArgs{
@@ -170,7 +171,7 @@ func TestTxProposal(t *testing.T) {
 func TestMatchesAddress(t *testing.T) {
 	acct := newAccount(t)
 	defer acct.Close()
-	acct.Synchronizer.WaitSynchronized()
+	require.Eventually(t, acct.Synced, time.Second, time.Millisecond*200)
 
 	// Test invalid Ethereum address
 	t.Run("Invalid Ethereum address", func(t *testing.T) {

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -217,8 +217,8 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/account-add", handlers.postAddAccount).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/keystores", handlers.getKeystores).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/accounts", handlers.getAccounts).Methods("GET")
-	getAPIRouter(apiRouter)("/accounts/balance", handlers.getAccountsBalance).Methods("GET")
-	getAPIRouter(apiRouter)("/accounts/coins-balance", handlers.getCoinsTotalBalance).Methods("GET")
+	getAPIRouterNoError(apiRouter)("/accounts/balance", handlers.getAccountsBalance).Methods("GET")
+	getAPIRouterNoError(apiRouter)("/accounts/coins-balance", handlers.getCoinsTotalBalance).Methods("GET")
 	getAPIRouter(apiRouter)("/accounts/total-balance", handlers.getAccountsTotalBalance).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/set-account-active", handlers.postSetAccountActive).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/set-token-active", handlers.postSetTokenActive).Methods("POST")
@@ -702,11 +702,15 @@ func (handlers *Handlers) postBtcFormatUnit(r *http.Request) interface{} {
 }
 
 // getAccountsBalanceHandler returns the balance of all the accounts, grouped by keystore and coin.
-func (handlers *Handlers) getAccountsBalance(*http.Request) (interface{}, error) {
+func (handlers *Handlers) getAccountsBalance(*http.Request) interface{} {
+	type response struct {
+		Success bool                                                     `json:"success"`
+		Balance map[string]map[coin.Code]accountHandlers.FormattedAmount `json:"balance,omitempty"`
+	}
 	totalAmount := make(map[string]map[coin.Code]accountHandlers.FormattedAmount)
 	accountsByKeystore, err := handlers.backend.AccountsByKeystore()
 	if err != nil {
-		return nil, err
+		return response{Success: false}
 	}
 	for rootFingerprint, accountList := range accountsByKeystore {
 		totalPerCoin := make(map[coin.Code]*big.Int)
@@ -720,12 +724,12 @@ func (handlers *Handlers) getAccountsBalance(*http.Request) (interface{}, error)
 			}
 			err := account.Initialize()
 			if err != nil {
-				return nil, err
+				return response{Success: false}
 			}
 			coinCode := account.Coin().Code()
 			b, err := account.Balance()
 			if err != nil {
-				return nil, err
+				return response{Success: false}
 			}
 			amount := b.Available()
 			if _, ok := totalPerCoin[coinCode]; !ok {
@@ -747,7 +751,7 @@ func (handlers *Handlers) getAccountsBalance(*http.Request) (interface{}, error)
 		for k, v := range totalPerCoin {
 			currentCoin, err := handlers.backend.Coin(k)
 			if err != nil {
-				return nil, err
+				return response{Success: false}
 			}
 			totalAmount[rootFingerprint][k] = accountHandlers.FormattedAmount{
 				Amount:      currentCoin.FormatAmount(coin.NewAmount(v), false),
@@ -757,7 +761,10 @@ func (handlers *Handlers) getAccountsBalance(*http.Request) (interface{}, error)
 		}
 	}
 
-	return totalAmount, nil
+	return response{
+		Success: true,
+		Balance: totalAmount,
+	}
 }
 
 type coinFormattedAmount struct {
@@ -767,7 +774,11 @@ type coinFormattedAmount struct {
 }
 
 // getCoinsTotalBalance returns the total balances grouped by coins.
-func (handlers *Handlers) getCoinsTotalBalance(_ *http.Request) (interface{}, error) {
+func (handlers *Handlers) getCoinsTotalBalance(_ *http.Request) interface{} {
+	type result struct {
+		Success           bool                  `json:"success"`
+		CoinsTotalBalance []coinFormattedAmount `json:"coinsTotalBalance,omitempty"`
+	}
 	var coinFormattedAmounts []coinFormattedAmount
 	var sortedCoins []coin.Code
 	totalCoinsBalances := make(map[coin.Code]*big.Int)
@@ -781,12 +792,12 @@ func (handlers *Handlers) getCoinsTotalBalance(_ *http.Request) (interface{}, er
 		}
 		err := account.Initialize()
 		if err != nil {
-			return nil, err
+			return result{Success: false}
 		}
 		coinCode := account.Coin().Code()
 		b, err := account.Balance()
 		if err != nil {
-			return nil, err
+			return result{Success: false}
 		}
 		amount := b.Available()
 
@@ -801,7 +812,7 @@ func (handlers *Handlers) getCoinsTotalBalance(_ *http.Request) (interface{}, er
 	for _, coinCode := range sortedCoins {
 		currentCoin, err := handlers.backend.Coin(coinCode)
 		if err != nil {
-			return nil, err
+			return result{Success: false}
 		}
 		coinFormattedAmounts = append(coinFormattedAmounts, coinFormattedAmount{
 			CoinCode: coinCode,
@@ -819,24 +830,22 @@ func (handlers *Handlers) getCoinsTotalBalance(_ *http.Request) (interface{}, er
 			},
 		})
 	}
-	return coinFormattedAmounts, nil
+	return result{
+		Success:           true,
+		CoinsTotalBalance: coinFormattedAmounts,
+	}
 }
 
 // getAccountsTotalBalanceHandler returns the total balance of all the accounts, gruped by keystore.
 func (handlers *Handlers) getAccountsTotalBalance(*http.Request) (interface{}, error) {
 	type response struct {
 		Success      bool                                   `json:"success"`
-		ErrorCode    string                                 `json:"errorCode,omitempty"`
-		ErrorMessage string                                 `json:"errorMessage,omitempty"`
 		TotalBalance map[string]backend.KeystoreTotalAmount `json:"totalBalance"`
 	}
 
 	totalBalance, err := handlers.backend.AccountsTotalBalanceByKeystore()
 	if err != nil {
-		if errp.Cause(err) == rates.ErrRatesNotAvailable {
-			return response{Success: false, ErrorCode: err.Error()}, nil
-		}
-		return response{Success: false, ErrorMessage: err.Error()}, nil
+		return response{Success: false}, nil
 	}
 	return response{Success: true, TotalBalance: totalBalance}, nil
 }
@@ -1217,14 +1226,13 @@ func (handlers *Handlers) apiMiddleware(devMode bool, h func(*http.Request) (int
 
 func (handlers *Handlers) getAccountSummary(*http.Request) interface{} {
 	type Result struct {
-		Error   string         `json:"error,omitempty"`
 		Data    *backend.Chart `json:"data,omitempty"`
 		Success bool           `json:"success"`
 	}
 
 	data, err := handlers.backend.ChartData()
 	if err != nil {
-		return Result{Success: false, Error: err.Error()}
+		return Result{Success: false}
 	}
 	return Result{Success: true, Data: data}
 }

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -83,11 +83,19 @@ export type TAccountsBalanceByCoin = {
   [key in CoinCode]?: IAmount;
 };
 
+export type TAccountsBalanceResponse = {
+  success: true;
+  balance: TAccountsBalance;
+
+} | {
+  success: false;
+}
+
 export type TAccountsBalance = {
   [rootFingerprint in TKeystore['rootFingerprint']]: TAccountsBalanceByCoin;
 };
 
-export const getAccountsBalance = (): Promise<TAccountsBalance> => {
+export const getAccountsBalance = (): Promise<TAccountsBalanceResponse> => {
   return apiGet('accounts/balance');
 };
 
@@ -105,8 +113,6 @@ export type TAccountsTotalBalanceResponse = {
     totalBalance: TAccountsTotalBalance;
 } | {
     success: false;
-    errorCode?: 'ratesNotAvailable';
-    errorMessage?: string;
 }
 
 export const getAccountsTotalBalance = (): Promise<TAccountsTotalBalanceResponse> => {
@@ -119,9 +125,16 @@ type CoinFormattedAmount = {
   formattedAmount: IAmount;
 };
 
+export type TCoinsTotalBalanceResponse = {
+  success: true;
+  coinsTotalBalance: TCoinsTotalBalance;
+} | {
+  success: false;
+}
+
 export type TCoinsTotalBalance = CoinFormattedAmount[];
 
-export const getCoinsTotalBalance = (): Promise<TCoinsTotalBalance> => {
+export const getCoinsTotalBalance = (): Promise<TCoinsTotalBalanceResponse> => {
   return apiGet('accounts/coins-balance');
 };
 
@@ -197,7 +210,6 @@ export type TSummaryResponse = {
     data: TSummary;
 } | {
   success: false;
-  error: string;
 }
 
 export type TSummary = {
@@ -233,7 +245,14 @@ export interface IBalance {
     incoming: IAmount;
 }
 
-export const getBalance = (code: AccountCode): Promise<IBalance> => {
+export type TBalanceResponse = {
+  success: true;
+  balance: IBalance;
+} | {
+  success: false;
+}
+
+export const getBalance = (code: AccountCode): Promise<TBalanceResponse> => {
   return apiGet(`account/${code}/balance`);
 };
 

--- a/frontends/web/src/components/groupedaccountselector/services.ts
+++ b/frontends/web/src/components/groupedaccountselector/services.ts
@@ -12,7 +12,10 @@ export const createGroupedOptions = (accountsByKeystore: TAccountsByKeystore[]) 
 
 const appendBalance = async (option: TOption) => {
   const balance = await getBalance(option.value);
-  return { ...option, balance: `${balance.available.amount} ${balance.available.unit}` };
+  if (!balance.success) {
+    return { ... option };
+  }
+  return { ...option, balance: `${balance.balance.available.amount} ${balance.balance.available.unit}` };
 };
 
 export const getBalancesForGroupedAccountSelector = async (originalGroupedOptions: TGroupedOption[]) => {

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -155,7 +155,12 @@ const RemountAccount = ({
     }
     if (status.synced && status.offlineError === null) {
       Promise.all([
-        accountApi.getBalance(code).then(setBalance),
+        accountApi.getBalance(code).then(
+          balance => {
+            if (balance.success) {
+              setBalance(balance.balance);
+            }
+          }),
         accountApi.getTransactionList(code).then(setTransactions),
       ])
         .catch(console.error);

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -94,7 +94,12 @@ class Send extends Component<Props, State> {
 
   public componentDidMount() {
     const updateBalance = (code: string) => accountApi.getBalance(code)
-      .then(balance => this.setState({ balance }))
+      .then(balance => {
+        if (!balance.success) {
+          return;
+        }
+        this.setState({ balance: balance.balance });
+      })
       .catch(console.error);
 
     updateBalance(this.props.account.code);

--- a/frontends/web/src/routes/accounts/all-accounts.tsx
+++ b/frontends/web/src/routes/accounts/all-accounts.tsx
@@ -43,10 +43,14 @@ const AccountItem = ({ account, hideAmounts }: { account: accountApi.IAccount, h
   useEffect(() => {
     const fetchBalance = async () => {
       try {
-        const balanceData = await getBalance(account.code);
+        const balance = await getBalance(account.code);
         if (!mounted.current) {
           return;
         }
+        if (!balance.success) {
+          return;
+        }
+        const balanceData = balance.balance;
         if (balanceData.hasAvailable) {
           setBalance(balanceData.available.amount);
         } else {

--- a/frontends/web/src/routes/bitsurance/dashboard.tsx
+++ b/frontends/web/src/routes/bitsurance/dashboard.tsx
@@ -104,9 +104,12 @@ export const BitsuranceDashboard = ({ accounts }: TProps) => {
             if (!mounted.current) {
               return;
             }
+            if (!balance.success) {
+              return;
+            }
             setBalances((prevBalances) => ({
               ...prevBalances,
-              [account.code]: balance
+              [account.code]: balance.balance
             }));
           });
         });


### PR DESCRIPTION
Note: this is still VERY MUCH Work In Progress. Feel free to take a look at the overall logic but be aware that it needs to be cleaned up and there are still TODOs

We don't want calls to Balance, Transactions,
GetUnusedReceiveAddressesses and SpendableOutputs to block as this can cause calls to pile up and consume resources; also, this calls can be made irrelevant if the user switches to a different page.

Instead, while the first sync is in progress, we return an appropriate error. After that, every call returns the latest known state.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
