### PR TITLE
fronted/qt: fix web engine profile for external links

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -353,8 +353,8 @@ int main(int argc, char *argv[])
         view->adjustSize();
     }
 
-    externalPage = new QWebEnginePage(view);
     profile = new QWebEngineProfile("BitBoxApp");
+    externalPage = new QWebEnginePage(profile, view);
     mainPage = new WebEnginePage(profile);
     view->setPage(mainPage);
 


### PR DESCRIPTION
In 00d7607 we switched from the default profile to a dedicated one, to store profile data on disk. This change didn't involve the WebEnginePage used to display external resources (e.g. links in 3rd party widgets) and caused external links not to be displayed because of incompatible profiles.

This fixes the issue sharing the same profile also for external pages.