### PR TITLE
frontend: disable option to connect via tor proxy on ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Improved offline UX: added detection to show an offline warning banner and auto-reconnect when back online
 - iOS: various UI improvements
 - Add option to disable Bluetooth for BitBox02 Nova (non-iOS devices only)
+- Disabled the option to enable Tor proxy on iOS
 
 ## v4.48.0
 - Bundle BitBox02 firmware version v9.23.0

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -819,6 +819,7 @@
     "buy_crypto": "Buy crypto",
     "enabled_false": "Disabled",
     "enabled_true": "Enabled",
+    "noOptionOnIos": "Not available on iOS",
     "noOptions": "No options found",
     "receive": "Receive {{coinCode}}",
     "receive_bitcoin": "Receive Bitcoin",

--- a/frontends/web/src/routes/settings/components/advanced-settings/enable-tor-proxy-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/enable-tor-proxy-setting.tsx
@@ -16,10 +16,11 @@
 
 import { Dispatch, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { TProxyConfig } from '@/routes/settings/advanced-settings';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
 import { TorProxyDialog } from './tor-proxy-dialog';
 import { Message } from '@/components/message/message';
-import { TProxyConfig } from '@/routes/settings/advanced-settings';
+import { runningInIOS } from '@/utils/env';
 import styles from './enable-tor-proxy-setting.module.css';
 
 type TProps = {
@@ -34,6 +35,15 @@ export const EnableTorProxySetting = ({ proxyConfig, onChangeConfig }: TProps) =
 
   const proxyEnabled = proxyConfig ? proxyConfig.useProxy : false;
 
+  const isIOS = runningInIOS();
+  const displayedValue = (
+    isIOS
+      ? t('generic.noOptionOnIos')
+      : proxyEnabled
+        ? t('generic.enabled_true')
+        : t('generic.enabled_false')
+  );
+
   return (
     <>
       { showRestartMessage ? (
@@ -44,9 +54,9 @@ export const EnableTorProxySetting = ({ proxyConfig, onChangeConfig }: TProps) =
       <SettingsItem
         className={styles.settingItem}
         settingName={t('settings.expert.useProxy')}
-        onClick={() => setShowTorProxyDialog(true)}
+        onClick={isIOS ? undefined : () => setShowTorProxyDialog(true)}
         secondaryText={t('newSettings.advancedSettings.torProxy.description')}
-        displayedValue={proxyEnabled ? t('generic.enabled_true') : t('generic.enabled_false')}
+        displayedValue={displayedValue}
       />
       <TorProxyDialog
         open={showTorProxyDialog}


### PR DESCRIPTION
The Tor proxy can currently not be used on iOS. iOS restricts exposing local ports to other apps.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [x] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
