### PR TITLE
frontend: fix postmessage error

### DIFF
--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -155,6 +155,8 @@ export const BTCDirect = ({
         event.source?.postMessage({
           action: 'confirm-transaction-id',
           transactionId: txId
+        }, {
+          targetOrigin: event.origin
         });
         // stop here and continue in the widget
         return;
@@ -175,6 +177,8 @@ export const BTCDirect = ({
     // cancel the sell order here if txProposal or sendTx was unsuccessful
     event.source?.postMessage({
       action: 'cancel-order',
+    }, {
+      targetOrigin: event.origin
     });
 
   }, [code, t]);


### PR DESCRIPTION
This fixes the following error:

Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('bitboxapp:') does not match the recipient window's origin ('https://bitboxapp.shiftcrypto.io')

Posting 'configuration' in handleConfiguration already works and was missing in the two new postMessage's that are used to 'confirm-transaction-id' and 'cancel-order'.
