### PR TITLE
frontend: hide media controls on password entry video

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/components/password-entry/password-entry.tsx
+++ b/frontends/web/src/routes/device/bitbox02/components/password-entry/password-entry.tsx
@@ -42,6 +42,7 @@ export const PasswordEntry = () => {
     <div className={styles.passwordGesturesWrapper}>
       <video
         autoPlay
+        playsInline
         ref={ref}
         className={styles.passwordGestures}
         loop


### PR DESCRIPTION
On iOS, the password entry video previously showed system media controls, and you were able to open it in fullscreen. Adding "playsInline" removes the option to interact with the video and hides these controls.

Tested on iOS and macOS.