### PR TITLE
android: make cmake version a minimum

### DIFF
--- a/frontends/android/BitBoxApp/app/build.gradle
+++ b/frontends/android/BitBoxApp/app/build.gradle
@@ -31,7 +31,7 @@ android {
     externalNativeBuild {
         cmake {
             path file('src/main/cpp/CMakeLists.txt')
-            version '3.31.6'
+            version '3.31.6+'
         }
     }
 }


### PR DESCRIPTION
I could not figure out how to install 3.31.6 in my Android Studio, but later versions also work fine.

