### PR TITLE
frontend: fix confirmation time for ERC20 tokens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix a bug that would prevent the app to perform firmware upgrade when offline.
 - Replace sidebar with bottom navigation bar for mobile devices
 - Introduce full screen selector for mobile in place of dropdown
+- Fix wrong estimated confirmation time for ERC20 tokens.
 
 # v4.47.2
 - Linux: fix compatiblity with some versions of Mesa that are incompatible with the bundled wayland libraries

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -64,6 +64,9 @@ export const getCoinCode = (coinCode: CoinCode): CoinCode | undefined => {
   case 'sepeth':
     return 'eth';
   }
+  if (coinCode.startsWith('eth-erc20-')) {
+    return 'eth';
+  }
 };
 
 export const getScriptName = (scriptType: ScriptType): string => {


### PR DESCRIPTION
The current GetCoinCode logic omits erc20 tokens, so we just use the "standard" text for confirmation time. 

With this change, we return "eth" for erc20 tokens so that we can show the correct confirmation time.

![image](https://github.com/user-attachments/assets/2faf4dd3-25c6-4c62-ba4c-1ed17e7d747f)


Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
