### PR TITLE
tests: move Playwright CI to stock image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,13 @@ jobs:
           OS_NAME: linux
 
   playwright:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: test-lint
+    container:
+      # Keep this in sync with frontends/web/package-lock.json.
+      image: mcr.microsoft.com/playwright:v1.57.0-jammy
+      # This below is needed to be able to run docker in the CI.
+      options: --volume /var/run/docker.sock:/var/run/docker.sock --add-host=host.docker.internal:host-gateway
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +58,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends docker.io jq lsof python3-pip
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
       - name: Download simulator v9.24.0 from simulators.json
+        shell: bash
         run: |
           set -euo pipefail
           simulator_url=$(jq -r '.[] | select(.url | contains("firmware%2Fv9.24.0/")) | .url' backend/devices/bitbox02/testdata/simulators.json)
@@ -73,21 +89,12 @@ jobs:
       - name: Install dependencies
         run: |
           cd frontends/web
-          npm install
+          npm ci
 
       - name: Build frontend
         run: |
           cd frontends/web
           npm run build
-
-      - name: Install Playwright browsers
-        run: |
-          cd frontends/web
-          if [ "${{ matrix.project }}" = "Chromium" ]; then
-            npx playwright install --with-deps chromium
-          else
-            npx playwright install --with-deps webkit
-          fi
 
       - name: Setup Python 3
         uses: actions/setup-python@v6
@@ -96,11 +103,12 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install ecdsa bech32
+          python3 -m pip install ecdsa bech32 pycryptodome
 
       - name: Run Playwright tests
         env:
           PLAYWRIGHT_USE_PREBUILT_WEB: "1"
+          REGTEST_ELECTRUM_HOST: host.docker.internal
           SIMULATOR_PATH: ${{ github.workspace }}/simulator-bin/simulator
         run: cd frontends/web && npx playwright test --project="${{ matrix.project }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,13 @@ jobs:
           OS_NAME: linux
 
   playwright:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: test-lint
+    container:
+      # Keep this in sync with frontends/web/package.json.
+      image: mcr.microsoft.com/playwright:v1.60.0-jammy
+      # This below is needed to be able to run docker in the CI.
+      options: --volume /var/run/docker.sock:/var/run/docker.sock --add-host=host.docker.internal:host-gateway
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +58,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends docker.io jq lsof python3-pip
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
       - name: Download simulator v9.24.0 from simulators.json
+        shell: bash
         run: |
           set -euo pipefail
           simulator_url=$(jq -r '.[] | select(.url | contains("firmware%2Fv9.24.0/")) | .url' backend/devices/bitbox02/testdata/simulators.json)
@@ -80,15 +96,6 @@ jobs:
           cd frontends/web
           npm run build
 
-      - name: Install Playwright browsers
-        run: |
-          cd frontends/web
-          if [ "${{ matrix.project }}" = "Chromium" ]; then
-            npx playwright install --with-deps chromium
-          else
-            npx playwright install --with-deps webkit
-          fi
-
       - name: Setup Python 3
         uses: actions/setup-python@v6
         with:
@@ -96,11 +103,12 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install ecdsa bech32
+          python3 -m pip install ecdsa bech32 pycryptodome
 
       - name: Run Playwright tests
         env:
           PLAYWRIGHT_USE_PREBUILT_WEB: "1"
+          REGTEST_ELECTRUM_HOST: host.docker.internal
           SIMULATOR_PATH: ${{ github.workspace }}/simulator-bin/simulator
         run: cd frontends/web && npx playwright test --project="${{ matrix.project }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
   playwright:
     runs-on: ubuntu-latest
     needs: test-lint
+    container:
+      # Keep this in sync with frontends/web/package.json.
+      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      # This below is needed to be able to run docker in the CI.
+      options: --volume /var/run/docker.sock:/var/run/docker.sock --add-host=host.docker.internal:host-gateway
     strategy:
       fail-fast: false
       matrix:
@@ -53,11 +58,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download simulator v9.24.0 from simulators.json
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends docker.io jq lsof python3-pip
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Download simulator v9.26.1 from simulators.json
+        shell: bash
         run: |
           set -euo pipefail
