### PR TITLE
frontend: use btcdirect address from payment-request

### DIFF
--- a/frontends/web/public/btcdirect/coin-to-fiat.html
+++ b/frontends/web/public/btcdirect/coin-to-fiat.html
@@ -28,6 +28,7 @@
     let orderId = '';
 
     const onMessage = (event) => {
+
       switch (event.data?.action) {
       case 'configuration':
         const {
@@ -129,6 +130,7 @@
         amount: String(e.detail?.amount),
         currency: e.detail?.currency,
         orderId: e.detail?.orderId,
+        walletAddress: e.detail?.walletAddress,
       }, '*');
 
     });

--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -106,7 +106,12 @@ export const BTCDirect = ({
   };
 
   const handlePaymentRequest = useCallback(async (event: MessageEvent) => {
-    const { amount, currency, orderId } = event.data;
+    const {
+      amount,
+      currency,
+      orderId,
+      walletAddress,
+    } = event.data;
 
     if (!btcdirectInfo || btcdirectInfo?.success === false) {
       if (btcdirectInfo?.errorMessage) {
@@ -137,7 +142,7 @@ export const BTCDirect = ({
     }
 
     const txInput: TTxInput = {
-      address: btcdirectInfo.address,
+      address: walletAddress, // TODO: remove btcdirectInfo.address,
       amount: txAmount,
       paymentRequest: null,
       sendAll: 'no',


### PR DESCRIPTION
Use BTC Direct walletAddress from btcdirect-embeddable-coin-to- fiat-order-requested event.

With this the hardcoded addresses can be removed in the backend.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)

