### PR TITLE
 frontend/btcdirect: share sell address to btcdirect widget

### DIFF
--- a/frontends/web/public/btcdirect/coin-to-fiat.html
+++ b/frontends/web/public/btcdirect/coin-to-fiat.html
@@ -32,6 +32,7 @@
       case 'configuration':
         const {
           apiKey,
+          address,
           baseCurrency,
           locale,
           mode,
@@ -85,6 +86,18 @@
           locale: locale || 'en-GB',
           returnUrl: 'https://bitboxapp.shiftcrypto.io/widgets/btcdirect/v1/back-to-app.html',
           theme: theme || 'light',
+        });
+
+        // FIXME: The address should not be needed for the sell flow: this is a temporary workaround to
+        // force the coin type in the widget. Without this, the widget UI allows the user to pick a
+        // coin, potentially breaking the flow.
+        btcdirect('wallet-addresses', {
+          addresses: {
+            address,
+            currency,
+            id: 'BTC Direct',
+            name: 'BTC Direct'
+          }
         });
 
         btcdirect('currencies', {

--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -195,7 +195,9 @@ export const BTCDirect = ({
     }
     event.source?.postMessage({
       action: 'configuration',
-      ...(action === 'buy' && { address: btcdirectInfo.address }),
+      // address should not be needed for sell, but we provide it to lock the coin option
+      // in the widget. See coin-to-fiat.html for details.
+      address: btcdirectInfo.address,
       locale,
       theme: isDarkMode ? 'dark' : 'light',
       baseCurrency: account.coinUnit,
@@ -205,7 +207,7 @@ export const BTCDirect = ({
     }, {
       targetOrigin: event.origin
     });
-  }, [account, action, btcdirectInfo, isDarkMode, isDevServers, locale]);
+  }, [account, btcdirectInfo, isDarkMode, isDevServers, locale]);
 
   const onMessage = useCallback((event: MessageEvent) => {
     if (


### PR DESCRIPTION
This is a temporary workaround to force the coin type in the widget. Without this, the widget UI allows the user to pick a coin, potentially breaking the flow.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