-          simulator_url=$(jq -r '.[] | select(.url | contains("firmware%2Fv9.24.0/")) | .url' backend/devices/bitbox02/testdata/simulators.json)
-          simulator_sha=$(jq -r '.[] | select(.url | contains("firmware%2Fv9.24.0/")) | .sha256' backend/devices/bitbox02/testdata/simulators.json)
+          simulator_url=$(jq -r '.[] | select(.url | contains("firmware%2Fv9.26.1/")) | .url' backend/devices/bitbox02/testdata/simulators.json)
+          simulator_sha=$(jq -r '.[] | select(.url | contains("firmware%2Fv9.26.1/")) | .sha256' backend/devices/bitbox02/testdata/simulators.json)
           mkdir -p simulator-bin
           curl -L "$simulator_url" -o simulator-bin/simulator
           echo "$simulator_sha  simulator-bin/simulator" | sha256sum -c -
@@ -80,15 +96,6 @@ jobs:
           cd frontends/web
           npm run build
 
-      - name: Install Playwright browsers
-        run: |
-          cd frontends/web
-          if [ "${{ matrix.project }}" = "Chromium" ]; then
-            npx playwright install --with-deps chromium
-          else
-            npx playwright install --with-deps webkit
-          fi
-
       - name: Setup Python 3
         uses: actions/setup-python@v6
         with:
@@ -96,11 +103,12 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install ecdsa bech32
+          python3 -m pip install ecdsa bech32 pycryptodome
 
       - name: Run Playwright tests
         env:
           PLAYWRIGHT_USE_PREBUILT_WEB: "1"
+          REGTEST_ELECTRUM_HOST: host.docker.internal
           SIMULATOR_PATH: ${{ github.workspace }}/simulator-bin/simulator
         run: cd frontends/web && npx playwright test --project="${{ matrix.project }}"
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -490,9 +490,15 @@ mCMuGBNHsbrs6rI1hbI4Qq6GYazLaDRqdCufTA==
 	case coinpkg.CodeTBTC:
 		return []*config.ServerInfo{{Server: "tbtc1.shiftcrypto.dev:443", TLS: true, PEMCert: devShiftCA}}
 	case coinpkg.CodeRBTC:
+		// In Github CI we can't use 127.0.0.1 so we need to pass
+		// the host name through an env variable.
+		host := os.Getenv("REGTEST_ELECTRUM_HOST")
+		if host == "" {
+			host = "127.0.0.1"
+		}
 		return []*config.ServerInfo{
-			{Server: "127.0.0.1:52001", TLS: false, PEMCert: ""},
-			{Server: "127.0.0.1:52002", TLS: false, PEMCert: ""},
+			{Server: fmt.Sprintf("%s:52001", host), TLS: false, PEMCert: ""},
+			{Server: fmt.Sprintf("%s:52002", host), TLS: false, PEMCert: ""},
 		}
 	case coinpkg.CodeLTC:
 		return []*config.ServerInfo{{Server: "ltc1.shiftcrypto.dev:443", TLS: true, PEMCert: devShiftCA}}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -499,9 +499,15 @@ mCMuGBNHsbrs6rI1hbI4Qq6GYazLaDRqdCufTA==
 	case coinpkg.CodeTBTC:
 		return []*config.ServerInfo{{Server: "tbtc1.shiftcrypto.dev:443", TLS: true, PEMCert: devShiftCA}}
 	case coinpkg.CodeRBTC:
+		// In Github CI we can't use 127.0.0.1 so we need to pass
+		// the host name through an env variable.
+		host := os.Getenv("REGTEST_ELECTRUM_HOST")
+		if host == "" {
+			host = "127.0.0.1"
+		}
 		return []*config.ServerInfo{
-			{Server: "127.0.0.1:52001", TLS: false, PEMCert: ""},
-			{Server: "127.0.0.1:52002", TLS: false, PEMCert: ""},
+			{Server: fmt.Sprintf("%s:52001", host), TLS: false, PEMCert: ""},
+			{Server: fmt.Sprintf("%s:52002", host), TLS: false, PEMCert: ""},
 		}
 	case coinpkg.CodeLTC:
 		return []*config.ServerInfo{{Server: "ltc1.shiftcrypto.dev:443", TLS: true, PEMCert: devShiftCA}}

--- a/frontends/web/tests/helpers/regtest.ts
+++ b/frontends/web/tests/helpers/regtest.ts
@@ -14,6 +14,9 @@ const DATADIR = '/bitcoin';
 const BITCOIND_CONTAINER = 'bitcoind-regtest';
 const ELECTRS_CONTAINER1 = 'electrs-regtest1';
 const ELECTRS_CONTAINER2 = 'electrs-regtest2';
