### PR TITLE
backend/handlers: fix header sync tx timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix wrong btc/ltc transaction timestamp during header sync
 
 ## v4.48.1
 - Bundle BitBox02 firmware version v9.23.1

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -140,9 +140,6 @@ func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail
 	amount := txInfo.Amount.FormatWithConversions(handlers.account.Coin(), false, accountConfig.RateUpdater)
 	var formattedTime *string
 	timestamp := txInfo.Timestamp
-	if timestamp == nil {
-		timestamp = txInfo.CreatedTimestamp
-	}
 
 	deductedAmountAtTime := txInfo.DeductedAmount.FormatWithConversionsAtTime(handlers.account.Coin(), timestamp, accountConfig.RateUpdater)
 	amountAtTime := txInfo.Amount.FormatWithConversionsAtTime(handlers.account.Coin(), timestamp, accountConfig.RateUpdater)


### PR DESCRIPTION
The use of creation timestamp when the tx timestamp was not available caused the app to show the current date for all the btc/ltc transactions during the header syncing. This removes the use of the tx creation timestamp, as it doesn't seem to be really useful anyway.

Now during header sync the tx date is not showed at all.

