### PR TITLE
frontend: fix input element looses focus when typing

### DIFF
--- a/frontends/web/src/hooks/keyboard.ts
+++ b/frontends/web/src/hooks/keyboard.ts
@@ -107,12 +107,14 @@ export const useFocusTrap = (
     // Save previously focused element
     previouslyFocused.current = document.activeElement as HTMLElement;
 
-    // Autofocus first element
-    const firstFocusable = (
-      ref.current.querySelector<HTMLElement>('[autofocus]:not(:disabled)')
-      ?? ref.current.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)
-    );
-    firstFocusable?.focus();
+    // Autofocus first element, but only if nothing inside already has focus
+    if (!ref.current.contains(document.activeElement)) {
+      const firstFocusable = (
+        ref.current.querySelector<HTMLElement>('[autofocus]:not(:disabled)')
+        ?? ref.current.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)
+      );
+      firstFocusable?.focus({ preventScroll: true });
+    }
 
     return () => {
       // Restore focus if element is still in DOM


### PR DESCRIPTION
Only apply focus to first element with autoFocus, if no other element already has focus.

This fixed a bug where typing into the input element looses focus due to re-rendering and re-focusing the same element.
