### PR TITLE
frontend: close sidebar on mobile when rotating to portrait

### DIFF
--- a/frontends/web/src/contexts/AppProvider.tsx
+++ b/frontends/web/src/contexts/AppProvider.tsx
@@ -23,6 +23,8 @@ import { getNativeLocale } from '@/api/nativelocale';
 import { getDevServers, getTesting } from '@/api/backend';
 import { i18nextFormat } from '@/i18n/utils';
 import type { TChartDisplay } from './AppContext';
+import { useOrientation } from '@/hooks/orientation';
+import { useMediaQuery } from '@/hooks/mediaquery';
 
 type TProps = {
     children: ReactNode;
@@ -39,6 +41,9 @@ export const AppProvider = ({ children }: TProps) => {
   const [chartDisplay, setChartDisplay] = useState<TChartDisplay>('all');
   const [firmwareUpdateDialogOpen, setFirmwareUpdateDialogOpen] = useState(false);
 
+  const orientation = useOrientation();
+  const isMobile = useMediaQuery('(max-width: 768px)');
+
   const toggleGuide = () => {
     setConfig({ frontend: { guideShown: !guideShown } });
     setGuideShown(prev => !prev);
@@ -52,6 +57,12 @@ export const AppProvider = ({ children }: TProps) => {
   const toggleSidebar = () => {
     setActiveSidebar(prev => !prev);
   };
+
+  useEffect(() => {
+    if (activeSidebar && isMobile && orientation === 'portrait') {
+      setActiveSidebar(false);
+    }
+  }, [activeSidebar, isMobile, orientation]);
 
   useEffect(() => {
     getConfig().then(({ frontend }) => {

--- a/frontends/web/src/hooks/mediaquery.ts
+++ b/frontends/web/src/hooks/mediaquery.ts
@@ -32,7 +32,6 @@ export const useMediaQuery = (query: string) => {
     return () => {
       matchMedia.removeEventListener('change', handleChange);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
   return matches;

--- a/frontends/web/src/hooks/orientation.ts
+++ b/frontends/web/src/hooks/orientation.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2025 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect } from 'react';
+
+type TOrientation = 'landscape' | 'portrait';
+
+const getLegacyOrientation = (): TOrientation => {
+  return window.innerHeight > window.innerWidth ? 'portrait' : 'landscape';
+};
+
+export const useOrientation = (): TOrientation => {
+  const [orientation, setOrientation] = useState(getLegacyOrientation());
+
+  useEffect(() => {
+    const handleOrientation = () => setOrientation(getLegacyOrientation());
+    window.addEventListener('resize', handleOrientation);
+    return () => window.removeEventListener('resize', handleOrientation);
+  }, []);
+
+  return orientation;
+};
+
+// Modern version but may not be fully supported on iOS / Android
+// see https://caniuse.com/screen-orientation
+//
+// const isLandscape = () => screen.orientation.type.startsWith('landscape');
+// const getOrientation = (): TOrientation => isLandscape() ? 'landscape' : 'portrait';
+
+// export const useOrientation = (): TOrientation => {
+//   const [orientation, setOrientation] = useState(getOrientation());
+//   const handleOrientation = () => setOrientation(getOrientation());
+
+//   useEffect(() => {
+//     screen.orientation.addEventListener('change', handleOrientation, true);
+//     return () => {
+//       screen.orientation.removeEventListener('change', handleOrientation);
+//     };
+//   }, []);
+
+//   return orientation;
+// };


### PR DESCRIPTION
Fixed an issue where the sidebar remains open after toggling via
the hamburger menu and rotating the screen.

Now, the sidebar is always closed on mobile devices when switching
to portrait orientation.