### PR TITLE
frontend: move firmware required logic into pocket view

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -759,8 +759,7 @@
   "exchange": {
     "buySell": {
       "coinNotSupported": "No options available for this coin type.",
-      "regionNotSupported": "No options available for this region.",
-      "updateNow": "Update now"
+      "regionNotSupported": "No options available for this region."
     },
     "pocket": {
       "terms": {

--- a/frontends/web/src/routes/exchange/exchange.module.css
+++ b/frontends/web/src/routes/exchange/exchange.module.css
@@ -86,10 +86,6 @@
     text-align: center;
 }
 
-.updateButton {
-    height: var(--item-height-small);
-}
-
 .infoContainer {
     margin-top: var(--space-default);
     position: relative;

--- a/frontends/web/src/routes/exchange/exchange.tsx
+++ b/frontends/web/src/routes/exchange/exchange.tsx
@@ -42,10 +42,12 @@ import style from './exchange.module.css';
 type TProps = {
     accounts: IAccount[];
     code: AccountCode;
-    deviceIDs: string[];
 }
 
-export const Exchange = ({ code, accounts, deviceIDs }: TProps) => {
+export const Exchange = ({
+  accounts,
+  code,
+}: TProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [selectedRegion, setSelectedRegion] = useState('');
@@ -157,7 +159,6 @@ export const Exchange = ({ code, accounts, deviceIDs }: TProps) => {
                   <BuySell
                     accountCode={code}
                     selectedRegion={selectedRegion}
-                    deviceIDs={deviceIDs}
                     goToExchange={goToExchange}
                     showBackButton={supportedAccounts.length > 1}
                     action={activeTab}

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -180,23 +180,24 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
 
   const ExchangeEl = (<InjectParams>
     <Exchange
-      code={''}
       accounts={activeAccounts}
-      deviceIDs={deviceIDs}
+      code={''}
     />
   </InjectParams>);
 
   const PocketBuyEl = (<InjectParams>
     <Pocket
-      code={''}
       action="buy"
+      code={''}
+      deviceIDs={deviceIDs}
     />
   </InjectParams>);
 
   const PocketSellEl = (<InjectParams>
     <Pocket
-      code={''}
       action="sell"
+      code={''}
+      deviceIDs={deviceIDs}
     />
   </InjectParams>);
 


### PR DESCRIPTION
Pocket Bitcoin was the only sell option before and requires a newer firmware. The sell tab in buy/sell just displayed a require-fw-update message instead of showing the sell option (Pocket).

Moved the required-firmware-update into pocket component so the app can shows all options.
