### PR TITLE
backend/devices: split bb02 and nova product names

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -792,7 +792,7 @@ func (backend *Backend) Register(theDevice device.Interface) error {
 		backend.Notify(observable.Event{
 			Subject: fmt.Sprintf(
 				"devices/%s/%s/%s",
-				theDevice.ProductName(),
+				theDevice.PlatformName(),
 				theDevice.Identifier(),
 				event.Subject),
 			Action: event.Action,
@@ -814,8 +814,10 @@ func (backend *Backend) Register(theDevice device.Interface) error {
 	switch theDevice.ProductName() {
 	case bitbox.ProductName:
 		backend.banners.Activate(banners.KeyBitBox01)
-	case bitbox02.ProductName:
+	case bitbox02.BitBox02ProductName:
 		backend.banners.Activate(banners.KeyBitBox02)
+	case bitbox02.BitBox02NovaProductName:
+		backend.banners.Activate(banners.KeyBitBox02Nova)
 	}
 	return nil
 }
@@ -834,8 +836,10 @@ func (backend *Backend) Deregister(deviceID string) {
 		switch device.ProductName() {
 		case bitbox.ProductName:
 			backend.banners.Deactivate(banners.KeyBitBox01)
-		case bitbox02.ProductName:
+		case bitbox02.BitBox02ProductName:
 			backend.banners.Deactivate(banners.KeyBitBox02)
+		case bitbox02.BitBox02NovaProductName:
+			backend.banners.Deactivate(banners.KeyBitBox02Nova)
 		}
 
 	}

--- a/backend/banners/banners.go
+++ b/backend/banners/banners.go
@@ -52,6 +52,8 @@ const (
 	KeyBitBox01 MessageKey = "bitbox01"
 	// KeyBitBox02 is the message key for the event when a BitBox02 gets connected.
 	KeyBitBox02 MessageKey = "bitbox02"
+	// KeyBitBox02Nova is the message key for the event when a BitBox02 Nova gets connected.
+	KeyBitBox02Nova MessageKey = "bitbox02nova"
 )
 
 // Message is one entry in the banners json.
@@ -77,8 +79,9 @@ type Banners struct {
 
 	url     string
 	banners struct {
-		BitBox01 *Message `json:"bitbox01"`
-		BitBox02 *Message `json:"bitbox02"`
+		BitBox01     *Message `json:"bitbox01"`
+		BitBox02     *Message `json:"bitbox02"`
+		BitBox02nova *Message `json:"bitbox02nova"`
 	}
 
 	active     map[MessageKey]struct{}
@@ -162,6 +165,8 @@ func (banners *Banners) GetMessage(key MessageKey) *Message {
 		return banners.banners.BitBox01
 	case KeyBitBox02:
 		return banners.banners.BitBox02
+	case KeyBitBox02Nova:
+		return banners.banners.BitBox02nova
 	default:
 		banners.log.Errorf("unrecognized key: %s", key)
 		return nil

--- a/backend/devices/bitbox/device.go
+++ b/backend/devices/bitbox/device.go
@@ -1074,6 +1074,11 @@ func (dbb *Device) ProductName() string {
 	return ProductName
 }
 
+// PlatformName implements device.Interface.
+func (dbb *Device) PlatformName() string {
+	return ProductName
+}
+
 // Identifier implements device.Interface.
 func (dbb *Device) Identifier() string {
 	return dbb.deviceID

--- a/backend/devices/bitbox02bootloader/device.go
+++ b/backend/devices/bitbox02bootloader/device.go
@@ -119,6 +119,11 @@ func (device *Device) ProductName() string {
 	return ProductName
 }
 
+// PlatformName implements device.Device.
+func (device *Device) PlatformName() string {
+	return ProductName
+}
+
 // Identifier implements device.Device.
 func (device *Device) Identifier() string {
 	return device.deviceID

--- a/backend/devices/device/device.go
+++ b/backend/devices/device/device.go
@@ -25,10 +25,15 @@ type Interface interface {
 	observable.Interface
 
 	Init(testing bool) error
-	// ProductName returns the product name of the device in lowercase/no spaces.
-	// It acts as an identifier for the device type, not for display.
-	// If you change a device's product name, be sure to check the frontend and other places which
+	// PlatformName returns the Platform name of the device in lowercase/no spaces.
+	// It acts as an identifier for the device type, not for the specific model (e.g.
+	// it return bitbox02 for both the bitbox02 and the bitbox02 nova).
+	// If you change a device's platform name, be sure to check the frontend and other places which
 	// assume this is a constant.
+	PlatformName() string
+
+	// ProductName is the actual model of the product in lowercase/no spaces
+	// (e.g. bitbox, bitbox02, bitbox02nova).
 	ProductName() string
 
 	// Identifier returns the hash of the type and the serial number.

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -913,7 +913,7 @@ func (handlers *Handlers) postAccountsReinitialize(*http.Request) interface{} {
 func (handlers *Handlers) getDevicesRegistered(*http.Request) interface{} {
 	jsonDevices := map[string]string{}
 	for deviceID, device := range handlers.backend.DevicesRegistered() {
-		jsonDevices[deviceID] = device.ProductName()
+		jsonDevices[deviceID] = device.PlatformName()
 	}
 	return jsonDevices
 }

--- a/frontends/web/src/api/devices.ts
+++ b/frontends/web/src/api/devices.ts
@@ -16,10 +16,10 @@
 
 import { apiGet } from '@/utils/request';
 
-export type TProductName = 'bitbox' | 'bitbox02' | 'bitbox02-bootloader';
+export type TPlatformName = 'bitbox' | 'bitbox02' | 'bitbox02-bootloader';
 
 export type TDevices = {
-    readonly [key in string]: TProductName;
+    readonly [key in string]: TPlatformName;
 };
 
 export const getDeviceList = (): Promise<TDevices> => {

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -188,8 +188,8 @@ export const App = () => {
             <Aopp />
             <KeystoreConnectPrompt />
             {
-              Object.entries(devices).map(([deviceID, productName]) => {
-                if (productName === 'bitbox02') {
+              Object.entries(devices).map(([deviceID, platformName]) => {
+                if (platformName === 'bitbox02') {
                   return (
                     <Fragment key={deviceID}>
                       <BitBox02Wizard

--- a/frontends/web/src/components/banners/banner.tsx
+++ b/frontends/web/src/components/banners/banner.tsx
@@ -23,7 +23,7 @@ import { A } from '@/components/anchor/anchor';
 import style from './banner.module.css';
 
 type TBannerProps = {
-  msgKey: 'bitbox01' | 'bitbox02';
+  msgKey: 'bitbox01' | 'bitbox02' | 'bitbox02nova';
 }
 
 export const Banner = ({ msgKey }: TBannerProps) => {

--- a/frontends/web/src/components/banners/index.tsx
+++ b/frontends/web/src/components/banners/index.tsx
@@ -26,6 +26,7 @@ export const GlobalBanners = () => {
       <Update />
       <Banner msgKey="bitbox01" />
       <Banner msgKey="bitbox02" />
+      <Banner msgKey="bitbox02nova" />
       <MobileDataWarning />
     </>
   );

--- a/frontends/web/src/routes/settings/bb02-settings.tsx
+++ b/frontends/web/src/routes/settings/bb02-settings.tsx
@@ -107,7 +107,6 @@ const Content = ({ deviceID }: TProps) => {
           return;
         }
         setDeviceInfo(result.deviceInfo);
-        console.log('LOL', result);
       })
       .catch(console.error);
   }, [deviceID, t]);

--- a/frontends/web/src/routes/settings/components/tabs.tsx
+++ b/frontends/web/src/routes/settings/components/tabs.tsx
@@ -17,7 +17,7 @@
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink, useNavigate } from 'react-router-dom';
-import type { TDevices, TProductName } from '@/api/devices';
+import type { TDevices, TPlatformName } from '@/api/devices';
 import { useLoad } from '@/hooks/api';
 import { getVersion } from '@/api/bitbox02';
 import { SettingsItem } from './settingsItem/settingsItem';
@@ -101,7 +101,7 @@ export const Tab = ({
 
 type TTabWithVersionCheck = TTab & {
   deviceID: string;
-  device: TProductName;
+  device: TPlatformName;
 }
 
 const TabWithVersionCheck = ({ deviceID, device, ...props }: TTabWithVersionCheck) => {


### PR DESCRIPTION
We want to be able to show different banners to bb02 and bb02nova users. This adds a backend check to differentiate the product name and adds a new banner category for the nova.


