### PR TITLE
Frontend fix factory reset

### DIFF
--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -181,6 +181,10 @@ export const Dialog = ({
   );
 };
 
+type DialogButtonsProps = {
+  children: React.ReactNode;
+}
+
 /**
  * ### Container to place buttons in a dialog
  *
@@ -199,11 +203,6 @@ export const Dialog = ({
  *   </Dialog>
  * ```
  */
-
-interface DialogButtonsProps {
-    children: React.ReactNode;
-}
-
 export const DialogButtons = ({ children }: DialogButtonsProps) => {
   return (
     <div className={style.dialogButtons}>{children}</div>

--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -47,36 +47,58 @@ export const Dialog = ({
   const [isVisible, setIsVisible] = useState(false);
   const [status, setStatus] = useState<'idle' | 'opening' | 'open' | 'closing'>('idle');
   const contentRef = useRef<HTMLDivElement>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useFocusTrap(contentRef, status === 'open');
 
-  // Mount/unmount lifecycle
+  /**
+   * Deactivate (close) animation handler.
+   * If fireOnClose = true, it means user action triggered the close,
+   * so we call onClose(). If false, it means parent controlled it, so skip.
+   */
+  const deactivate = useCallback((fireOnClose: boolean) => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+    }
+    setStatus('closing');
+
+    closeTimerRef.current = setTimeout(() => {
+      setIsVisible(false);
+      setStatus('idle');
+
+      if (fireOnClose && onClose) {
+        onClose();
+      }
+    }, 400); // match CSS transition
+
+    return () => {
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+      }
+    };
+  }, [onClose]);
+
+  // Handle external open state changes.
   useEffect(() => {
     if (open) {
       setIsVisible(true);
       setStatus('opening');
-      const id = setTimeout(() => setStatus('open'), 20); // let CSS transition start
+      const id = setTimeout(() => setStatus('open'), 20);
       return () => clearTimeout(id);
     } else if (isVisible) {
-      setStatus('closing');
-      const id = setTimeout(() => {
-        setIsVisible(false);
-        setStatus('idle');
-        onClose?.();
-      }, 400); // match CSS transition
-      return () => clearTimeout(id);
+      // When parent closes it (open=false), skip firing onClose again.
+      deactivate(false);
     }
-  }, [open, isVisible, onClose]);
+  }, [open, isVisible, deactivate]);
 
