### PR TITLE
ios: handle version with and without `v` prefix

### DIFF
--- a/frontends/ios/BitBoxApp/BitBoxApp/Bluetooth.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/Bluetooth.swift
@@ -498,7 +498,10 @@ class BluetoothDeviceInfo: NSObject, MobileserverGoDeviceInfoInterfaceProtocol {
     }
 
     func serial() -> String {
-        return "v" + productInfo.version
+        // BitBox delivers the version with the `v` prefix, and adding it manually here can be
+        // dropped at some point. Only testing firmwares before the first release did not include
+        // the prefix.
+        return productInfo.version.hasPrefix("v") ? productInfo.version : "v" + productInfo.version
     }
 
     func usagePage() -> Int {


### PR DESCRIPTION
Before https://github.com/BitBoxSwiss/bitbox02-firmware/pull/1447/, the product characteristic version string didn't include a 'v' prefix, but after it does.

The app backend requires it to parse the version.

We handle both cases for backwards compatibility.
