### PR TITLE
android: react to change in network capabilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Format BTC/sat spaces consitently in account summary and total balance
+- Improved offline UX: added detection to show an offline warning banner and auto-reconnect when back online
 
 ## v4.48.0
 - Removed the BTC/sat switch from the general settings in favor of a rotating unit in the account balance.

--- a/backend/mobileserver/mobileserver.go
+++ b/backend/mobileserver/mobileserver.go
@@ -157,6 +157,11 @@ func UsingMobileDataChanged() {
 	bridgecommon.UsingMobileDataChanged()
 }
 
+// SetOnline exposes `bridgecommon.SetOnline` to Java/Kotlin.
+func SetOnline(online bool) {
+	bridgecommon.SetOnline(online)
+}
+
 // UsbUpdate exposes `bridgecommon.UsbUpdate` to Java/Kotlin.
 func UsbUpdate() {
 	bridgecommon.UsbUpdate()

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1896,7 +1896,7 @@
   },
   "warning": {
     "coincontrol": "One or more UTXOs have a reused address. Be aware the receiver will see all UTXOs associated with those addresses.",
-    "offline": "You are currently offline. You can still view your accounts, but you will not be able to send transactions or see the latest exchange rates.",
+    "offline": "You are currently offline. You will not be able to send transactions or see the latest exchange rates.",
     "sdcard": "Keep the microSD card stored separate from the BitBox, unless you want to manage backups.",
     "testnet": "You are using Testnet mode. Transactions and coins here are not real and have no value. Only use for testing purposes."
   },


### PR DESCRIPTION
NOTE: this is based on https://github.com/BitBoxSwiss/bitbox-wallet-app/pull/3421 so that one needs to be reviewed before this one. 


Use ConnectivityManager to react to onLost (connection entirely lost, e.g. going into airplane mode), onAvailable (the opposite), and onCapabilitiesChanged (other scenarios, for example the network loses access to the internet, but it still works locally)

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
