### PR TITLE
iPadOS: fix crash when clicking "export logs"

### DIFF
--- a/frontends/ios/BitBoxApp/BitBoxApp/BitBoxAppApp.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/BitBoxAppApp.swift
@@ -134,6 +134,11 @@ class GoEnvironment: NSObject, MobileserverGoEnvironmentInterfaceProtocol, UIDoc
                 // Local file path, use UIDocumentInteractionController
                 if let rootViewController = self.getRootViewController() {
                     let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+                    if let popover = activityViewController.popoverPresentationController {
+                        popover.sourceView = rootViewController.view
+                        popover.sourceRect = CGRect(x: rootViewController.view.bounds.midX, y: rootViewController.view.bounds.midY, width: 0, height: 0)
+                        popover.permittedArrowDirections = []
+                    }
                     rootViewController.present(activityViewController, animated: true, completion: nil)
                 }
             } else {


### PR DESCRIPTION
On iPad, popovers require a non-nil `sourceView` and `sourceRect`. This change configures `popoverPresentationController` to anchor to the `rootViewController`'s view, resolving the runtime exception.

Tested on XCode simulator, I'm not sure who owns an iPad but testing on a real device would be much appreciated :D

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
