### PR TITLE
backend/bitbox02: simulator test that change is not confirmed

### DIFF
--- a/backend/devices/bitbox02/keystore_simulator_test.go
+++ b/backend/devices/bitbox02/keystore_simulator_test.go
@@ -511,6 +511,8 @@ func TestSimulatorSignBTCTransactionMixedInputs(t *testing.T) {
 		// Before simulator v9.20, address confirmation data was not written to stdout.
 		if device.Version().AtLeast(semver.NewSemVer(9, 20, 0)) {
 			require.Contains(t, stdOut.String(), "ADDRESS: 18p3G8gQ3oKy4U9EqnWs7UZswdqAMhE3r8")
+			// Change address is not confirmed, it is verified automatically.
+			require.NotContains(t, stdOut.String(), proposedTransaction.TXProposal.ChangeAddress.String())
 		}
 	})
 }


### PR DESCRIPTION
Easy to miss, if the change output info is missing and sent to the BitBox as an external address by accident, it will be explicitly confirmed. This helps catch regressions when refactoring signing logic.
