### PR TITLE
frontend: add make webserve task for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ webtest:
 	cd ${WEBROOT} && $(MAKE) jstest
 webtestwatch:
 	cd ${WEBROOT} && $(MAKE) jstest-watch
+webserve:
+	cd ${WEBROOT} && $(MAKE) serve
 qt-linux: # run inside dockerdev
 	$(MAKE) buildweb
 	cd frontends/qt && $(MAKE) linux

--- a/frontends/web/Makefile
+++ b/frontends/web/Makefile
@@ -28,3 +28,5 @@ jstest-cover:
 listdeps:
 	@echo "Listing JavaScript production dependencies. Be careful to not pull in many deps accidentally."
 	npm list -prod -long
+serve:
+	npm run serve

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -54,6 +54,7 @@
     "lint-debug": "eslint ./src --inspect-config",
     "typescript": "tsc -p tsconfig.json",
     "test": "vitest",
-    "preview": "vite preview --port 8080"
+    "preview": "vite preview --port 8080",
+    "serve": "npm run build && npm run preview"
   }
 }


### PR DESCRIPTION
For testing purpose sometimes we want to test the actual prodution build instead of vite dev mode.

This first builds the frontend and serves without hot reloading.
