### PR TITLE
frontend: deep link into backup workflow

### DIFF
--- a/frontends/web/src/components/banners/backup.tsx
+++ b/frontends/web/src/components/banners/backup.tsx
@@ -63,7 +63,7 @@ export const BackupReminder = ({ keystore, accountsBalanceSummary }: BackupRemin
         // This shouldn't happen in theory, as the connectKeystore functions has succeeded.
         return;
       }
-      const deviceSettingsURL = `/settings/device-settings/${Object.keys(devices)[0]}`;
+      const deviceSettingsURL = `/settings/device-settings/recovery-words/${Object.keys(devices)[0]}`;
       // Proceed to the setting screen if the keystore was connected.
       navigate(deviceSettingsURL);
     }


### PR DESCRIPTION
Previously, a backup reminder was added but it was not possible to deep link directly into the workflow:
- 852f9c7c1f79537d0f660d07d2e14116ab7754b0

The recovery workflow has since been refactored to support deep linking:
- 747803a18255fd41153bfbf2907153aba635797c
