### PR TITLE
frontend: include order-id in transaction note when selling

### DIFF
--- a/frontends/web/public/btcdirect/coin-to-fiat.html
+++ b/frontends/web/public/btcdirect/coin-to-fiat.html
@@ -123,7 +123,7 @@
         action: 'request-payment',
         amount: String(e.detail?.amount),
         currency: e.detail?.currency,
-        // orderId: e.detail?.orderId,
+        orderId: e.detail?.orderId,
       }, '*');
 
     });

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -814,6 +814,7 @@
     "enabled_false": "Disabled",
     "enabled_true": "Enabled",
     "noOptions": "No options found",
+    "paymentRequestNote": "{{name}} payment {{orderId}}",
     "receive": "Receive {{coinCode}}",
     "receive_bitcoin": "Receive Bitcoin",
     "receive_crypto": "Receive crypto",

--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -105,7 +105,7 @@ export const BTCDirect = ({
   };
 
   const handlePaymentRequest = useCallback(async (event: MessageEvent) => {
-    const { amount, currency } = event.data;
+    const { amount, currency, orderId } = event.data;
 
     if (
       typeof currency !== 'string'
@@ -148,7 +148,10 @@ export const BTCDirect = ({
 
     const txProposal = await proposeTx(code, txInput);
     if (txProposal.success) {
-      const txNote = t('buy.pocket.paymentRequestNote') + ' BTC Direct'; // TODO: change to generic sell message with name placeholder 'Payment request from {name}'
+      const txNote = t('generic.paymentRequestNote', {
+        name: 'BTC Direct',
+        orderId,
+      });
       const sendResult = await sendTx(code, txNote);
       if (sendResult.success) {
         const { txId } = sendResult;


### PR DESCRIPTION
Showing the order-id in the transaction note when selling to BTC Direct could help if there was an issue.
