### PR TITLE
frontend: show banners on bitbox01 settings page

### DIFF
--- a/frontends/web/src/routes/device/bitbox01/settings/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/settings.tsx
@@ -30,6 +30,8 @@ import Reset from './components/reset';
 import UpgradeFirmware from '../components/upgradefirmware';
 import { SettingsButton } from '../../../../components/settingsButton/settingsButton';
 import { SettingsItem } from '../../../../components/settingsButton/settingsItem';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
+import { Banner } from '@/components/banners/banner';
 
 type Props = {
   deviceID: string;
@@ -77,6 +79,9 @@ export const Settings = ({ deviceID }: Props) => {
     <div className="contentWithGuide">
       <div className="container">
         <div className="innerContainer scrollableContainer">
+          <ContentWrapper>
+            <Banner msgKey="bitbox01" />
+          </ContentWrapper>
           <Header title={<h2>{name === null ? '' : name || 'BitBox'}</h2>} />
           <div className="content padded">
             <div className="columnsContainer">


### PR DESCRIPTION
In a recent release BitBox01 support has been dropped, except for backup management. For this reason the app navigates directly into BitBox01-settings. This view was missing the banners, especially the BitBox01 EOL banner.

Added BitBox01 EOL banner to BitBox01-settings.