### PR TITLE
backend/btc/address: be explicit about chainIndex/addressIndex

### DIFF
--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -151,7 +151,7 @@ func MockBtcAccount(t *testing.T, config *accounts.AccountConfig, coin *btc.Coin
 			for _, signingConfig := range config.Config.SigningConfigurations {
 				addressChain := addresses.NewAddressChain(
 					signingConfig,
-					coin.Net(), 20, 0,
+					coin.Net(), 20, false,
 					func(*addresses.AccountAddress) (bool, error) {
 						return false, nil
 					},

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -331,9 +331,9 @@ func (account *Account) Initialize() error {
 		account.log.Infof("gap limits: receive=%d, change=%d", gapLimits.Receive, gapLimits.Change)
 
 		subacc.receiveAddresses = addresses.NewAddressChain(
-			signingConfiguration, account.coin.Net(), int(gapLimits.Receive), 0, account.isAddressUsed, account.log)
+			signingConfiguration, account.coin.Net(), int(gapLimits.Receive), false, account.isAddressUsed, account.log)
 		subacc.changeAddresses = addresses.NewAddressChain(
-			signingConfiguration, account.coin.Net(), int(gapLimits.Change), 1, account.isAddressUsed, account.log)
+			signingConfiguration, account.coin.Net(), int(gapLimits.Change), true, account.isAddressUsed, account.log)
 
 		account.subaccounts = append(account.subaccounts, subacc)
 	}

--- a/backend/coins/btc/addresses/address.go
+++ b/backend/coins/btc/addresses/address.go
@@ -49,20 +49,25 @@ type AccountAddress struct {
 // NewAccountAddress creates a new account address.
 func NewAccountAddress(
 	accountConfiguration *signing.Configuration,
-	keyPath signing.RelativeKeypath,
+	derivation types.Derivation,
 	net *chaincfg.Params,
 	log *logrus.Entry,
 ) *AccountAddress {
 
 	var address btcutil.Address
 	var redeemScript []byte
-	configuration, err := accountConfiguration.Derive(keyPath)
+	configuration, err := accountConfiguration.Derive(
+		signing.NewEmptyRelativeKeypath().
+			Child(derivation.SimpleChainIndex(), signing.NonHardened).
+			Child(derivation.AddressIndex, signing.NonHardened),
+	)
 	if err != nil {
 		log.WithError(err).Panic("Failed to derive the configuration.")
 	}
 	log = log.WithFields(logrus.Fields{
-		"key-path":      configuration.AbsoluteKeypath().Encode(),
-		"configuration": configuration.String(),
+		"accountConfiguration": accountConfiguration.String(),
+		"change":               derivation.Change,
+		"addressIndex":         derivation.AddressIndex,
 	})
 	log.Debug("Creating new account address")
 

--- a/backend/coins/btc/addresses/test/test.go
+++ b/backend/coins/btc/addresses/test/test.go
@@ -16,6 +16,7 @@ package test
 
 import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/addresses"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/types"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/logging"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
@@ -48,7 +49,7 @@ func NewAddressChain(
 	}
 	configuration := signing.NewBitcoinConfiguration(
 		signing.ScriptTypeP2PKH, []byte{1, 2, 3, 4}, derivationPath, xpub)
-	return configuration, addresses.NewAddressChain(configuration, net, 20, 0, isAddressUsed, log)
+	return configuration, addresses.NewAddressChain(configuration, net, 20, false, isAddressUsed, log)
 }
 
 // GetAddress returns a dummy address for a given address type.
@@ -61,7 +62,7 @@ func GetAddress(scriptType signing.ScriptType) *addresses.AccountAddress {
 		scriptType, []byte{1, 2, 3, 4}, absoluteKeypath, extendedPublicKey)
 	return addresses.NewAccountAddress(
 		configuration,
-		signing.NewEmptyRelativeKeypath(),
+		types.Derivation{Change: false, AddressIndex: 0},
 		net,
 		logging.Get().WithGroup("addresses_test"),
 	)

--- a/backend/coins/btc/types/types.go
+++ b/backend/coins/btc/types/types.go
@@ -52,3 +52,21 @@ func (s *Signature) SerializeCompact() []byte {
 	s.S.FillBytes(result[32:])
 	return result
 }
+
+// Derivation contains the derivation information to derive address-level information from a BTC
+// account descriptor.
+type Derivation struct {
+	// Change is true to derive change address details and false to derive receive address details.
+	Change       bool
+	AddressIndex uint32
+}
+
+// SimpleChainIndex returns 0 for receive and 1 or change. This applies to standard BIP-44
+// derivations, but not to multipath descriptors.
+func (d Derivation) SimpleChainIndex() uint32 {
+	if d.Change {
+		return 1
+	}
+
+	return 0
+}

--- a/backend/devices/bitbox02/keystore_simulator_test.go
+++ b/backend/devices/bitbox02/keystore_simulator_test.go
@@ -335,10 +335,10 @@ func makeTx(t *testing.T, device *Device, recipient *maketx.OutputInfo) *btc.Pro
 		makeConfig(t, device, signing.ScriptTypeP2WPKH, mustKeypath("m/84'/0'/0'")),
 		makeConfig(t, device, signing.ScriptTypeP2WPKHP2SH, mustKeypath("m/49'/0'/0'")),
 	}
-	inputAddress0 := addresses.NewAccountAddress(configurations[0], signing.NewEmptyRelativeKeypath().Child(0, false).Child(0, false), network, log)
-	inputAddress1 := addresses.NewAccountAddress(configurations[1], signing.NewEmptyRelativeKeypath().Child(0, false).Child(0, false), network, log)
-	inputAddress2 := addresses.NewAccountAddress(configurations[2], signing.NewEmptyRelativeKeypath().Child(0, false).Child(0, false), network, log)
-	changeAddress := addresses.NewAccountAddress(configurations[0], signing.NewEmptyRelativeKeypath().Child(1, false).Child(0, false), network, log)
+	inputAddress0 := addresses.NewAccountAddress(configurations[0], types.Derivation{Change: false, AddressIndex: 0}, network, log)
+	inputAddress1 := addresses.NewAccountAddress(configurations[1], types.Derivation{Change: false, AddressIndex: 0}, network, log)
+	inputAddress2 := addresses.NewAccountAddress(configurations[2], types.Derivation{Change: false, AddressIndex: 0}, network, log)
+	changeAddress := addresses.NewAccountAddress(configurations[0], types.Derivation{Change: true, AddressIndex: 1}, network, log)
 
 	prevTx := &wire.MsgTx{
 		Version: 2,
@@ -449,7 +449,7 @@ func TestSimulatorSignBTCTransactionSendSelfSameAccount(t *testing.T) {
 		cfg := makeConfig(t, device, signing.ScriptTypeP2TR, mustKeypath("m/86'/0'/0'"))
 		selfAddress := addresses.NewAccountAddress(
 			cfg,
-			signing.NewEmptyRelativeKeypath().Child(0, false).Child(0, false),
+			types.Derivation{Change: false, AddressIndex: 0},
 			network,
 			log)
 		proposedTransaction := makeTx(t, device, maketx.NewOutputInfo(selfAddress.PubkeyScript()))


### PR DESCRIPTION
The relative keypath always has two elements, the first element indicating change and the second indicating the address index.

A relative keypath of arbitrary length is harder to handle. E.g. it is not compatible with output descriptors with multipath indices (`xpub/<0;1>/*`), where also two elements are required to derive an address (the multipath index selecting between `<X;Y>` and the address index).

The unit tests change because the GetAddress test function used an empty relative path instead of a chainIndex and addressIndex, which now was forced to change with the stricter types.

I considered keeping `ChainIndex uint32` instead of `Change bool`,
because in multipaths, one could have more than two,
e.g. `xpub/<X;Y;Z>/*`, but I prefer the stricter type and it's not
likely we will ever need more than two (receive & change).
