### PR TITLE
chore: enable trimpath flag for go build.

### DIFF
--- a/backend/mobileserver/Makefile
+++ b/backend/mobileserver/Makefile
@@ -3,8 +3,8 @@ include ../../android-env.mk.inc
 # Set -glflags to fix the vendor issue with gomobile, see: https://github.com/golang/go/issues/67927#issuecomment-2241523694
 build-android:
 	# androidapi version should match minSdkVersion in frontends/android/BitBoxApp/app/build.gradle
-	ANDROID_HOME=${ANDROID_SDK_ROOT} gomobile bind -x -a -glflags="-mod=readonly" -ldflags="-s -w" -target android -androidapi 24 .
+	ANDROID_HOME=${ANDROID_SDK_ROOT} gomobile bind -x -a -glflags="-mod=readonly" -ldflags="-s -w" -trimpath -target android -androidapi 24 .
 build-ios:
-	gomobile bind -x -a -glflags="-mod=readonly" -ldflags="-s -w" -target ios,iossimulator .
+	gomobile bind -x -a -glflags="-mod=readonly" -trimpath -ldflags="-s -w" -target ios,iossimulator .
 clean:
 	rm -f mobileserver.aar mobileserver-sources.jar

--- a/frontends/qt/server/Makefile.linux
+++ b/frontends/qt/server/Makefile.linux
@@ -11,7 +11,7 @@ linux:
 	CGO_CFLAGS="${GOLNXSECFLAGS} ${CFLAGS}" \
 	CGO_LDFLAGS="${GOLNXLDFLAGS} ${LFLAGS}" \
 	GOARCH=${GOARCH} CGO_ENABLED=${CGO} GOOS=${GOOS} GOTOOLCHAIN=${GOTOOLCHAIN} \
-	go build -x -mod=vendor -buildmode=${BUILDMODE} -ldflags \
+	go build -trimpath -x -mod=vendor -buildmode=${BUILDMODE} -ldflags \
 		-extldflags="${GOLNXEXTLDFLAGS}" -o ${LIBNAME}.so
 
 clean:

--- a/frontends/qt/server/Makefile.macosx
+++ b/frontends/qt/server/Makefile.macosx
@@ -9,8 +9,8 @@ darwin:
 	CGO_CFLAGS="-g ${GODARWINSECFLAGS} ${CFLAGS}" \
 	CGO_LDFLAGS="${GODARWINLDFLAGS} ${LFLAGS}" \
 	MACOSX_DEPLOYMENT_TARGET=${MACOS_MIN_VERSION} \
-	GOARCH=arm64 CGO_ENABLED=${CGO} GOOS=${GOOS} GOTOOLCHAIN=${GOTOOLCHAIN} go build -ldflags='-s' -x -mod=vendor -buildmode="c-shared" -o ${LIBNAME}_arm64.so
-	GOARCH=amd64 CGO_ENABLED=${CGO} GOOS=${GOOS} GOTOOLCHAIN=${GOTOOLCHAIN} go build -ldflags='-s' -x -mod=vendor -buildmode="c-shared" -o ${LIBNAME}_amd64.so
+	GOARCH=arm64 CGO_ENABLED=${CGO} GOOS=${GOOS} GOTOOLCHAIN=${GOTOOLCHAIN} go build -trimpath -ldflags='-s' -x -mod=vendor -buildmode="c-shared" -o ${LIBNAME}_arm64.so
+	GOARCH=amd64 CGO_ENABLED=${CGO} GOOS=${GOOS} GOTOOLCHAIN=${GOTOOLCHAIN} go build -trimpath -ldflags='-s' -x -mod=vendor -buildmode="c-shared" -o ${LIBNAME}_amd64.so
 	lipo -create -output ${LIBNAME}.so ${LIBNAME}_arm64.so ${LIBNAME}_amd64.so
 	# Without this, the internal names of the two libs are libserver_arm64.so and libserver_amd64.so, and
 	# will be linked with these names in the final executable (even though the library is fat and its name is libserver.so).

--- a/frontends/qt/server/Makefile.windows
+++ b/frontends/qt/server/Makefile.windows
@@ -10,7 +10,7 @@ windows:
 	CGO_CFLAGS="${GOWINSECFLAGS} ${CFLAGS}" \
 	CGO_LDFLAGS="${GOWINLDFLAGS} ${LFLAGS}" \
 	GOARCH=${GOARCH} CGO_ENABLED=${CGO} GOOS=${GOOS} GOTOOLCHAIN=${GOTOOLCHAIN} \
-       	go build -x -mod=vendor \
+       	go build -trimpath -x -mod=vendor \
         -buildmode="${BUILDMODE}" -o ${LIBNAME}.dll
 
 windows-cross:
@@ -19,7 +19,7 @@ windows-cross:
 	CGO_CFLAGS="-g ${GOWINSECFLAGS} ${CFLAGS}" \
 	CGO_LDFLAGS="${GOWINLDFLAGS} ${LFLAGS}" \
 	GOARCH=${GOARCH} CGO_ENABLED=${CGO} GOOS=${GOOS} GOTOOLCHAIN=${GOTOOLCHAIN} \
-       	go build -x -mod=vendor \
+       	go build -trimpath -x -mod=vendor \
         -buildmode="${BUILDMODE}" -o ${LIBNAME}.dll
 
 windows-legacy:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -22,7 +22,7 @@ export GORACE="halt_on_error=1"
 export GOTOOLCHAIN="local"
 
 # This script has to be called from the project root directory.
-go build -mod=vendor ./...
+go build -trimpath -mod=vendor ./...
 go test -race -mod=vendor ./... -count=1 -v
 golangci-lint --version
 golangci-lint config verify


### PR DESCRIPTION
As per official docs, `-trimpath `removes all file system paths from the resulting executable.

This way, stack traces in the logs won't show hardcoded paths that can confuse users.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
