### PR TITLE
backend: remove error when trying to sell non-btc.

### DIFF
--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -871,15 +871,7 @@ func (handlers *Handlers) getHasPaymentRequest(r *http.Request) (interface{}, er
 		ErrorCode    string `json:"errorCode,omitempty"`
 	}
 
-	account, ok := handlers.account.(*btc.Account)
-	if !ok {
-		return response{
-			Success:      false,
-			ErrorMessage: "An account must be BTC based to support payment requests.",
-		}, nil
-	}
-
-	keystore, err := account.Config().ConnectKeystore()
+	keystore, err := handlers.account.Config().ConnectKeystore()
 	if err != nil {
 		return response{Success: false, ErrorMessage: err.Error()}, nil
 	}


### PR DESCRIPTION
We now have BTC Direct which supports selling coins other than BTC.

I also think we should rename this function as it might be non entirely correct now (and it is imho not super clear what its purpose is) but I am open to suggestions

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
