### PR TITLE
backend: don't require pairing code over BLE

### DIFF
--- a/backend/devices/bitbox02/device.go
+++ b/backend/devices/bitbox02/device.go
@@ -51,6 +51,7 @@ func NewDevice(
 	product bitbox02common.Product,
 	config firmware.ConfigInterface,
 	communication firmware.Communication,
+	opts ...firmware.DeviceOption,
 ) *Device {
 	log := logging.Get().
 		WithGroup("device").
@@ -64,7 +65,9 @@ func NewDevice(
 			version,
 			&product,
 			config,
-			communication, logger{log},
+			communication,
+			logger{log},
+			opts...,
 		),
 		deviceID: deviceID,
 		log:      log,

--- a/backend/devices/usb/hid.go
+++ b/backend/devices/usb/hid.go
@@ -53,6 +53,11 @@ type hidDeviceInfo struct {
 	hid.DeviceInfo
 }
 
+// IsBluetooth implements DeviceInfo.
+func (info hidDeviceInfo) IsBluetooth() bool {
+	return false
+}
+
 // VendorID implements DeviceInfo.
 func (info hidDeviceInfo) VendorID() int {
 	return int(info.DeviceInfo.VendorID)

--- a/backend/devices/usb/manager.go
+++ b/backend/devices/usb/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/logging"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/socksproxy"
 	bitbox02common "github.com/BitBoxSwiss/bitbox02-api-go/api/common"
+	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware"
 	"github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid"
 	"github.com/BitBoxSwiss/bitbox02-api-go/util/semver"
 	"github.com/sirupsen/logrus"
@@ -46,6 +47,8 @@ const (
 
 // DeviceInfo contains the usb descriptor info and a way to open the device for reading and writing.
 type DeviceInfo interface {
+	// IsBluetooth means the communication layer is Bluetooth, otherwise USB.
+	IsBluetooth() bool
 	VendorID() int
 	ProductID() int
 	UsagePage() int
@@ -218,6 +221,7 @@ func (manager *Manager) makeBitBox02(deviceInfo DeviceInfo) (*bitbox02.Device, e
 		product,
 		bitbox02.NewConfig(manager.bitbox02ConfigDir),
 		u2fhid.NewCommunication(hidDevice, bitboxCMD),
+		firmware.WithOptionalNoisePairingConfirmation(deviceInfo.IsBluetooth()),
 	), nil
 }
 

--- a/backend/mobileserver/mobileserver.go
+++ b/backend/mobileserver/mobileserver.go
@@ -77,6 +77,7 @@ type GoReadWriteCloserInterface interface {
 
 // GoDeviceInfoInterface adapts usb.DeviceInfo's Open method to return the adapted ReadWriteCloser.
 type GoDeviceInfoInterface interface {
+	IsBluetooth() bool
 	VendorID() int
 	ProductID() int
 	UsagePage() int

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
@@ -80,6 +80,9 @@ public class GoViewModel extends AndroidViewModel {
 
 
         }
+        public boolean isBluetooth() {
+            return false;
+        }
         public String product() {
             return device.getProductName();
         }

--- a/frontends/ios/BitBoxApp/BitBoxApp/Bluetooth.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/Bluetooth.swift
@@ -484,6 +484,10 @@ class BluetoothDeviceInfo: NSObject, MobileserverGoDeviceInfoInterfaceProtocol {
         return BluetoothReadWriteCloser(bluetoothManager: bluetoothManager)
     }
 
+    func isBluetooth() -> Bool {
+        return true
+    }
+
     func product() -> String {
         // TODO: return bluetoothManager.productStr() and have the backend identify and handle it
         return productInfo.product

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/BitBoxSwiss/bitbox-wallet-app
 go 1.23
 
 require (
-	github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20250508091842-e5b786c4a88d
+	github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20250526110026-4c21ece5b081
 	github.com/BitBoxSwiss/block-client-go v0.0.0-20241009081439-924dde98b9c1
 	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20250508091842-e5b786c4a88d h1:Zd6ISD5tzAFEsy+Td0XwmENqssuL+9aKHHBFyMpPUCg=
-github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20250508091842-e5b786c4a88d/go.mod h1:lyYwD22hA6TQ8XNXx37VE75Exp6qYdgZgUAO4+lyhSU=
+github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20250526110026-4c21ece5b081 h1:57aszTkvQz1aQcL9pbNUpyVepFuRlrBaoNyKV0rMdIM=
+github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20250526110026-4c21ece5b081/go.mod h1:lyYwD22hA6TQ8XNXx37VE75Exp6qYdgZgUAO4+lyhSU=
 github.com/BitBoxSwiss/block-client-go v0.0.0-20241009081439-924dde98b9c1 h1:5hjP8mYSVKFibesrz8L6U0Vp5zSJt0LwXB3DSZGhnSo=
 github.com/BitBoxSwiss/block-client-go v0.0.0-20241009081439-924dde98b9c1/go.mod h1:SJTiQZU9ggBzVKMni97rpNS9GddPKErndFXNSDrfEGc=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/btc.go
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/btc.go
@@ -121,6 +121,18 @@ func NewBTCScriptConfigMultisig(
 	return scriptConfig, nil
 }
 
+// NewBTCScriptConfigPolicy is a helper to construct the a BIP-388 wallet policy script config.
+func NewBTCScriptConfigPolicy(policy string, keys []*messages.KeyOriginInfo) *messages.BTCScriptConfig {
+	return &messages.BTCScriptConfig{
+		Config: &messages.BTCScriptConfig_Policy_{
+			Policy: &messages.BTCScriptConfig_Policy{
+				Policy: policy,
+				Keys:   keys,
+			},
+		},
+	}
+}
+
 // BTCXPub queries the device for a btc, ltc, tbtc, tltc xpubs.
 func (device *Device) BTCXPub(
 	coin messages.BTCCoin,

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/device.go
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/device.go
@@ -108,6 +108,8 @@ type Device struct {
 	mu      sync.RWMutex
 	onEvent func(Event, interface{})
 	log     Logger
+
+	options *deviceOptions
 }
 
 // BluetoothInfo contains Bluetooth-related info.
@@ -144,9 +146,14 @@ func NewDevice(
 	config ConfigInterface,
 	communication Communication,
 	log Logger,
+	opts ...DeviceOption,
 ) *Device {
 	if (version == nil) != (product == nil) {
 		panic("both version and product have to be specified, or none")
+	}
+	options := &deviceOptions{}
+	for _, opt := range opts {
+		opt(options)
 	}
 	return &Device{
 		communication: communication,
@@ -155,6 +162,7 @@ func NewDevice(
 		config:        config,
 		status:        StatusConnected,
 		log:           log,
+		options:       options,
 	}
 }
 

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/options.go
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/options.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firmware
+
+type deviceOptions struct {
+	// If true, the host does not require noise pairing confirmation before communicating over the
+	// encrypted noise channel.
+	optionalNoisePairingConfirmation bool
+}
+
+// DeviceOption provides functional options.
+type DeviceOption func(*deviceOptions)
+
+// WithOptionalNoisePairingConfirmation allows the host to communicate over the encrypted noise
+// channel without requiring a pairing confirmation on the BitBox.
+//
+// SECURITY NOTE: this enables a MITM in the noise channel to go undetected. Use only if the noise
+// channel is wrapped in another secure transport layer, e.g. a paired Bluetooth connection.
+func WithOptionalNoisePairingConfirmation(optional bool) DeviceOption {
+	return func(o *deviceOptions) {
+		o.optionalNoisePairingConfirmation = optional
+	}
+}

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/pairing.go
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/pairing.go
@@ -101,8 +101,7 @@ func (device *Device) pair() error {
 		panic(errp.New("expected 32 byte remote static pubkey"))
 	}
 
-	pairingVerificationRequiredByApp := !device.config.ContainsDeviceStaticPubkey(
-		device.deviceNoiseStaticPubkey)
+	pairingVerificationRequiredByApp := !device.options.optionalNoisePairingConfirmation && !device.config.ContainsDeviceStaticPubkey(device.deviceNoiseStaticPubkey)
 	pairingVerificationRequiredByDevice := string(responseBytes) == "\x01"
 
 	if pairingVerificationRequiredByDevice || pairingVerificationRequiredByApp {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20250508091842-e5b786c4a88d
+# github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20250526110026-4c21ece5b081
 ## explicit; go 1.22
 github.com/BitBoxSwiss/bitbox02-api-go/api/bootloader
 github.com/BitBoxSwiss/bitbox02-api-go/api/common


### PR DESCRIPTION
Connecting to a BitBox02 over BLE already requires pairing, so the noise pairing is redundant. This does not prevent confirming the pairing code at any time after, it just means the confirmation is optional.

```
go get github.com/BitBoxSwiss/bitbox02-api-go@4c21ece5b08182e2946362303347bc4b50906e46
go mod tidy
go mod vendor
```
