### PR TITLE
chore: increase servewallet timeout.

### DIFF
--- a/frontends/web/tests/helpers/servewallet.ts
+++ b/frontends/web/tests/helpers/servewallet.ts
@@ -42,7 +42,7 @@ export async function waitForServewallet(
   servewalletPort: number,
   frontendPort: number,
   host: string,
-  timeout = 60000,
+  timeout = 90000,
 ) {
   const start = Date.now();
 
@@ -50,9 +50,12 @@ export async function waitForServewallet(
     try {
       await connectOnce(host, servewalletPort);
       await page.goto(`http://${host}:${frontendPort}`);
+      const elapsed = Date.now() - start;
+      console.log(`Connected to servewallet on ${host}:${servewalletPort} after ${elapsed} ms`);
       return;
     } catch {
       await new Promise(r => setTimeout(r, 200));
+
     }
   }
   throw new Error(`Timeout exceeded waiting for servewallet on ${host}:${servewalletPort}`);


### PR DESCRIPTION
To avoid spurious failures when the servewallet takes more times to be ready, we increase the timeout but also we log how long a successful connection took, in order to help keep track of it.

Looking at one execution, we were very close to the timeout limit so it does make sense that we had intermittent failures.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
