### PR TITLE
backend: remove QT workaround for dark mode.

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -252,11 +252,6 @@ public:
 
 int main(int argc, char *argv[])
 {
-    // Make `@media (prefers-color-scheme: light/dark)` CSS rules work.
-    // See https://github.com/qutebrowser/qutebrowser/issues/5915#issuecomment-737115530
-    // This might only be needed for Qt 5.15.2, should revisit this when updating Qt.
-    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--blink-settings=preferredColorScheme=1");
-
     // QT configuration parameters which change the attack surface for memory
     // corruption vulnerabilities
 #if QT_VERSION >= QT_VERSION_CHECK(5,8,0)


### PR DESCRIPTION
With Qt 5.15.2, dark mode was not working on Linux/Windows/MacOS We have since then updated to Qt 6 and the workaround is not needed anymore.

I have tested only on MacOS and dark mode works. Testing on other environments is welcome :) 

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
