### PR TITLE
frontend: set vite/esbuild build target to chrome 122

### DIFF
--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -46,16 +46,6 @@
       "react-app/jest"
     ]
   },
-  "browserslist": {
-    "production": [
-      "chrome >= 83"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
   "scripts": {
     "dev": "npm run start",
     "start": "vite --cors --host",

--- a/frontends/web/vite.config.mjs
+++ b/frontends/web/vite.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig((env) => {
     build: {
       modulePreload: false,
       outDir: 'build',
-      target: ['chrome83'],
+      target: ['chrome122'],
     },
     plugins: [
       react(),


### PR DESCRIPTION
Qt was upgraded to 6.8.2 which includes a newer chromium version in 84a8a71ab80701f493602221e80464491f110a2d

Bumped build target in vite config, this saves a few bytes.

- https://github.com/BitBoxSwiss/bitbox-wallet-app/commit/84a8a71ab80701f493602221e80464491f110a2d
- https://wiki.qt.io/QtWebEngine/ChromiumVersions
- https://vite.dev/guide/build#browser-compatibility
- https://esbuild.github.io/api/#target

Browserlist in package.json seems to be only supported by vite plugin-legacy, see:
- https://github.com/vitejs/vite/tree/main/packages/plugin-legacy#targets

Removed Browserlist in package.json.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
