### PR TITLE
android: fix ndk version

### DIFF
--- a/frontends/android/BitBoxApp/app/build.gradle
+++ b/frontends/android/BitBoxApp/app/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdk 35
+    // Keep in sync with android-env.mk.inc and the NDK installed in docker_install.sh.
+    ndkVersion "28.2.13676358"
     defaultConfig {
         applicationId "ch.shiftcrypto.bitboxapp"
         // minSdkVersion should match the `-androidapi` gomobile bind flag


### PR DESCRIPTION
We have NDK 28 installed by docker_install.sh. Still, `make android` gave this output:

```
Checking the license for package NDK (Side by side) 27.0.12077973 in /opt/android-sdk/licenses
License for package NDK (Side by side) 27.0.12077973 accepted.
Preparing "Install NDK (Side by side) 27.0.12077973 v.27.0.12077973".
```

It is unclear `gradlew assemble` chose this version, it's not in any cache/localprops.

Adding the version to build.gradle resolves this.
