### PR TITLE
frontend: block ui in case of sign request

### DIFF
--- a/frontends/web/src/routes/exchange/iframe.module.css
+++ b/frontends/web/src/routes/exchange/iframe.module.css
@@ -23,3 +23,18 @@
     position: relative;
     z-index: 2200;
 }
+
+.blocking {
+    background-color: var(--bg-transparent-dark);
+    bottom: 0;
+    left: 0;
+    position: fixed;
+    right: 0;
+    top: calc(-1 * var(--header-height));
+    /* z-index: 1; would be enough to cover the bottom-menu on mobile */
+    z-index: 4003; /* header has z-index: 2200; and sidebar z-index: 4002; */
+}
+
+.blocking + .iframe {
+    z-index: 4004;
+}

--- a/frontends/web/src/routes/exchange/pocket.tsx
+++ b/frontends/web/src/routes/exchange/pocket.tsx
@@ -45,6 +45,7 @@ export const Pocket = ({ code, action }: TProps) => {
 
   const [height, setHeight] = useState(0);
   const [iframeLoaded, setIframeLoaded] = useState(false);
+  const [blocking, setBlocking] = useState(false);
   const [agreedTerms, setAgreedTerms] = useState(false);
   const [verifying, setVerifying] = useState(false);
 
@@ -216,7 +217,9 @@ export const Pocket = ({ code, action }: TProps) => {
     let result = await proposeTx(code, txInput);
     if (result.success) {
       let txNote = t('buy.pocket.paymentRequestNote') + ' ' + message.slip24.recipientName;
+      setBlocking(true);
       const sendResult = await sendTx(code, txNote);
+      setBlocking(false);
       if (!sendResult.success && !('aborted' in sendResult)) {
         alertUser(t('unknownError', { errorMessage: sendResult.errorMessage }));
       }
@@ -290,6 +293,9 @@ export const Pocket = ({ code, action }: TProps) => {
             <div style={{ height }}>
               <UseDisableBackButton />
               {!iframeLoaded && <Spinner text={t('loading')} /> }
+              {blocking && (
+                <div className={style.blocking}></div>
+              )}
               <iframe
                 onLoad={() => {
                   setIframeLoaded(true);


### PR DESCRIPTION
The bitbox02 only can handle one request at a time, this means that an ongoing message signing request blocks the device until it is finished.

Currently, it is possible to request a message signing inside the pocket workflow and leave the workflow while the signing request is ongoing. If the user tried to make other operations, e.g. verifying an address or opening the manage device screen, each bb02 request remains pending.

By blocking everything but the iframe the user is forced to stay in the workflow and has to either complete or abort the signing.

When blocking the view should always surpress native back, by using

    <UseDisableBackButton />
