### PR TITLE
backend: only update account's nextNonce when needed.

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -899,6 +899,9 @@ func (backend *Backend) addAccount(account accounts.Interface) {
 		backend.log.WithError(err).Error("error initializing account")
 		return
 	}
+	if ethAccount, ok := account.(*eth.Account); ok {
+		backend.updateBalance <- ethAccount
+	}
 	if backend.onAccountInit != nil {
 		backend.onAccountInit(account)
 	}
@@ -1064,7 +1067,7 @@ func (backend *Backend) createAndAddAccount(coin coinpkg.Coin, persistedConfig *
 		)
 		backend.addAccount(account)
 	case *eth.Coin:
-		account = backend.makeEthAccount(accountConfig, specificCoin, backend.httpClient, backend.log)
+		account = backend.makeEthAccount(accountConfig, specificCoin, backend.httpClient, backend.log, backend.updateBalance)
 		backend.addAccount(account)
 
 		// Load ERC20 tokens enabled with this Ethereum account.

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -280,7 +280,7 @@ func newBackend(t *testing.T, testing, regtest bool) *Backend {
 	b.makeBtcAccount = func(config *accounts.AccountConfig, coin *btc.Coin, gapLimits *types.GapLimits, getAddress func(*btc.Account, blockchain.ScriptHashHex) (*addresses.AccountAddress, bool, error), log *logrus.Entry) accounts.Interface {
 		return MockBtcAccount(t, config, coin, gapLimits, log)
 	}
-	b.makeEthAccount = func(config *accounts.AccountConfig, coin *eth.Coin, httpClient *http.Client, log *logrus.Entry) accounts.Interface {
+	b.makeEthAccount = func(config *accounts.AccountConfig, coin *eth.Coin, httpClient *http.Client, log *logrus.Entry, updateBalance chan *eth.Account) accounts.Interface {
 		return MockEthAccount(config, coin, httpClient, log)
 	}
 

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/errors"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth/rpcclient/mocks"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore"
@@ -106,7 +107,9 @@ func newAccount(t *testing.T) *Account {
 		coin,
 		&http.Client{},
 		log,
+		make(chan *Account, 1),
 	)
+	acct.balance = coinpkg.NewAmount(big.NewInt(1e18))
 	require.NoError(t, acct.Initialize())
 	return acct
 }

--- a/backend/notes_test.go
+++ b/backend/notes_test.go
@@ -88,7 +88,7 @@ func (s *notesTestSuite) SetupTest() {
 
 		return accountMock
 	}
-	s.backend.makeEthAccount = func(config *accounts.AccountConfig, coin *eth.Coin, httpClient *http.Client, log *logrus.Entry) accounts.Interface {
+	s.backend.makeEthAccount = func(config *accounts.AccountConfig, coin *eth.Coin, httpClient *http.Client, log *logrus.Entry, updateBalances chan *eth.Account) accounts.Interface {
 		accountMock := MockEthAccount(config, coin, httpClient, log)
 		accountMock.NotesFunc = notesFunc(config.Config.Code)
 		accountMock.TransactionsFunc = transactionsFunc(config.Config.Code)


### PR DESCRIPTION
NOTE: this is based on https://github.com/BitBoxSwiss/bitbox-wallet-app/pull/3471 and needs to be reviewed after that.

Instead of updating the next nonce everytime we update the account, we
now update the nonce only when we need it (i.e. when sending a Tx).

This reduces the amount of calls we have to make to Etherscan.


Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
