### PR TITLE
frontend: fix selecting altcoins in the btcdirect sell widget

### DIFF
--- a/frontends/web/public/btcdirect/coin-to-fiat.html
+++ b/frontends/web/public/btcdirect/coin-to-fiat.html
@@ -86,21 +86,10 @@
           theme: theme || 'light',
         });
 
-        btcdirect('set-parameters',
-          mode === 'production' ? {
-            baseCurrency: currency,
-            fixedCurrency: true,
-            quoteCurrency,
-            // paymentMethod: any of 'bancontact', 'bankTransfer', 'creditCard', 'giropay', 'iDeal', 'sofort', 'applepay'
-            // showWalletAddress: false,
-          } : {
-            baseCurrency: currency,
-            fixedCurrency: true,
-            paymentMethod: 'sofort', // sandbox currently only supports sofort payment method
-            quoteCurrency,
-            // showWalletAddress: false,
-          }
-        );
+        btcdirect('currencies', {
+          crypto: currency,
+          fiat: quoteCurrency,
+        });
 
         break;
 


### PR DESCRIPTION
Using set-parameters was the recommended way for the buy widget but does not work for the sell widget (coin-to-fiat).

https://developer.btcdirect.eu/widget/sell-order-form.html