### PR TITLE
backend: re-enable the sandbox for Qt.

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -265,22 +265,6 @@ int main(int argc, char *argv[])
     qputenv("DRAW_USE_LLVM", "0");
 #endif
 
-    // The QtWebEngine may make a clone3 syscall introduced in glibc v2.34.
-    // The syscall is missing from the Chromium sandbox whitelist in Qt versions 5.15.2
-    // and earlier which visually results in a blank app screen.
-    // Disabling the sandbox allows all syscalls.
-    //
-    // See the following for more details.
-    // https://github.com/BitBoxSwiss/bitbox-wallet-app/issues/1447
-    // https://bugreports.qt.io/browse/QTBUG-96214
-    // https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1944468
-#if defined(Q_OS_LINUX)
-    const static char* kDisableWebSandbox = "QTWEBENGINE_DISABLE_SANDBOX";
-    if (!qEnvironmentVariableIsSet(kDisableWebSandbox)) {
-        qputenv(kDisableWebSandbox, "1");
-    }
-#endif
-
     QString renderMode = qEnvironmentVariable("BITBOXAPP_RENDER", "software");
     if (renderMode == "software") {
         // Force software rendering over GPU-accelerated rendering as various rendering artefact


### PR DESCRIPTION
The sandbox was disabled for Linux on Qt 5.15.2 as it would cause the app to show a blank screen. This is not needed anymore as we upgraded to Qt 6.

Needs to be tested by someone with Linux as I currently only have a Macbook to work on.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
