### PR TITLE
lightning: synchronize sdk service access

### DIFF
--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
@@ -38,6 +39,7 @@ type Lightning struct {
 
 	log          *logrus.Entry
 	sdkService   *breez_sdk_spark.BreezSdk
+	sdkServiceMu sync.RWMutex
 	sparkStatus  func() (breez_sdk_spark.SparkStatus, error)
 	httpClient   *http.Client
 	ratesUpdater *rates.RateUpdater
@@ -120,6 +122,9 @@ func (lightning *Lightning) Connect() {
 
 // Disconnect closes an active Breez SDK instance. After this, no requests should be made.
 func (lightning *Lightning) Disconnect() {
+	lightning.sdkServiceMu.Lock()
+	defer lightning.sdkServiceMu.Unlock()
+
 	if lightning.sdkService != nil {
 		if err := lightning.sdkService.Disconnect(); err != nil {
 			lightning.log.WithError(err).Warn("BreezSDK: Error disconnecting SDK")
@@ -129,6 +134,13 @@ func (lightning *Lightning) Disconnect() {
 		lightning.sdkService = nil
 		lightning.synced = false
 	}
+}
+
+func (lightning *Lightning) activeSDKLocked() (*breez_sdk_spark.BreezSdk, error) {
+	if lightning.Account() == nil || lightning.sdkService == nil {
+		return nil, errp.New("Lightning not initialized")
+	}
+	return lightning.sdkService, nil
 }
 
 // Deactivate disconnects the instance, deletes cache folder and changes the config to inactive.
@@ -154,25 +166,29 @@ func (lightning *Lightning) Deactivate() error {
 
 // CheckActive returns an error if the lightning service has not been activated.
 func (lightning *Lightning) CheckActive() error {
-	if lightning.Account() == nil || lightning.sdkService == nil {
-		return errp.New("Lightning not initialized")
-	}
-	return nil
+	lightning.sdkServiceMu.RLock()
+	defer lightning.sdkServiceMu.RUnlock()
+
+	_, err := lightning.activeSDKLocked()
+	return err
 }
 
 // Balance returns the balance of the lightning account.
 func (lightning *Lightning) Balance() (*accounts.Balance, error) {
-	if err := lightning.CheckActive(); err != nil {
+	lightning.sdkServiceMu.RLock()
+	defer lightning.sdkServiceMu.RUnlock()
+
+	sdkService, err := lightning.activeSDKLocked()
+	if err != nil {
 		return nil, err
 	}
 
 	ensureSynced := false
-	info, err := lightning.sdkService.GetInfo(breez_sdk_spark.GetInfoRequest{
+	info, err := sdkService.GetInfo(breez_sdk_spark.GetInfoRequest{
 		// EnsureSynced: true will ensure the SDK is synced with the Spark network
 		// before returning the balance
 		EnsureSynced: &ensureSynced,
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -227,6 +243,9 @@ func accountBreezFolder(accountCode types.Code) string {
 
 // connect initializes the connection configuration and calls connect to create a Breez SDK instance.
 func (lightning *Lightning) connect(_ bool) error {
+	lightning.sdkServiceMu.Lock()
+	defer lightning.sdkServiceMu.Unlock()
+
 	account := lightning.Account()
 
 	if account != nil && lightning.sdkService == nil {

--- a/backend/lightning/payments.go
+++ b/backend/lightning/payments.go
@@ -62,10 +62,14 @@ type paymentFee struct {
 
 // ParsePaymentInput validates and classifies a lightning input string.
 func (lightning *Lightning) ParsePaymentInput(inputStr string) (*parsePaymentInputResponse, error) {
-	if err := lightning.CheckActive(); err != nil {
+	lightning.sdkServiceMu.RLock()
+	defer lightning.sdkServiceMu.RUnlock()
+
+	sdkService, err := lightning.activeSDKLocked()
+	if err != nil {
 		return nil, err
 	}
-	input, err := lightning.sdkService.Parse(inputStr)
+	input, err := sdkService.Parse(inputStr)
 	if err != nil {
 		return nil, err
 	}
@@ -243,10 +247,14 @@ func checkApprovedPaymentFee(fee uint64, approvedFee uint64) error {
 
 // PreparePayment computes the fee quote for the provided payment request.
 func (lightning *Lightning) PreparePayment(paymentInvoice string, amountSat *uint64) (*paymentFee, error) {
-	if err := lightning.CheckActive(); err != nil {
+	lightning.sdkServiceMu.RLock()
+	defer lightning.sdkServiceMu.RUnlock()
+
+	sdkService, err := lightning.activeSDKLocked()
+	if err != nil {
 		return nil, err
 	}
-	prepareResponse, err := lightning.sdkService.PrepareSendPayment(prepareSendPaymentRequest(paymentInvoice, amountSat))
+	prepareResponse, err := sdkService.PrepareSendPayment(prepareSendPaymentRequest(paymentInvoice, amountSat))
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +269,11 @@ func (lightning *Lightning) PreparePayment(paymentInvoice string, amountSat *uin
 
 // SendPayment executes a payment for the provided payment request.
 func (lightning *Lightning) SendPayment(paymentInvoice string, amount *uint64, approvedFee uint64) error {
-	if err := lightning.CheckActive(); err != nil {
+	lightning.sdkServiceMu.RLock()
+	defer lightning.sdkServiceMu.RUnlock()
+
+	sdkService, err := lightning.activeSDKLocked()
+	if err != nil {
 		return err
 	}
 	lightning.log.Infof("Sending payment to %+v", paymentInvoice)
@@ -269,7 +281,7 @@ func (lightning *Lightning) SendPayment(paymentInvoice string, amount *uint64, a
 		lightning.log.Infof("Optional amount: %+v sat", *amount)
 	}
 
-	prepareResponse, err := lightning.sdkService.PrepareSendPayment(prepareSendPaymentRequest(paymentInvoice, amount))
+	prepareResponse, err := sdkService.PrepareSendPayment(prepareSendPaymentRequest(paymentInvoice, amount))
 	if err != nil {
 		return err
 	}
@@ -290,7 +302,7 @@ func (lightning *Lightning) SendPayment(paymentInvoice string, amount *uint64, a
 		PrepareResponse: prepareResponse,
 		Options:         &options,
 	}
-	_, err = lightning.sdkService.SendPayment(payRequest)
+	_, err = sdkService.SendPayment(payRequest)
 
 	if err != nil {
 		return err
@@ -300,14 +312,18 @@ func (lightning *Lightning) SendPayment(paymentInvoice string, amount *uint64, a
 
 // BoardingAddress returns a bitcoin address that can be used to fund lightning.
 func (lightning *Lightning) BoardingAddress() (string, error) {
-	if err := lightning.CheckActive(); err != nil {
+	lightning.sdkServiceMu.RLock()
+	defer lightning.sdkServiceMu.RUnlock()
+
+	sdkService, err := lightning.activeSDKLocked()
+	if err != nil {
 		return "", err
 	}
 	request := breez_sdk_spark.ReceivePaymentRequest{
 		PaymentMethod: breez_sdk_spark.ReceivePaymentMethodBitcoinAddress{},
 	}
 
-	response, err := lightning.sdkService.ReceivePayment(request)
+	response, err := sdkService.ReceivePayment(request)
 	if err != nil {
 		return "", err
 	}
@@ -321,7 +337,11 @@ func (lightning *Lightning) BoardingAddress() (string, error) {
 
 // ReceivePayment creates a BOLT11 invoice and returns an app-facing response.
 func (lightning *Lightning) ReceivePayment(amountSat uint64, description string) (*receivePaymentResponse, error) {
-	if err := lightning.CheckActive(); err != nil {
+	lightning.sdkServiceMu.RLock()
+	defer lightning.sdkServiceMu.RUnlock()
+
+	sdkService, err := lightning.activeSDKLocked()
+	if err != nil {
 		return nil, err
 	}
 	if len(description) < 1 {
@@ -335,7 +355,7 @@ func (lightning *Lightning) ReceivePayment(amountSat uint64, description string)
 		},
 	}
 
-	response, err := lightning.sdkService.ReceivePayment(request)
+	response, err := sdkService.ReceivePayment(request)
 	if err != nil {
 		return nil, err
 	}
@@ -348,10 +368,14 @@ func (lightning *Lightning) ReceivePayment(amountSat uint64, description string)
 
 // ListPayments fetches lightning payments and converts them to the app-facing contract.
 func (lightning *Lightning) ListPayments() ([]lightningPayment, error) {
-	if err := lightning.CheckActive(); err != nil {
+	lightning.sdkServiceMu.RLock()
+	defer lightning.sdkServiceMu.RUnlock()
+
+	sdkService, err := lightning.activeSDKLocked()
+	if err != nil {
 		return nil, err
 	}
-	response, err := lightning.sdkService.ListPayments(breez_sdk_spark.ListPaymentsRequest{})
+	response, err := sdkService.ListPayments(breez_sdk_spark.ListPaymentsRequest{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Guard Breez SDK service reads and reconnects with a mutex, and route payment operations through the active SDK helper so disconnects cannot race direct service access.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
