### PR TITLE
update notes import and export file type to jsonl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enable unlock test wallet in testnet
 - Added support to show on the BitBox when a transaction's recipient is an address of a different account on the device.
 - Persist third party widget sessions
+- Change notes export file type to JSON Lines
 
 ## v4.47.3
 - Upgrade Etherscan API to V2

--- a/backend/notes.go
+++ b/backend/notes.go
@@ -158,7 +158,7 @@ func (backend *Backend) ExportNotes() error {
 	if err != nil {
 		return err
 	}
-	name := fmt.Sprintf("%s-notes.txt", time.Now().Format("2006-01-02-at-15-04-05"))
+	name := fmt.Sprintf("%s-notes.jsonl", time.Now().Format("2006-01-02-at-15-04-05"))
 	suggestedPath := filepath.Join(exportsDir, name)
 	path := backend.Environment().GetSaveFilename(suggestedPath)
 	if path == "" {

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -51,6 +51,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -352,13 +353,8 @@ public class MainActivity extends AppCompatActivity {
                 MainActivity.this.filePathCallback = filePathCallback;
                 String[] mimeTypes = fileChooserParams.getAcceptTypes();
                 String fileType = "*/*";
-                if (mimeTypes.length == 1) {
-                    // import notes form uses .txt file type, but is not supported here.
-                    if (".txt".equals(mimeTypes[0])) {
-                        fileType = "text/plain";
-                    } else if (MimeTypeMap.getSingleton().hasMimeType(mimeTypes[0])) {
-                        fileType = mimeTypes[0];
-                    }
+                if (mimeTypes.length == 1 && MimeTypeMap.getSingleton().hasMimeType(mimeTypes[0])) {
+                    fileType = mimeTypes[0];
                 }
                 mGetContent.launch(fileType);
                 return true;

--- a/frontends/web/src/routes/settings/components/appearance/notesImport.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/notesImport.tsx
@@ -32,7 +32,7 @@ export const NotesImport = () => {
         type="file"
         className={style.fileInput}
         ref={fileInputRef}
-        accept=".txt"
+        accept=".jsonl,.txt"
         onChange={async (e: React.ChangeEvent<HTMLInputElement>) => {
           setImportDisabled(e.target.files === null || e.target.files.length === 0);
           if (fileInputRef.current === null) {


### PR DESCRIPTION
Changes the file type of notes exports to .jsonl (JSON Lines), which is a more common format used by compatible wallets as specified in BIP-329.

For example, exporting labels with Sparrow Wallet creates a .jsonl, which would previously have to be renamed manually in order to allow importing it in the BitBoxApp.

The supported import file types are updated accordingly, still allowing .txt imports for exports created prior to this change.