### PR TITLE
frontend: remove code for swiping the sidebar

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -103,54 +103,6 @@ const Sidebar = ({
     checkUpgradableDevices();
   }, [devices]);
 
-  useEffect(() => {
-    const swipe = {
-      active: false,
-      x: 0,
-      y: 0,
-    };
-
-    const handleTouchStart = (event: TouchEvent) => {
-      const touch = event.touches[0];
-      swipe.x = touch.clientX;
-      swipe.y = touch.clientY;
-    };
-
-    const handleTouchMove = (event: TouchEvent) => {
-      if (
-        event.changedTouches
-        && event.changedTouches.length
-      ) {
-        swipe.active = true;
-      }
-    };
-
-    const handleTouchEnd = (event: TouchEvent) => {
-      const touch = event.changedTouches[0];
-      const travelX = Math.abs(touch.clientX - swipe.x);
-      const travelY = Math.abs(touch.clientY - swipe.y);
-      const validSwipe = window.innerWidth <= 901 && swipe.active && travelY < 100 && travelX > 70;
-      if (
-        (!activeSidebar && validSwipe && swipe.x < 60)
-        || (activeSidebar && validSwipe && swipe.x > 230)
-      ) {
-        toggleSidebar();
-      }
-      swipe.x = 0;
-      swipe.y = 0;
-      swipe.active = false;
-    };
-
-    document.addEventListener('touchstart', handleTouchStart);
-    document.addEventListener('touchmove', handleTouchMove);
-    document.addEventListener('touchend', handleTouchEnd);
-    return () => {
-      document.removeEventListener('touchstart', handleTouchStart);
-      document.removeEventListener('touchmove', handleTouchMove);
-      document.removeEventListener('touchend', handleTouchEnd);
-    };
-  }, [activeSidebar, toggleSidebar]);
-
   const keystores = useKeystores();
 
   const handleSidebarItemClick = (event: React.SyntheticEvent) => {


### PR DESCRIPTION
In recent commit the hamburger navigation was replaced by bottom menu navigation on mobile. Note: we still use the hamburger on medium sized screens.

See a6d6af08191fc1b8c40c1352e62a6f5d1548df4c

The sidebar contained some code to listen for swipe events to open and close the sidebar on mobile. So when a user swipes from left to right in order to go back, it could happen that the swipe listener takes over and opens the sidebar instead of going back 1 step in history.

Removed the swipe listener in this commit.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
