### PR TITLE
frontend: hide exchange button on mobile

### DIFF
--- a/frontends/web/src/routes/account/account.module.css
+++ b/frontends/web/src/routes/account/account.module.css
@@ -132,7 +132,7 @@
     }
 
     .actionsContainer {
-        justify-content: space-between;
+        justify-content: center;
         margin-bottom: var(--space-half);
         padding-bottom: 0;
         width: 100%;

--- a/frontends/web/src/routes/account/actionButtons.tsx
+++ b/frontends/web/src/routes/account/actionButtons.tsx
@@ -37,6 +37,7 @@ export const ActionButtons = ({ canSend, code, coinCode, exchangeSupported, acco
   const navigate = useNavigate();
   const walletConnectEnabled = isEthereumBased(account.coinCode) && !account.isToken;
   const isLargeTablet = useMediaQuery('(max-width: 830px)');
+  const isMobile = useMediaQuery('(max-width: 768px)');
 
   // When clicking 'Send', for Ethereum based accounts we first prompt to connect the keystore
   // before proceeding. The reason is that in ETH, we need to know what keystore (which BitBox02
@@ -73,7 +74,7 @@ export const ActionButtons = ({ canSend, code, coinCode, exchangeSupported, acco
         </span>
       )}
 
-      {exchangeSupported && (
+      {(exchangeSupported && !isMobile) && (
         accountDataLoaded ? (
           <Link key="exchange" to={`/exchange/info/${code}`} className={style.exchange}>
             <span>{t('generic.buySell')}</span>

--- a/frontends/web/src/routes/account/info/buy-receive-cta.tsx
+++ b/frontends/web/src/routes/account/info/buy-receive-cta.tsx
@@ -87,7 +87,6 @@ export const BuyReceiveCTA = ({
         )}
         {(exchangeSupported && !isMobile) && (
           <Button primary onClick={onExchangeCTA}>
-            {/* "Exchange Bitcoin", "Exchange crypto" or "Exchange LTC" (via placeholder "Exchange {{coinCode}}") */}
             {t('generic.buySell')}
           </Button>
         )}

--- a/frontends/web/src/routes/account/info/buy-receive-cta.tsx
+++ b/frontends/web/src/routes/account/info/buy-receive-cta.tsx
@@ -17,8 +17,8 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import type { AccountCode, CoinUnit, IAccount, IBalance } from '@/api/account';
 import { useMediaQuery } from '@/hooks/mediaquery';
-import { CoinUnit, IAccount, IBalance } from '@/api/account';
 import { Button } from '@/components/forms';
 import { Balances } from '@/routes/account/summary/accountssummary';
 import { isBitcoinCoin, isEthereumBased } from '@/routes/account/utils';
@@ -30,8 +30,8 @@ import styles from './buy-receive-cta.module.css';
 
 type TBuyReceiveCTAProps = {
   balanceList?: IBalance[];
-  code?: string;
-  unit?: string;
+  code?: AccountCode;
+  unit?: CoinUnit;
   exchangeSupported?: boolean;
   account?: IAccount;
 };

--- a/frontends/web/src/routes/account/info/buy-receive-cta.tsx
+++ b/frontends/web/src/routes/account/info/buy-receive-cta.tsx
@@ -85,7 +85,7 @@ export const BuyReceiveCTA = ({
             })}
           </Button>
         )}
-        {exchangeSupported && (
+        {(exchangeSupported && !isMobile) && (
           <Button primary onClick={onExchangeCTA}>
             {/* "Exchange Bitcoin", "Exchange crypto" or "Exchange LTC" (via placeholder "Exchange {{coinCode}}") */}
             {t('generic.buySell')}

--- a/frontends/web/src/routes/account/info/buy-receive-cta.tsx
+++ b/frontends/web/src/routes/account/info/buy-receive-cta.tsx
@@ -50,7 +50,7 @@ export const BuyReceiveCTA = ({
 }: TBuyReceiveCTAProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const isBitcoin = isBitcoinCoin(unit as CoinUnit);
+  const isBitcoin = isBitcoinCoin(unit);
   const isMobile = useMediaQuery('(max-width: 768px)');
 
   const onExchangeCTA = () => navigate(code ? `/exchange/info/${code}` : '/exchange/info');

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -34,7 +34,17 @@ export const isBitcoinOnly = (coinCode: CoinCode): boolean => {
   }
 };
 
-export const isBitcoinCoin = (coin: CoinUnit) => (coin === 'BTC') || (coin === 'TBTC') || (coin === 'sat') || (coin === 'tsat');
+export const isBitcoinCoin = (coin: CoinUnit | undefined) => {
+  switch (coin) {
+  case 'BTC':
+  case 'TBTC':
+  case 'sat':
+  case 'tsat':
+    return true;
+  default:
+    return false;
+  }
+};
 
 export const isBitcoinBased = (coinCode: CoinCode): boolean => {
   switch (coinCode) {


### PR DESCRIPTION
With the new bottom menu the app always prominently shows 'Buy & sell'
on mobile, so there is no need to show and clutter the send, recieve
buttons.

also added 3 small cleanup commits