### PR TITLE
frontend: disable native back in confirm send step

### DIFF
--- a/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
@@ -16,6 +16,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { CoinCode, ConversionUnit, FeeTargetCode, Fiat, IAmount } from '@/api/account';
+import { UseDisableBackButton } from '@/hooks/backbutton';
 import { Amount } from '@/components/amount/amount';
 import { customFeeUnit } from '@/routes/account/utils';
 import { View, ViewContent, ViewHeader } from '@/components/view/view';
@@ -74,9 +75,9 @@ export const ConfirmSend = ({
   const canShowFeeFiatValue = proposedFee && proposedFee.conversions && proposedFee.conversions[fiatUnit];
   const canShowTotalFiatValue = (proposedTotal && proposedTotal.conversions) && proposedTotal.conversions[fiatUnit];
 
-
   return (
     <View fullscreen width="840px">
+      <UseDisableBackButton />
       <ViewHeader title={<div className={style.title}>{t('send.confirm.title')}</div>} />
       <ViewContent>
         <Message type="info">


### PR DESCRIPTION
When confirming transaction details on the device the app should block native Android back.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
