### PR TITLE
frontend: remove currency selector and fix suggested account name for BTC-only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Ethereum bugfix: show all internal transactions that share the same transaction ID
 - Allow up to 6 unused BTC/LTC accounts (previously 5)
 - Add support for New Zealand Dollar (NZD)
+- Fix empty suggested name for BTC account when only BTC is supported by the BitBox.
 
 ## v4.48.4
 - macOS: fix potential USB communication issue with BitBox02 bootloaders <v1.1.2 and firmwares <v9.23.1

--- a/frontends/web/src/routes/account/add/add.tsx
+++ b/frontends/web/src/routes/account/add/add.tsx
@@ -68,7 +68,7 @@ export const AddAccount = ({ accounts }: TAddAccountGuide) => {
       setStep(onlyOneCoinIsSupported ? 'choose-name' : 'select-coin');
       setSupportedCoins(coins);
       if (onlyOneCoinIsSupported) {
-        setAccountCode(coins[0].suggestedAccountName);
+        setAccountName(coins[0].suggestedAccountName);
       }
       inputRef.current?.focus();
     } catch (err) {
@@ -91,8 +91,12 @@ export const AddAccount = ({ accounts }: TAddAccountGuide) => {
       navigate(-1);
       break;
     case 'choose-name':
-      setStep('select-coin');
-      setErrorMessage(undefined);
+      if (onlyOneSupportedCoin()) {
+        navigate(-1);
+      } else {
+        setStep('select-coin');
+        setErrorMessage(undefined);
+      }
       break;
     case 'success':
       setStep('choose-name');


### PR DESCRIPTION
When there is only one coin supported, we want the back button on the choose name step to close the dialog. And we want the account name to be suggested.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [x] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