-  useEsc(() => open && onClose?.());
-
-  const closeHandler = useCallback(() => {
-    if (onClose !== undefined) {
-      return false;
+  // ESC closes dialog (fires onClose)
+  useEsc(() => {
+    if (open) {
+      deactivate(true);
     }
-    return true;
-  }, [onClose]);
+  });
 
+  // Overlay click closes dialog (fires onClose)
   const mouseDownTarget = useRef<EventTarget | null>(null);
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -85,14 +107,24 @@ export const Dialog = ({
 
   const handleMouseUp = (e: React.MouseEvent<HTMLDivElement>) => {
     if (
-      onClose
-      && mouseDownTarget.current === e.currentTarget // started on overlay
-      && e.target === e.currentTarget // ended on overlay
+      mouseDownTarget.current === e.currentTarget
+      && e.target === e.currentTarget
     ) {
-      onClose();
+      deactivate(true);
     }
     mouseDownTarget.current = null;
   };
+
+  // Close button handler
+  const handleCloseClick = useCallback(() => {
+    deactivate(true);
+  }, [deactivate]);
+
+  // Back button handler (mobile)
+  const closeHandler = useCallback(() => {
+    deactivate(true);
+    return false;
+  }, [deactivate]);
 
   if (!isVisible) {
     return null;
@@ -134,7 +166,7 @@ export const Dialog = ({
           <div className={headerClass}>
             <h3 className={style.title}>{title}</h3>
             {onClose && (
-              <button className={style.closeButton} onClick={onClose}>
+              <button className={style.closeButton} onClick={handleCloseClick}>
                 <CloseXDark className="show-in-lightmode" />
                 <CloseXWhite className="show-in-darkmode" />
               </button>
@@ -148,7 +180,6 @@ export const Dialog = ({
     </div>
   );
 };
-
 
 /**
  * ### Container to place buttons in a dialog

--- a/frontends/web/src/routes/settings/components/device-settings/factory-reset-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/factory-reset-setting.tsx
@@ -14,34 +14,22 @@
  * limitations under the License.
  */
 
+import { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { resetDevice } from '@/api/bitbox02';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
 import { WarningOutlined, PointToBitBox02 } from '@/components/icon';
 import { Dialog, DialogButtons } from '@/components/dialog/dialog';
 import { Button, Checkbox } from '@/components/forms';
-import { ChangeEvent, useState } from 'react';
-import { resetDevice } from '@/api/bitbox02';
 import { alertUser } from '@/components/alert/Alert';
-import styles from './factory-reset-setting.module.css';
 import { WaitDialog } from '@/components/wait-dialog/wait-dialog';
+import styles from './factory-reset-setting.module.css';
 
 type TProps = {
-    deviceID: string;
+  deviceID: string;
 }
 
-type TDialog = {
-    open: boolean;
-    handleCloseDialog: () => void;
-    understand: boolean;
-    handleUnderstandChange: (e: ChangeEvent<HTMLInputElement>) => void;
-    handleReset: () => void;
-}
-
-type TWaitDialog = {
-    isConfirming: boolean;
-}
-
-const FactoryResetSetting = ({ deviceID }: TProps) => {
+export const FactoryResetSetting = ({ deviceID }: TProps) => {
   const [understand, setUnderstand] = useState(false);
   const [isConfirming, setIsConfirming] = useState(false);
   const [activeDialog, setActiveDialog] = useState(false);
@@ -67,72 +55,44 @@ const FactoryResetSetting = ({ deviceID }: TProps) => {
     }
   };
 
-  const settingName = (<div className={styles.settingNameContainer}>
-    <WarningOutlined width={16} height={16} />
-    <p className={styles.settingName}>{t('deviceSettings.expert.factoryReset.title')}</p>
-  </div>);
-
   return (
     <>
       <SettingsItem
-        settingName={settingName}
+        settingName={
+          <div className={styles.settingNameContainer}>
+            <WarningOutlined width={16} height={16} />
+            <p className={styles.settingName}>
+              {t('deviceSettings.expert.factoryReset.title')}
+            </p>
+          </div>
+        }
         secondaryText={t('deviceSettings.expert.factoryReset.description')}
         onClick={() => setActiveDialog(true)}
       />
-      <FactoryResetDialog
+      <Dialog
         open={activeDialog}
-        handleCloseDialog={abort}
-        understand={understand}
-        handleUnderstandChange={handleUnderstandChange}
-        handleReset={reset}
-      />
-      <FactoryResetWaitDialog isConfirming={isConfirming} />
+        title={t('reset.title')}
+        onClose={abort}
+        small>
+        <p>{t('reset.description')}</p>
+        <Checkbox
+          id="reset_understand"
+          label={t('reset.understandBB02')}
+          checked={understand}
+          onChange={handleUnderstandChange} />
+        <DialogButtons>
+          <Button danger disabled={!understand} onClick={reset}>
+            {t('reset.title')}
+          </Button>
+        </DialogButtons>
+      </Dialog>
+      {isConfirming && (
+        <WaitDialog
+          title={t('reset.title')} >
+          {t('bitbox02Interact.followInstructions')}
+          <PointToBitBox02 />
+        </WaitDialog>
+      )}
     </>
-
   );
 };
-
-const FactoryResetDialog = ({
-  open,
-  handleCloseDialog,
-  understand,
-  handleUnderstandChange,
-  handleReset
-}: TDialog) => {
-  const { t } = useTranslation();
-  return (
-    <Dialog
-      open={open}
-      title={t('reset.title')}
-      onClose={handleCloseDialog}
-      small>
-      <p>{t('reset.description')}</p>
-      <Checkbox
-        id="reset_understand"
-        label={t('reset.understandBB02')}
-        checked={understand}
-        onChange={handleUnderstandChange} />
-      <DialogButtons>
-        <Button danger disabled={!understand} onClick={handleReset}>
-          {t('reset.title')}
-        </Button>
-      </DialogButtons>
-    </Dialog>);
-};
-
-const FactoryResetWaitDialog = ({ isConfirming }: TWaitDialog) => {
-  const { t } = useTranslation();
-  if (!isConfirming) {
-    return null;
-  }
-  return (
-    <WaitDialog
-      title={t('reset.title')} >
-      {t('bitbox02Interact.followInstructions')}
-      <PointToBitBox02 />
-    </WaitDialog>
-  );
-
-};
-
-export { FactoryResetSetting };


### PR DESCRIPTION
Fixed an issue with FactoryResetSetting where continuing to reset
the device should show a WaitDialog. But the simplified version in
a recent Dialog refactoring always called onClose as if the user
would aboard the workflow.

Regression introduced in:
- https://github.com/thisconnect/bitbox-wallet-app/commit/d5bb07888deac147a74b527c0251529f6ef0174f