+const BITCOIND_VOLUME = 'bitcoind-regtest-data';
+const ELECTRS_VOLUME1 = 'electrs-regtest-data1';
+const ELECTRS_VOLUME2 = 'electrs-regtest-data2';
 const BTC_DATA_DIR = '/tmp/regtest/btcdata';
 const ELECTRS_DATA_DIR1 = '/tmp/regtest/electrsdata1';
 const ELECTRS_DATA_DIR2 = '/tmp/regtest/electrsdata2';
@@ -74,6 +77,14 @@ docker container rm -f ${BITCOIND_CONTAINER} ${ELECTRS_CONTAINER1} ${ELECTRS_CON
 `);
   } catch (err) {
     console.warn('Docker cleanup failed:', err);
+  }
+
+  try {
+    await execAsync(`
+docker volume rm -f ${BITCOIND_VOLUME} ${ELECTRS_VOLUME1} ${ELECTRS_VOLUME2} >/dev/null 2>&1 || true
+`);
+  } catch (err) {
+    console.warn('Docker volume cleanup failed:', err);
   }
 
   for (const dir of [BTC_DATA_DIR, ELECTRS_DATA_DIR1, ELECTRS_DATA_DIR2]) {

--- a/frontends/web/tests/util/aopp/server.py
+++ b/frontends/web/tests/util/aopp/server.py
@@ -11,6 +11,11 @@ from urllib.parse import urlparse, parse_qs
 from ecdsa import VerifyingKey, SECP256k1, util
 from bech32 import bech32_encode, convertbits
 
+try:
+    from Crypto.Hash import RIPEMD160
+except ImportError:
+    RIPEMD160 = None
+
 # In-memory store
 requests_store = {}
 REGTEST_NET = "regtest"
@@ -54,7 +59,12 @@ def pubkey_to_p2wpkh_address(pubkey_bytes: bytes, network: str = "regtest") -> s
     Format: bech32(HRP, [WitnessVersion(0)] + WitnessProgram)
     """
     sha256_digest = hashlib.sha256(pubkey_bytes).digest()
-    h160 = hashlib.new('ripemd160', sha256_digest).digest()
+    try:
+        h160 = hashlib.new('ripemd160', sha256_digest).digest()
+    except (ValueError, TypeError):
+        if RIPEMD160 is None:
+            raise
+        h160 = RIPEMD160.new(sha256_digest).digest()
     data = convertbits(h160, 8, 5)
 
     # Prepend Witness Version 0
@@ -75,7 +85,8 @@ def verify_address_ownership(r_s_bytes: bytes, message_digest: bytes, expected_a
             r_s_bytes,
             message_digest,
             curve=SECP256k1,
-            hashfunc=hashlib.sha256
+            hashfunc=hashlib.sha256,
+            sigdecode=util.sigdecode_string,
         )
 
         for vk in candidates:
@@ -94,9 +105,7 @@ def verify_address_ownership(r_s_bytes: bytes, message_digest: bytes, expected_a
         return False
 
 # --- HTTP Request Handler ---
-
 class AOPPRequestHandler(http.server.BaseHTTPRequestHandler):
-
     def _send_response(self, status_code, body=None):
         self.send_response(status_code)
         if body:

--- a/scripts/run_regtest.sh
+++ b/scripts/run_regtest.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -e
 # SPDX-License-Identifier: Apache-2.0
 
-BITCOIN_DATADIR="/tmp/regtest/btcdata"
-ELECTRS_DATADIR1="/tmp/regtest/electrsdata1"
-ELECTRS_DATADIR2="/tmp/regtest/electrsdata2"
 BITCOIND_CONTAINER_NAME="bitcoind-regtest"
 ELECTRS_CONTAINER_NAME1="electrs-regtest1"
 ELECTRS_CONTAINER_NAME2="electrs-regtest2"
+BITCOIND_VOLUME_NAME="bitcoind-regtest-data"
+ELECTRS_VOLUME_NAME1="electrs-regtest-data1"
+ELECTRS_VOLUME_NAME2="electrs-regtest-data2"
 
 trap 'killall' EXIT
 
@@ -14,7 +14,9 @@ cleanup_leftovers() {
     docker rm -f "$BITCOIND_CONTAINER_NAME" >/dev/null 2>&1 || true
     docker rm -f "$ELECTRS_CONTAINER_NAME1" >/dev/null 2>&1 || true
     docker rm -f "$ELECTRS_CONTAINER_NAME2" >/dev/null 2>&1 || true
-    rm -rf "$BITCOIN_DATADIR" "$ELECTRS_DATADIR1" "$ELECTRS_DATADIR2"
+    docker volume rm -f "$BITCOIND_VOLUME_NAME" >/dev/null 2>&1 || true
+    docker volume rm -f "$ELECTRS_VOLUME_NAME1" >/dev/null 2>&1 || true
+    docker volume rm -f "$ELECTRS_VOLUME_NAME2" >/dev/null 2>&1 || true
 }
 
 killall() {
@@ -29,14 +31,14 @@ killall() {
 
 cleanup_leftovers
 
-mkdir -p "$BITCOIN_DATADIR"
-mkdir -p "$ELECTRS_DATADIR1"
-mkdir -p "$ELECTRS_DATADIR2"
-echo -n "dbb:dbb" > "$ELECTRS_DATADIR1/rpccreds"
-echo -n "dbb:dbb" > "$ELECTRS_DATADIR2/rpccreds"
-echo "bitcoind datadir: ${BITCOIN_DATADIR}"
-echo "electrs datadir1: ${ELECTRS_DATADIR1}"
-echo "electrs datadir2: ${ELECTRS_DATADIR2}"
+docker volume create "$BITCOIND_VOLUME_NAME" >/dev/null
+docker volume create "$ELECTRS_VOLUME_NAME1" >/dev/null
+docker volume create "$ELECTRS_VOLUME_NAME2" >/dev/null
+
+docker run --rm -v "${ELECTRS_VOLUME_NAME1}:/data" alpine:3.20 \
+       sh -lc 'echo -n "dbb:dbb" > /data/rpccreds'
+docker run --rm -v "${ELECTRS_VOLUME_NAME2}:/data" alpine:3.20 \
+       sh -lc 'echo -n "dbb:dbb" > /data/rpccreds'
 
 # Default docker bridge.
 DOCKER_IP="172.17.0.1"
@@ -44,12 +46,14 @@ BITCOIND_PORT=12340
 BITCOIND_RPC_PORT=10332
 ELECTRS_RPC_PORT1=52001
 ELECTRS_RPC_PORT2=52002
+ELECTRS_MONITORING_PORT1=24224
 ELECTRS_MONITORING_PORT2=24225
 
-docker run -v "$BITCOIN_DATADIR:/bitcoin/.bitcoin" --name="$BITCOIND_CONTAINER_NAME" \
+docker run -v "${BITCOIND_VOLUME_NAME}:/bitcoin/.bitcoin" --name="$BITCOIND_CONTAINER_NAME" \
        -p ${BITCOIND_RPC_PORT}:${BITCOIND_RPC_PORT} \
        -p ${BITCOIND_PORT}:${BITCOIND_PORT} \
        bitcoin/bitcoin:30.0 \
+       -datadir=/bitcoin \
        -regtest \
        -fallbackfee=0.00001 \
        -port=${BITCOIND_PORT} \
@@ -64,9 +68,10 @@ sleep 1
 
 docker run \
        -u $(id -u $USER) \
-       --net=host \
-       -v "$BITCOIN_DATADIR/.bitcoin:/bitcoin/.bitcoin" \
-       -v "$ELECTRS_DATADIR1:/data" \
+       -p ${ELECTRS_RPC_PORT1}:${ELECTRS_RPC_PORT1} \
+       -p ${ELECTRS_MONITORING_PORT1}:${ELECTRS_MONITORING_PORT1} \
+       -v "${BITCOIND_VOLUME_NAME}:/bitcoin/.bitcoin" \
+       -v "${ELECTRS_VOLUME_NAME1}:/data" \
        --name="$ELECTRS_CONTAINER_NAME1" \
        benma2/electrs:v0.10.10 \
         --cookie-file=/data/rpccreds \
@@ -74,15 +79,17 @@ docker run \
         --network=regtest \
         --daemon-rpc-addr=${DOCKER_IP}:${BITCOIND_RPC_PORT} \
         --daemon-p2p-addr=${DOCKER_IP}:${BITCOIND_PORT} \
-        --electrum-rpc-addr=127.0.0.1:${ELECTRS_RPC_PORT1} \
+        --electrum-rpc-addr=0.0.0.0:${ELECTRS_RPC_PORT1} \
+        --monitoring-addr=0.0.0.0:${ELECTRS_MONITORING_PORT1} \
         --daemon-dir=/bitcoin/.bitcoin \
         --db-dir=/data &
 
 docker run \
        -u $(id -u $USER) \
-       --net=host \
-       -v "$BITCOIN_DATADIR/.bitcoin:/bitcoin/.bitcoin" \
-       -v "$ELECTRS_DATADIR2:/data" \
+       -p ${ELECTRS_RPC_PORT2}:${ELECTRS_RPC_PORT2} \
+       -p ${ELECTRS_MONITORING_PORT2}:${ELECTRS_MONITORING_PORT2} \
+       -v "${BITCOIND_VOLUME_NAME}:/bitcoin/.bitcoin" \
+       -v "${ELECTRS_VOLUME_NAME2}:/data" \
        --name="$ELECTRS_CONTAINER_NAME2" \
        benma2/electrs:v0.10.10 \
         --cookie-file=/data/rpccreds \
@@ -90,8 +97,8 @@ docker run \
         --network=regtest \
         --daemon-rpc-addr=${DOCKER_IP}:${BITCOIND_RPC_PORT} \
         --daemon-p2p-addr=${DOCKER_IP}:${BITCOIND_PORT} \
-        --electrum-rpc-addr=127.0.0.1:${ELECTRS_RPC_PORT2} \
-        --monitoring-addr=127.0.0.1:${ELECTRS_MONITORING_PORT2} \
+        --electrum-rpc-addr=0.0.0.0:${ELECTRS_RPC_PORT2} \
+        --monitoring-addr=0.0.0.0:${ELECTRS_MONITORING_PORT2} \
         --daemon-dir=/bitcoin/.bitcoin \
         --db-dir=/data &
 

--- a/scripts/run_regtest.sh
+++ b/scripts/run_regtest.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -e
 # SPDX-License-Identifier: Apache-2.0
 
-BITCOIN_DATADIR="/tmp/regtest/btcdata"
-ELECTRS_DATADIR1="/tmp/regtest/electrsdata1"
-ELECTRS_DATADIR2="/tmp/regtest/electrsdata2"
 BITCOIND_CONTAINER_NAME="bitcoind-regtest"
 ELECTRS_CONTAINER_NAME1="electrs-regtest1"
 ELECTRS_CONTAINER_NAME2="electrs-regtest2"
+BITCOIND_VOLUME_NAME="bitcoind-regtest-data"
+ELECTRS_VOLUME_NAME1="electrs-regtest-data1"
+ELECTRS_VOLUME_NAME2="electrs-regtest-data2"
 
 trap 'killall' EXIT
 
@@ -14,7 +14,9 @@ cleanup_leftovers() {
     docker rm -f "$BITCOIND_CONTAINER_NAME" >/dev/null 2>&1 || true
     docker rm -f "$ELECTRS_CONTAINER_NAME1" >/dev/null 2>&1 || true
     docker rm -f "$ELECTRS_CONTAINER_NAME2" >/dev/null 2>&1 || true
-    rm -rf "$BITCOIN_DATADIR" "$ELECTRS_DATADIR1" "$ELECTRS_DATADIR2"
+    docker volume rm -f "$BITCOIND_VOLUME_NAME" >/dev/null 2>&1 || true
+    docker volume rm -f "$ELECTRS_VOLUME_NAME1" >/dev/null 2>&1 || true
+    docker volume rm -f "$ELECTRS_VOLUME_NAME2" >/dev/null 2>&1 || true
 }
 
 killall() {
@@ -29,14 +31,14 @@ killall() {
 
 cleanup_leftovers
 
-mkdir -p "$BITCOIN_DATADIR"
-mkdir -p "$ELECTRS_DATADIR1"
-mkdir -p "$ELECTRS_DATADIR2"
-echo -n "dbb:dbb" > "$ELECTRS_DATADIR1/rpccreds"
-echo -n "dbb:dbb" > "$ELECTRS_DATADIR2/rpccreds"
-echo "bitcoind datadir: ${BITCOIN_DATADIR}"
-echo "electrs datadir1: ${ELECTRS_DATADIR1}"
-echo "electrs datadir2: ${ELECTRS_DATADIR2}"
+docker volume create "$BITCOIND_VOLUME_NAME" >/dev/null
+docker volume create "$ELECTRS_VOLUME_NAME1" >/dev/null
+docker volume create "$ELECTRS_VOLUME_NAME2" >/dev/null
+
+docker run --rm -v "${ELECTRS_VOLUME_NAME1}:/data" alpine:3.20 \
+       sh -lc 'echo -n "dbb:dbb" > /data/rpccreds'
+docker run --rm -v "${ELECTRS_VOLUME_NAME2}:/data" alpine:3.20 \
+       sh -lc 'echo -n "dbb:dbb" > /data/rpccreds'
 
 # Default docker bridge.
 DOCKER_IP="172.17.0.1"
@@ -44,12 +46,14 @@ BITCOIND_PORT=12340
 BITCOIND_RPC_PORT=10332
 ELECTRS_RPC_PORT1=52001
 ELECTRS_RPC_PORT2=52002
+ELECTRS_MONITORING_PORT1=24224
 ELECTRS_MONITORING_PORT2=24225
 
-docker run -v "$BITCOIN_DATADIR:/bitcoin/.bitcoin" --name="$BITCOIND_CONTAINER_NAME" \
+docker run -v "${BITCOIND_VOLUME_NAME}:/bitcoin/.bitcoin" --name="$BITCOIND_CONTAINER_NAME" \
        -p ${BITCOIND_RPC_PORT}:${BITCOIND_RPC_PORT} \
        -p ${BITCOIND_PORT}:${BITCOIND_PORT} \
        bitcoin/bitcoin:30.0 \
+       -datadir=/bitcoin \
        -regtest \
        -fallbackfee=0.00001 \
        -port=${BITCOIND_PORT} \
@@ -63,10 +67,11 @@ docker run -v "$BITCOIN_DATADIR:/bitcoin/.bitcoin" --name="$BITCOIND_CONTAINER_N
 sleep 1
 
 docker run \
-       -u $(id -u $USER) \
-       --net=host \
-       -v "$BITCOIN_DATADIR/.bitcoin:/bitcoin/.bitcoin" \
-       -v "$ELECTRS_DATADIR1:/data" \
+       -u "$(id -u "$USER")" \
+       -p ${ELECTRS_RPC_PORT1}:${ELECTRS_RPC_PORT1} \
+       -p ${ELECTRS_MONITORING_PORT1}:${ELECTRS_MONITORING_PORT1} \
+       -v "${BITCOIND_VOLUME_NAME}:/bitcoin/.bitcoin" \
+       -v "${ELECTRS_VOLUME_NAME1}:/data" \
        --name="$ELECTRS_CONTAINER_NAME1" \
        benma2/electrs:v0.10.10 \
         --cookie-file=/data/rpccreds \
@@ -74,15 +79,17 @@ docker run \
         --network=regtest \
         --daemon-rpc-addr=${DOCKER_IP}:${BITCOIND_RPC_PORT} \
         --daemon-p2p-addr=${DOCKER_IP}:${BITCOIND_PORT} \
-        --electrum-rpc-addr=127.0.0.1:${ELECTRS_RPC_PORT1} \
+        --electrum-rpc-addr=0.0.0.0:${ELECTRS_RPC_PORT1} \
+        --monitoring-addr=0.0.0.0:${ELECTRS_MONITORING_PORT1} \
         --daemon-dir=/bitcoin/.bitcoin \
         --db-dir=/data &
 
 docker run \
-       -u $(id -u $USER) \
-       --net=host \
-       -v "$BITCOIN_DATADIR/.bitcoin:/bitcoin/.bitcoin" \
-       -v "$ELECTRS_DATADIR2:/data" \
+       -u "$(id -u "$USER")" \
+       -p ${ELECTRS_RPC_PORT2}:${ELECTRS_RPC_PORT2} \
+       -p ${ELECTRS_MONITORING_PORT2}:${ELECTRS_MONITORING_PORT2} \
+       -v "${BITCOIND_VOLUME_NAME}:/bitcoin/.bitcoin" \
+       -v "${ELECTRS_VOLUME_NAME2}:/data" \
        --name="$ELECTRS_CONTAINER_NAME2" \
        benma2/electrs:v0.10.10 \
         --cookie-file=/data/rpccreds \
@@ -90,8 +97,8 @@ docker run \
         --network=regtest \
         --daemon-rpc-addr=${DOCKER_IP}:${BITCOIND_RPC_PORT} \
         --daemon-p2p-addr=${DOCKER_IP}:${BITCOIND_PORT} \
-        --electrum-rpc-addr=127.0.0.1:${ELECTRS_RPC_PORT2} \
-        --monitoring-addr=127.0.0.1:${ELECTRS_MONITORING_PORT2} \
+        --electrum-rpc-addr=0.0.0.0:${ELECTRS_RPC_PORT2} \
+        --monitoring-addr=0.0.0.0:${ELECTRS_MONITORING_PORT2} \
         --daemon-dir=/bitcoin/.bitcoin \
         --db-dir=/data &
 

--- a/scripts/run_regtest.sh
+++ b/scripts/run_regtest.sh
@@ -1,12 +1,13 @@
 #!/bin/bash -e
 # SPDX-License-Identifier: Apache-2.0
 
-BITCOIN_DATADIR="/tmp/regtest/btcdata"
-ELECTRS_DATADIR1="/tmp/regtest/electrsdata1"
-ELECTRS_DATADIR2="/tmp/regtest/electrsdata2"
 BITCOIND_CONTAINER_NAME="bitcoind-regtest"
 ELECTRS_CONTAINER_NAME1="electrs-regtest1"
 ELECTRS_CONTAINER_NAME2="electrs-regtest2"
+BITCOIND_VOLUME_NAME="bitcoind-regtest-data"
+ELECTRS_VOLUME_NAME1="electrs-regtest-data1"
+ELECTRS_VOLUME_NAME2="electrs-regtest-data2"
+ELECTRS_UID="$(id -u)"
 
 trap 'killall' EXIT
 
@@ -14,7 +15,9 @@ cleanup_leftovers() {
     docker rm -f "$BITCOIND_CONTAINER_NAME" >/dev/null 2>&1 || true
     docker rm -f "$ELECTRS_CONTAINER_NAME1" >/dev/null 2>&1 || true
     docker rm -f "$ELECTRS_CONTAINER_NAME2" >/dev/null 2>&1 || true
-    rm -rf "$BITCOIN_DATADIR" "$ELECTRS_DATADIR1" "$ELECTRS_DATADIR2"
+    docker volume rm -f "$BITCOIND_VOLUME_NAME" >/dev/null 2>&1 || true
+    docker volume rm -f "$ELECTRS_VOLUME_NAME1" >/dev/null 2>&1 || true
+    docker volume rm -f "$ELECTRS_VOLUME_NAME2" >/dev/null 2>&1 || true
 }
 
 killall() {
@@ -29,14 +32,16 @@ killall() {
 
 cleanup_leftovers
 
-mkdir -p "$BITCOIN_DATADIR"
-mkdir -p "$ELECTRS_DATADIR1"
-mkdir -p "$ELECTRS_DATADIR2"
-echo -n "dbb:dbb" > "$ELECTRS_DATADIR1/rpccreds"
-echo -n "dbb:dbb" > "$ELECTRS_DATADIR2/rpccreds"
-echo "bitcoind datadir: ${BITCOIN_DATADIR}"
-echo "electrs datadir1: ${ELECTRS_DATADIR1}"
-echo "electrs datadir2: ${ELECTRS_DATADIR2}"
+docker volume create "$BITCOIND_VOLUME_NAME" >/dev/null
+docker volume create "$ELECTRS_VOLUME_NAME1" >/dev/null
+docker volume create "$ELECTRS_VOLUME_NAME2" >/dev/null
+
+docker run --rm -e ELECTRS_UID="$ELECTRS_UID" \
+       -v "${ELECTRS_VOLUME_NAME1}:/data" alpine:3.20 \
+       sh -lc 'echo -n "dbb:dbb" > /data/rpccreds && chown -R "$ELECTRS_UID" /data'
+docker run --rm -e ELECTRS_UID="$ELECTRS_UID" \
+       -v "${ELECTRS_VOLUME_NAME2}:/data" alpine:3.20 \
+       sh -lc 'echo -n "dbb:dbb" > /data/rpccreds && chown -R "$ELECTRS_UID" /data'
 
 # Default docker bridge.
 DOCKER_IP="172.17.0.1"
@@ -44,12 +49,14 @@ BITCOIND_PORT=12340
 BITCOIND_RPC_PORT=10332
 ELECTRS_RPC_PORT1=52001
 ELECTRS_RPC_PORT2=52002
+ELECTRS_MONITORING_PORT1=24224
 ELECTRS_MONITORING_PORT2=24225
 
-docker run -v "$BITCOIN_DATADIR:/bitcoin/.bitcoin" --name="$BITCOIND_CONTAINER_NAME" \
+docker run -v "${BITCOIND_VOLUME_NAME}:/bitcoin/.bitcoin" --name="$BITCOIND_CONTAINER_NAME" \
        -p ${BITCOIND_RPC_PORT}:${BITCOIND_RPC_PORT} \
        -p ${BITCOIND_PORT}:${BITCOIND_PORT} \
        bitcoin/bitcoin:30.0 \
+       -datadir=/bitcoin \
        -regtest \
        -fallbackfee=0.00001 \
        -port=${BITCOIND_PORT} \
@@ -63,10 +70,11 @@ docker run -v "$BITCOIN_DATADIR:/bitcoin/.bitcoin" --name="$BITCOIND_CONTAINER_N
 sleep 1
 
 docker run \
-       -u $(id -u $USER) \
-       --net=host \
-       -v "$BITCOIN_DATADIR/.bitcoin:/bitcoin/.bitcoin" \
-       -v "$ELECTRS_DATADIR1:/data" \
+       -u "$ELECTRS_UID" \
+       -p ${ELECTRS_RPC_PORT1}:${ELECTRS_RPC_PORT1} \
+       -p ${ELECTRS_MONITORING_PORT1}:${ELECTRS_MONITORING_PORT1} \
+       -v "${BITCOIND_VOLUME_NAME}:/bitcoin/.bitcoin" \
+       -v "${ELECTRS_VOLUME_NAME1}:/data" \
        --name="$ELECTRS_CONTAINER_NAME1" \
        benma2/electrs:v0.10.10 \
         --cookie-file=/data/rpccreds \
@@ -74,15 +82,17 @@ docker run \
         --network=regtest \
         --daemon-rpc-addr=${DOCKER_IP}:${BITCOIND_RPC_PORT} \
         --daemon-p2p-addr=${DOCKER_IP}:${BITCOIND_PORT} \
-        --electrum-rpc-addr=127.0.0.1:${ELECTRS_RPC_PORT1} \
+        --electrum-rpc-addr=0.0.0.0:${ELECTRS_RPC_PORT1} \
+        --monitoring-addr=0.0.0.0:${ELECTRS_MONITORING_PORT1} \
         --daemon-dir=/bitcoin/.bitcoin \
         --db-dir=/data &
 
 docker run \
-       -u $(id -u $USER) \
-       --net=host \
-       -v "$BITCOIN_DATADIR/.bitcoin:/bitcoin/.bitcoin" \
-       -v "$ELECTRS_DATADIR2:/data" \
+       -u "$ELECTRS_UID" \
+       -p ${ELECTRS_RPC_PORT2}:${ELECTRS_RPC_PORT2} \
+       -p ${ELECTRS_MONITORING_PORT2}:${ELECTRS_MONITORING_PORT2} \
+       -v "${BITCOIND_VOLUME_NAME}:/bitcoin/.bitcoin" \
+       -v "${ELECTRS_VOLUME_NAME2}:/data" \
        --name="$ELECTRS_CONTAINER_NAME2" \
        benma2/electrs:v0.10.10 \
         --cookie-file=/data/rpccreds \
@@ -90,8 +100,8 @@ docker run \
         --network=regtest \
         --daemon-rpc-addr=${DOCKER_IP}:${BITCOIND_RPC_PORT} \
         --daemon-p2p-addr=${DOCKER_IP}:${BITCOIND_PORT} \
-        --electrum-rpc-addr=127.0.0.1:${ELECTRS_RPC_PORT2} \
-        --monitoring-addr=127.0.0.1:${ELECTRS_MONITORING_PORT2} \
+        --electrum-rpc-addr=0.0.0.0:${ELECTRS_RPC_PORT2} \
+        --monitoring-addr=0.0.0.0:${ELECTRS_MONITORING_PORT2} \
         --daemon-dir=/bitcoin/.bitcoin \
         --db-dir=/data &
 


### PR DESCRIPTION
Run the Playwright job in the upstream Playwright container and adapt the regtest/AOPP  test setup to that environment.

Running on the Playwright container saves us the step of installing browsers, which can take a few minutes; sometimes, depending on network conditions, even up to 15.

Install the missing CI dependencies, make the regtest services reachable from the containerized job, add an RBTC electrum host override for CI, and harden the AOPP helper for raw signature recovery and missing RIPEMD160 support.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
