### PR TITLE
backend/eth: show all internal transactions that share the same txID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - iOS: Fix blank screens after prolonged inactivity
+- Ethereum bugfix: show all internal transactions that share the same transaction ID
 
 ## v4.48.1
 - Bundle BitBox02 firmware version v9.23.1


### PR DESCRIPTION
One ETH transaction can contain multiple deposits to a receive address. Because of the `seen` de-dup check, only the first one would be shown.

I checked if EtherScan really delivers two transactions instead of one for a self-transfer, but could not reproduce it.


