### PR TITLE
backend: close Electrum/failover connections too on shutdown

### DIFF
--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -312,12 +312,14 @@ func (coin *Coin) ValidateSilentPaymentAddress(address string) error {
 // Close implements coinpkg.Coin.
 func (coin *Coin) Close() error {
 	coin.log.Info("closing coin")
+	if coin.blockchain != nil {
+		coin.blockchain.Close()
+	}
 	if coin.headers != nil {
 		coin.log.Info("closing headers")
 		if err := coin.headers.Close(); err != nil {
 			return err
 		}
 	}
-	// TODO: shutdown Electrum connection.
 	return nil
 }


### PR DESCRIPTION
Without this, if no backends/servers are configured, headers download would be stuck on some call that keeps failing over or retrying forever, and headers.Close() would be blocked from finishing.

This is a quick fix, there is still a delay to shut down until some Electrum call in headers.go fails (probably up to 30s due to the retry timeout?).

More things to do:

- Add a ctx var for every Electrum call that should get cancelled on shutdown to not delay
- Do not block closing headers on the same lock which is held during a blockchain call (use a different lock, or by the above ctx solution)

