### PR TITLE
frontend: set view title to sell bitcoin/crypto for sell widget

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -815,7 +815,10 @@
     "receive": "Receive {{coinCode}}",
     "receive_bitcoin": "Receive Bitcoin",
     "receive_crypto": "Receive crypto",
-    "search": "Search…"
+    "search": "Search…",
+    "sell": "Sell {{coinCode}}",
+    "sell_bitcoin": "Sell Bitcoin",
+    "sell_crypto": "Sell crypto"
   },
   "genericError": "An error occurred. If you notice any issues, please restart the application.",
   "goal": {

--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -247,7 +247,12 @@ export const BTCDirect = ({
           <div className={style.header}>
             <Header title={
               <h2>
-                {t('generic.buy', { context: translationContext })}
+                {action === 'buy' ? (
+                  t('generic.buy', { context: translationContext })
+                ) : (
+                  t('generic.sell', { context: translationContext })
+                )}
+                {}
               </h2>
             } />
           </div>


### PR DESCRIPTION
So far only PocketBitcoin has a sell option for Bitcoin only.

Added generic.sell with new translation for BTC Direct sell widget.
