### PR TITLE
frontend/ios: fix blank screens when foregrounding after inactivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- iOS: Fix blank screens after prolonged inactivity
 
 ## v4.48.1
 - Bundle BitBox02 firmware version v9.23.1

--- a/frontends/ios/BitBoxApp/BitBoxApp/WebView.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/WebView.swift
@@ -182,6 +182,11 @@ struct WebView: UIViewRepresentable {
             return nil
         }
 
+        // Reload root page when WKWebView content process is terminated by the system.
+        // Avoids blank screens when foregrounding the app after long inactivity.
+        func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+            webView.load((URLRequest(url: URL(string: scheme + ":/index.html")!)))
+        }
 
         // Automatically grant camera permission when used in the webview.
         // The camera permission was already granted at install time via


### PR DESCRIPTION
As part of system memory and energy management, iOS may terminate the web view of the app at whim, e.g. after backgrounding the app for a long time, usually combined with many different apps open during active usage.

Whenever this happens, the "webViewWebContentProcessDidTerminate" hook is triggered and forces a reload of the web view, set to the root page. As this is only triggered if the web view was killed, it will not interfere with regular usage.

Users may experience the reload briefly when they foreground the app and the conditions for the reload are met. While this fixes the blank screen issue, this is still somewhat suboptimal, as the user would expect the last state from when they used the app to reload.

To test in the simulator, termination of the web content can be forced with:

```sh
kill $(pgrep -P $(pgrep launchd_sim) com.apple.WebKit.WebContent)
```

The reload will be very noticable doing that.

To test on-device:

* Open the app and visit any page other than the root page (to easily notice whether the reload was triggered later)
* Background the app and do something else, e.g. opening many tabs in Safari may help
* Leave phone unattended for ~1h
* When foregrounding the app again, you will see the app reloading to the portfolio or welcome screen (instead of where you left off). Previously, this is where one would have encountered a blank screen.

The reload is very subtle here.