### PR TITLE
frontend/bitrefill: add local copy of bitrefill.html

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -1403,7 +1403,7 @@ func (handlers *Handlers) getMarketBitrefillInfo(r *http.Request) interface{} {
 	}
 
 	action := market.Action(mux.Vars(r)["action"])
-	bitrefillInfo := market.BitrefillInfo(action, acct)
+	bitrefillInfo := market.BitrefillInfo(action, acct, handlers.backend.DevServers())
 
 	return result{
 		Success: true,

--- a/backend/market/bitrefill.go
+++ b/backend/market/bitrefill.go
@@ -27,6 +27,8 @@ const (
 
 	bitrefillRef = "SHU5bB6y"
 
+	bitrefillDevUrl = "/bitrefill/bitrefill.html"
+
 	bitrefillProdUrl = "https://bitboxapp.shiftcrypto.io/widgets/bitrefill/v1/bitrefill.html"
 )
 
@@ -100,10 +102,14 @@ func BitrefillDeals() *DealsList {
 
 // BitrefillInfo returns the information needed to interact with Bitrefill,
 // including the widget URL, referral code and an unused address for refunds.
-func BitrefillInfo(action Action, acct accounts.Interface) bitrefillInfo {
+func BitrefillInfo(action Action, acct accounts.Interface, devServers bool) bitrefillInfo {
+	url := bitrefillProdUrl
+	if devServers {
+		url = bitrefillDevUrl
+	}
 	addr := acct.GetUnusedReceiveAddresses()[0].Addresses[0].EncodeForHumans()
 	res := bitrefillInfo{
-		Url:     bitrefillProdUrl,
+		Url:     url,
 		Ref:     bitrefillRef,
 		Address: &addr}
 

--- a/frontends/web/public/bitrefill/bitrefill.css
+++ b/frontends/web/public/bitrefill/bitrefill.css
@@ -1,0 +1,16 @@
+html, body {
+  font-family: sans-serif;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+.bitrefill-widget {
+  display: flex;
+  justify-content: center;
+}
+
+iframe {
+  border: none;
+  min-height: 100vh;
+}

--- a/frontends/web/public/bitrefill/bitrefill.html
+++ b/frontends/web/public/bitrefill/bitrefill.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Bitrefill</title>
+
+<link href="./bitrefill.css" rel="stylesheet">
+
+<div class="bitrefill-widget" id="bitrefill-widget-container">
+
+</div>
+
+<script lang="js">
+  // NOTE: please note this static page is for development purposes only and may not be in sync with the actual version
+  ;(() => {
+    // Abort if not embedded in another context
+    if (window.top === window) {
+      showError('Unexpected error');
+      return;
+    }
+
+    // Polyfill if crypto.randomUUID is not available, i.e. in Qt WebEngine
+    if (!crypto.randomUUID) {
+      crypto.randomUUID = function () {
+        return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+          (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+        );
+      };
+    }
+
+    const onMessage = (event) => {
+      const data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+      switch (data?.event) {
+        case 'configuration': {
+          const {
+            ref,
+            utm_source,
+            theme,
+            hl,
+            paymentMethods,
+            refundAddress,
+            paymentPending,
+            region,
+            showPaymentInfo,
+          } = data || {};
+
+          if ( // ensure critical parameters are available
+            !ref
+            || !utm_source
+            || !refundAddress
+            || !paymentMethods
+          ) {
+            showError(`Unexpected error:
+              ${!ref ? 'Referral code missing' : ''}
+              ${!utm_source ? 'UTM source missing' : ''}
+              ${!refundAddress ? 'Refund address missing' : ''}
+              ${!paymentMethods ? 'Payment method missing' : ''}
+            `);
+            return;
+          }
+
+          const bitrefillUrl = new URL('https://embed.bitrefill.com/');
+
+          if (region) {
+            bitrefillUrl.pathname = region;
+          }
+
+          bitrefillUrl.search = new URLSearchParams({
+            ref: ref,
+            utm_source: utm_source,
+            theme: theme,
+            hl: hl,
+            paymentMethods: paymentMethods,
+            refundAddress: refundAddress,
+            paymentPending: paymentPending,
+            showPaymentInfo: showPaymentInfo
+          }).toString();
+          
+          const iframe = document.createElement('iframe');
+          iframe.src = bitrefillUrl;
+          iframe.title = "Bitrefill";
+          iframe.width="100%"
+          iframe.height="100%"
+          iframe.sandbox = "allow-same-origin allow-popups allow-scripts allow-forms";
+          document.getElementById('bitrefill-widget-container').appendChild(iframe);
+
+          break;
+        }
+        case 'payment_intent': {
+          // Forward payment intent to the app
+          window.parent.postMessage(data, '*');
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    };
+
+    window.addEventListener('message', onMessage);
+
+    // Request the parent to send attributes
+    window.parent.postMessage({
+      event: 'request-configuration'
+    }, '*');
+
+    function showError(message) {
+      document.body.append(
+        Object.assign(document.createElement('h1'), {
+          style: 'color: red; padding: 1rem;',
+          textContent: message,
+        })
+      );
+    }
+
+  })();
+</script>

--- a/frontends/web/src/routes/market/bitrefill.tsx
+++ b/frontends/web/src/routes/market/bitrefill.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Header } from '@/components/layout';
 import { Spinner } from '@/components/spinner/Spinner';
@@ -32,6 +32,7 @@ import { getURLOrigin } from '@/utils/url';
 import { WaitDialog } from '@/components/wait-dialog/wait-dialog';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import style from './iframe.module.css';
+import { AppContext } from '@/contexts/AppContext';
 
 // Map coins supported by Bitrefill
 const coinMapping: Readonly<Record<string, string>> = {
@@ -51,6 +52,7 @@ type TProps = {
 export const Bitrefill = ({ accounts, code }: TProps) => {
   const { t } = useTranslation();
   const { isDarkMode } = useDarkmode();
+  const { isDevServers } = useContext(AppContext);
   const account = findAccount(accounts, code);
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -190,7 +192,9 @@ export const Bitrefill = ({ accounts, code }: TProps) => {
   const handleMessage = useCallback(async (event: MessageEvent) => {
     if (
       !bitrefillInfo?.success
-      || ![getURLOrigin(bitrefillInfo.url), 'https://embed.bitrefill.com'].includes(event.origin)
+      || (
+        !isDevServers // if prod check that event is from same origin as bitrefillInfo.url
+        && ![getURLOrigin(bitrefillInfo.url), 'https://embed.bitrefill.com'].includes(event.origin))
     ) {
       return;
     }
@@ -210,7 +214,7 @@ export const Bitrefill = ({ accounts, code }: TProps) => {
       break;
     }
     }
-  }, [bitrefillInfo, handleConfiguration, handlePaymentRequest]);
+  }, [bitrefillInfo, handleConfiguration, handlePaymentRequest, isDevServers]);
 
   useEffect(() => {
     window.addEventListener('message', handleMessage);


### PR DESCRIPTION
This adds a local copy of bitrefill.html, which handles the communication between the app and the bitrefill widget, to make future development easier. When the app runs in dev mode, the local file will be used instead of the remote one.

