### PR TITLE
frontend: add backup reminder banner.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Added BTC Direct sell option
+- Added a banner to remind user to backup their seed phrase when an account reaches a certain threshold.
 
 ## v4.48.2
 - iOS: Fix blank screens after prolonged inactivity

--- a/backend/rates/mock.go
+++ b/backend/rates/mock.go
@@ -36,9 +36,13 @@ func MockRateUpdater() *RateUpdater {
 	updater.last = map[string]map[string]float64{
 		"BTC": {
 			"USD": 21.0,
+			"EUR": 18.0,
+			"CHF": 19.0,
 		},
 		"ETH": {
 			"USD": 1.0,
+			"EUR": 0.9,
+			"CHF": 0.95,
 		},
 	}
 	return updater

--- a/frontends/web/src/api/backupBanner.ts
+++ b/frontends/web/src/api/backupBanner.ts
@@ -1,0 +1,27 @@
+
+/**
+ * Copyright 2025 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apiGet } from '@/utils/request';
+import type { Fiat } from './account';
+
+export type TShowBackupBannerResponse =
+  | { success: false }
+  | { success: true; show: boolean; fiat: Fiat; threshold: string };
+
+export const getShowBackupBanner = (rootFingerprint: string): Promise<TShowBackupBannerResponse> => {
+  return apiGet(`keystore/show-backup-banner/${rootFingerprint}`);
+};

--- a/frontends/web/src/components/amount/amount.tsx
+++ b/frontends/web/src/components/amount/amount.tsx
@@ -44,7 +44,7 @@ const formatSats = (amount: string): JSX.Element => {
   );
 };
 
-const formatLocalizedAmount = (
+export const formatLocalizedAmount = (
   amount: string,
   group: string,
   decimal: string

--- a/frontends/web/src/components/banners/backup.tsx
+++ b/frontends/web/src/components/banners/backup.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2025 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MouseEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getDeviceList } from '@/api/devices';
+import { Link, useNavigate } from 'react-router-dom';
+import { connectKeystore } from '@/api/keystores';
+import { Status } from '@/components/status/status';
+import { MultilineMarkup } from '@/utils/markup';
+import { TKeystore } from '@/api/account';
+import { AppContext } from '@/contexts/AppContext';
+import { getShowBackupBanner, TShowBackupBannerResponse } from '@/api/backupBanner';
+import { useContext, useEffect, useState } from 'react';
+import { TAccountsBalanceSummary } from '@/api/account';
+import { formatLocalizedAmount } from '@/components/amount/amount';
+import { LocalizationContext } from '@/contexts/localization-context';
+
+type BackupReminderProps = {
+  keystore: TKeystore;
+  accountsBalanceSummary?: TAccountsBalanceSummary;
+}
+
+export const BackupReminder = ({ keystore, accountsBalanceSummary }: BackupReminderProps) => {
+  const { t } = useTranslation();
+  const [bannerResponse, setBannerResponse] = useState<TShowBackupBannerResponse | null>(null);
+  const { hideAmounts } = useContext(AppContext);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    getShowBackupBanner(keystore.rootFingerprint).then(setBannerResponse);
+  }, [keystore.rootFingerprint, accountsBalanceSummary]);
+
+
+  if (hideAmounts) {
+    // If amounts are hidden, we don't show the backup reminder.
+    return;
+  }
+
+  if (!bannerResponse || !bannerResponse.success) {
+    return null;
+  }
+
+  const maybeNavigateToSettings = async (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    const connectResult = await connectKeystore(keystore.rootFingerprint);
+    if (connectResult.success) {
+      const devices = await getDeviceList();
+      if (Object.keys(devices).length === 0) {
+        // If no devices are connected, we cannot navigate to settings.
+        // This shouldn't happen in theory, as the connectKeystore functions has succeeded.
+        return;
+      }
+      const deviceSettingsURL = `/settings/device-settings/${Object.keys(devices)[0]}`;
+      // Proceed to the setting screen if the keystore was connected.
+      navigate(deviceSettingsURL);
+    }
+  };
+
+  const { decimal, group } = useContext(LocalizationContext);
+  return (
+    <Status
+      type="info"
+      hidden={!bannerResponse.show}
+      dismissible={`banner-backup-${keystore.rootFingerprint}`}>
+      <MultilineMarkup
+        tagName="span"
+        withBreaks
+        markup={t('account.backupReminder',
+          {
+            name: keystore.name,
+            fiat: bannerResponse.fiat,
+            threshold: formatLocalizedAmount(bannerResponse.threshold, group, decimal),
+          })}
+      />
+      <Link to="#" onClick={maybeNavigateToSettings} >{t('account.backupReminderLink')} </Link>
+    </Status>
+  );
+};

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -2,6 +2,8 @@
   "account": {
     "account": "Account",
     "accounts": "Accounts",
+    "backupReminder": "Your wallet <strong>{{name}}</strong> passed {{fiat}} {{threshold}}!\n\nWe recommend creating a paper backup for extra protection. It's quick and simple.",
+    "backupReminderLink": "Create paper backup",
     "disconnect": "Connection lost. Retrying…",
     "export": "Export",
     "exportTransactions": "Export transactions to downloads folder as CSV file",

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -39,6 +39,7 @@ import { getAccountsByKeystore, isAmbiguousName } from '@/routes/account/utils';
 import { RatesContext } from '@/contexts/RatesContext';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { GlobalBanners } from '@/components/banners';
+import { BackupReminder } from '@/components/banners/backup';
 
 type TProps = {
   accounts: accountApi.IAccount[];
@@ -170,6 +171,10 @@ export const AccountsSummary = ({
     getAccountsBalanceSummary();
   }, [onStatusChanged, getAccountsBalanceSummary, accounts]);
 
+  useEffect(() => {
+    getAccountsBalanceSummary();
+  }, [defaultCurrency, getAccountsBalanceSummary]);
+
   return (
     <GuideWrapper>
       <GuidedContent>
@@ -179,6 +184,13 @@ export const AccountsSummary = ({
             <Status hidden={!hasCard} type="warning">
               {t('warning.sdcard')}
             </Status>
+            {accountsByKeystore.map(({ keystore }) => (
+              <BackupReminder
+                key={keystore.rootFingerprint}
+                keystore={keystore}
+                accountsBalanceSummary={accountsBalanceSummary}
+              />
+            ))}
           </ContentWrapper>
           <Header title={<h2>{t('accountSummary.title')}</h2>}>
             <HideAmountsButton />


### PR DESCRIPTION
For each wallet, the first time it crosses 1000 USD/CHF/EUR, display a banner suggesting users to create a paper backup of their seed. If the default currency is different from these three, we use USD.

If the keystore is connected, the banner shows a link to the device setting where the user can see their recovery words.
If the keystore is not connected, the banner asks the user to connect it.

If amounts are hidden, we do not display the banner at all.

Video (where I manually changed the threshold from 1000 to 1, you'll need to do the same to test it if you don't have at least 1000 in a wallet) - note: the video is slightly outdated but still shows the overall flow

https://github.com/user-attachments/assets/83619e6f-d659-4bd0-bd41-41d4981370ba

A few comments are left inline.

Tested on Android and Linux
Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
