### PR TITLE
frontend: show global banners in the wait screen too

### DIFF
--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -25,6 +25,8 @@ import { useKeystores } from '@/hooks/backend';
 import { useDarkmode } from '@/hooks/darkmode';
 import { useDefault } from '@/hooks/default';
 import { Bluetooth } from '@/components/bluetooth/bluetooth';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
+import { GlobalBanners } from '@/components/banners';
 import { Entry } from '@/components/guide/entry';
 import { Guide } from '@/components/guide/guide';
 import { Spinner } from '@/components/spinner/Spinner';
@@ -60,6 +62,9 @@ export const Waiting = () => {
     <GuideWrapper>
       <GuidedContent>
         <Main>
+          <ContentWrapper>
+            <GlobalBanners />
+          </ContentWrapper>
           <Header title={<h2>{t('welcome.title')}</h2>}>
             <OutlinedSettingsButton />
           </Header>


### PR DESCRIPTION
It's important to see the testnet warning early, otherwise it's very hard to see if one is in testnet mode.

It's also good to see the mobile data warning *before* one connects a device and all the data starts being used.

