### PR TITLE
backend/accounts: skip unsupported coins when adding hidden accounts

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -1496,6 +1496,14 @@ func (backend *Backend) maybeAddHiddenUnusedAccounts() {
 		coinCodes = []coinpkg.Code{coinpkg.CodeBTC, coinpkg.CodeLTC}
 	}
 	for _, coinCode := range coinCodes {
+		coin, err := backend.Coin(coinCode)
+		if err != nil {
+			backend.log.Errorf("could not find coin %s", coinCode)
+			continue
+		}
+		if !backend.keystore.SupportsCoin(coin) {
+			continue
+		}
 		var newAccountCode *accountsTypes.Code
 		err = backend.config.ModifyAccountsConfig(func(cfg *config.AccountsConfig) error {
 			newAccountCode = do(cfg, coinCode)
@@ -1509,11 +1517,6 @@ func (backend *Backend) maybeAddHiddenUnusedAccounts() {
 			continue
 		}
 		if newAccountCode != nil {
-			coin, err := backend.Coin(coinCode)
-			if err != nil {
-				backend.log.Errorf("could not find coin %s", coinCode)
-				continue
-			}
 			accountConfig := backend.config.AccountsConfig().Lookup(*newAccountCode)
 			if accountConfig == nil {
 				backend.log.Errorf("could not find newly persisted account %s", *newAccountCode)

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -208,6 +208,9 @@ func TestNextAccountNumber(t *testing.T) {
 	fingerprintEmpty := []byte{0x77, 0x77, 0x77, 0x77}
 	ks := func(fingerprint []byte, supportsMultipleAccounts bool) *keystoremock.KeystoreMock {
 		return &keystoremock.KeystoreMock{
+			SupportsCoinFunc: func(coin coinpkg.Coin) bool {
+				return true
+			},
 			RootFingerprintFunc: func() ([]byte, error) {
 				return fingerprint, nil
 			},
@@ -372,6 +375,9 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 	bitbox01LikeKeystore := &keystoremock.KeystoreMock{
 		RootFingerprintFunc: func() ([]byte, error) {
 			return rootFingerprint1, nil
+		},
+		SupportsCoinFunc: func(coin coinpkg.Coin) bool {
+			return true
 		},
 		SupportsAccountFunc: func(coin coinpkg.Coin, meta interface{}) bool {
 			switch coin.(type) {
@@ -704,6 +710,9 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 			RootFingerprintFunc: func() ([]byte, error) {
 				return rootFingerprint1, nil
 			},
+			SupportsCoinFunc: func(coin coinpkg.Coin) bool {
+				return true
+			},
 			SupportsAccountFunc: func(coin coinpkg.Coin, meta interface{}) bool {
 				return true
 			},
@@ -950,6 +959,9 @@ func TestTaprootUpgrade(t *testing.T) {
 		RootFingerprintFunc: func() ([]byte, error) {
 			return fingerprint, nil
 		},
+		SupportsCoinFunc: func(coin coinpkg.Coin) bool {
+			return true
+		},
 		SupportsAccountFunc: func(coin coinpkg.Coin, meta interface{}) bool {
 			switch coin.(type) {
 			case *btc.Coin:
@@ -974,6 +986,9 @@ func TestTaprootUpgrade(t *testing.T) {
 		},
 		RootFingerprintFunc: func() ([]byte, error) {
 			return fingerprint, nil
+		},
+		SupportsCoinFunc: func(coin coinpkg.Coin) bool {
+			return true
 		},
 		SupportsAccountFunc: func(coin coinpkg.Coin, meta interface{}) bool {
 			switch coin.(type) {
@@ -1283,6 +1298,9 @@ func TestWatchonly(t *testing.T) {
 			RootFingerprintFunc: func() ([]byte, error) {
 				return rootFingerprint1, nil
 			},
+			SupportsCoinFunc: func(coin coinpkg.Coin) bool {
+				return true
+			},
 			SupportsAccountFunc: func(coin coinpkg.Coin, meta interface{}) bool {
 				switch coin.(type) {
 				case *btc.Coin:
@@ -1303,6 +1321,9 @@ func TestWatchonly(t *testing.T) {
 			},
 			RootFingerprintFunc: func() ([]byte, error) {
 				return rootFingerprint2, nil
+			},
+			SupportsCoinFunc: func(coin coinpkg.Coin) bool {
+				return true
 			},
 			SupportsAccountFunc: func(coin coinpkg.Coin, meta interface{}) bool {
 				switch coin.(type) {

--- a/backend/aopp_test.go
+++ b/backend/aopp_test.go
@@ -63,6 +63,9 @@ func makeKeystore(
 		RootFingerprintFunc: func() ([]byte, error) {
 			return rootFingerprint1, nil
 		},
+		SupportsCoinFunc: func(coin coinpkg.Coin) bool {
+			return true
+		},
 		SupportsAccountFunc: func(coin coinpkg.Coin, meta interface{}) bool {
 			switch coin.(type) {
 			case *btc.Coin:

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -87,6 +87,9 @@ func makeBitBox02Multi() *keystoremock.KeystoreMock {
 		RootFingerprintFunc: func() ([]byte, error) {
 			return rootFingerprint1, nil
 		},
+		SupportsCoinFunc: func(coin coinpkg.Coin) bool {
+			return true
+		},
 		SupportsAccountFunc: func(coin coinpkg.Coin, meta interface{}) bool {
 			switch coin.(type) {
 			case *btc.Coin:
@@ -110,6 +113,9 @@ func makeBitBox02Multi() *keystoremock.KeystoreMock {
 // accounts, no legacy P2PKH.
 func makeBitBox02BTCOnly() *keystoremock.KeystoreMock {
 	ks := makeBitBox02Multi()
+	ks.SupportsCoinFunc = func(coin coinpkg.Coin) bool {
+		return coin.Code() == coinpkg.CodeBTC || coin.Code() == coinpkg.CodeTBTC || coin.Code() == coinpkg.CodeRBTC
+	}
 	ks.SupportsAccountFunc = func(coin coinpkg.Coin, meta interface{}) bool {
 		switch coin.(type) {
 		case *btc.Coin:
@@ -340,6 +346,9 @@ func TestRegisterKeystore(t *testing.T) {
 		RootFingerprintFunc: func() ([]byte, error) {
 			return rootFingerprint1, nil
 		},
+		SupportsCoinFunc: func(coin coinpkg.Coin) bool {
+			return true
+		},
 		SupportsAccountFunc: func(coin coinpkg.Coin, meta interface{}) bool {
 			switch coin.(type) {
 			case *btc.Coin:
@@ -360,6 +369,9 @@ func TestRegisterKeystore(t *testing.T) {
 		},
 		RootFingerprintFunc: func() ([]byte, error) {
 			return rootFingerprint2, nil
+		},
+		SupportsCoinFunc: func(coin coinpkg.Coin) bool {
+			return true
 		},
 		SupportsAccountFunc: func(coin coinpkg.Coin, meta interface{}) bool {
 			switch coin.(type) {


### PR DESCRIPTION
With a BB02 BTC-only version, the log showed attempts to add LTC accounts, which were then skipped as unsupported. We can abort earlier in this case, which prevents the log from showing 'automatically created hidden account' for LTC accounts when LTC is not supported.

