### PR TITLE
frontend: add missing return url

### DIFF
--- a/frontends/web/public/btcdirect/coin-to-fiat.html
+++ b/frontends/web/public/btcdirect/coin-to-fiat.html
@@ -8,6 +8,7 @@
 <div class="btcdirect-widget"></div>
 
 <script lang="js">
+  // NOTE: please note this static page is for development purposes only and may not be in sync with the actual version
   ;(() => {
 
     if (window.top === window) {

--- a/frontends/web/public/btcdirect/fiat-to-coin.html
+++ b/frontends/web/public/btcdirect/fiat-to-coin.html
@@ -84,6 +84,7 @@
           token: apiKey,
           debug: mode === 'debug',
           locale: locale || 'en-GB',
+          returnUrl: 'https://bitboxapp.shiftcrypto.io/widgets/btcdirect/v1/back-to-app.html',
           theme: theme || 'light',
         });
 


### PR DESCRIPTION
This adds the missing return url to go back to the app, not this
was already on our subdomain on shiftcrypto.io but just missing
in the static file that is used for local testing.