### PR TITLE
notes: track transaction note metadata

### DIFF
--- a/backend/accounts/notes/notes.go
+++ b/backend/accounts/notes/notes.go
@@ -5,8 +5,10 @@ package notes
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 )
@@ -20,6 +22,22 @@ type Data struct {
 
 	// a map of transaction ID to transaction note.
 	TransactionNotes map[string]string `json:"transactions"`
+	// TransactionsMetadata tracks metadata for entries in TransactionNotes. It
+	// is stored separately so the longstanding notes file shape remains a
+	// simple txID -> note map for backwards compatibility.
+	TransactionsMetadata map[string]TransactionMetadata `json:"transactionsMetadata,omitempty"`
+}
+
+// TransactionMetadata stores metadata for a transaction note.
+type TransactionMetadata struct {
+	// ModifiedAt is when the transaction note was last edited.
+	ModifiedAt time.Time `json:"modifiedAt,omitempty"`
+}
+
+// TransactionNoteEntry is a transaction note plus sync metadata.
+type TransactionNoteEntry struct {
+	Note     string
+	Metadata TransactionMetadata
 }
 
 // read deserializes the json files into notes. If the file does not exist yet, no error is
@@ -74,28 +92,30 @@ func LoadNotes(filename string) (*Notes, error) {
 	}, nil
 }
 
-// SetTxNote stores a note for a transaction. An empty note will result in the entry being deleted
-// (or not written if it didn't exist), since `TxNote()` returns an empty string anyway if there is
-// no note. Returns whether the note was modified.
+// SetTxNote stores a note for a transaction. Empty notes are stored explicitly
+// as tombstones only when clearing existing note state, so transaction-note sync
+// can propagate deletions. TxNote still returns an empty string for both missing
+// notes and explicit tombstones.
 func (notes *Notes) SetTxNote(txID string, note string) (bool, error) {
 	notes.dataMu.Lock()
 	defer notes.dataMu.Unlock()
 
 	if len(note) > MaxNoteLen {
-		return false, errp.Newf("Length of note must be smaller than %d. Got %d", MaxNoteLen, len(note))
+		return false, transactionNoteTooLongError(len(note))
 	}
 
 	if notes.data.TransactionNotes == nil {
 		notes.data.TransactionNotes = map[string]string{}
 	}
-	changed := notes.data.TransactionNotes[txID] != note
-	if note == "" {
-		// Since not existing entries are returned as `""` anyway, there no need to actually store
-		// them in the JSON file.
-		delete(notes.data.TransactionNotes, txID)
-	} else {
-		notes.data.TransactionNotes[txID] = note
+	current, ok := notes.data.TransactionNotes[txID]
+	if !ok && note == "" {
+		return false, nil
 	}
+	changed := !ok || current != note
+	if changed {
+		notes.setTxNoteModifiedAt(txID, time.Now().UTC())
+	}
+	notes.data.TransactionNotes[txID] = note
 	return changed, write(notes.data, notes.filename)
 }
 
@@ -107,11 +127,38 @@ func (notes *Notes) TxNote(txID string) string {
 	return notes.data.TransactionNotes[txID]
 }
 
-// Data retrieves all stored notes. You must not modify the returned object.
-func (notes *Notes) Data() *Data {
+// TransactionNoteEntries returns a copy of all stored transaction notes with
+// their metadata. Notes from older files may have zero metadata until they are
+// edited or updated by sync.
+func (notes *Notes) TransactionNoteEntries() map[string]TransactionNoteEntry {
 	notes.dataMu.RLock()
 	defer notes.dataMu.RUnlock()
-	return notes.data
+
+	return notes.transactionNoteEntries()
+}
+
+// UpdateTransactionNoteEntries atomically updates transaction notes together
+// with their metadata.
+//
+// update is called while the notes lock is held. It may inspect and mutate the
+// supplied map, but it must not retain it after returning. The map is written to
+// disk only when update returns changed=true.
+func (notes *Notes) UpdateTransactionNoteEntries(
+	update func(map[string]TransactionNoteEntry) (changed bool, err error),
+) (bool, error) {
+	notes.dataMu.Lock()
+	defer notes.dataMu.Unlock()
+
+	entries := notes.transactionNoteEntries()
+	changed, err := update(entries)
+	if err != nil || !changed {
+		return changed, err
+	}
+	if err := validateTransactionNoteEntries(entries); err != nil {
+		return false, err
+	}
+	notes.setTransactionNoteEntries(entries)
+	return true, write(notes.data, notes.filename)
 }
 
 // MergeLegacy merges the notes from an older/legacy notes file. Current/new notes take priority in
@@ -124,11 +171,73 @@ func (notes *Notes) MergeLegacy(legacy *Notes) error {
 		notes.data.TransactionNotes = map[string]string{}
 	}
 
-	legacyData := legacy.Data()
-	for txID, note := range legacyData.TransactionNotes {
+	for txID, entry := range legacy.TransactionNoteEntries() {
 		if _, ok := notes.data.TransactionNotes[txID]; !ok {
-			notes.data.TransactionNotes[txID] = note
+			notes.data.TransactionNotes[txID] = entry.Note
+			if !entry.Metadata.isZero() {
+				notes.setTransactionMetadata(txID, entry.Metadata)
+			}
 		}
 	}
 	return write(notes.data, notes.filename)
+}
+
+func (notes *Notes) setTxNoteModifiedAt(txID string, modifiedAt time.Time) {
+	if notes.data.TransactionsMetadata == nil {
+		notes.data.TransactionsMetadata = map[string]TransactionMetadata{}
+	}
+	metadata := notes.data.TransactionsMetadata[txID]
+	metadata.ModifiedAt = modifiedAt.UTC()
+	notes.data.TransactionsMetadata[txID] = metadata
+}
+
+func (notes *Notes) transactionNoteEntries() map[string]TransactionNoteEntry {
+	entries := make(map[string]TransactionNoteEntry, len(notes.data.TransactionNotes))
+	for txID, note := range notes.data.TransactionNotes {
+		metadata := notes.data.TransactionsMetadata[txID]
+		entries[txID] = TransactionNoteEntry{
+			Note:     note,
+			Metadata: metadata,
+		}
+	}
+	return entries
+}
+
+func (notes *Notes) setTransactionNoteEntries(entries map[string]TransactionNoteEntry) {
+	notes.data.TransactionNotes = make(map[string]string, len(entries))
+	notes.data.TransactionsMetadata = nil
+	for txID, entry := range entries {
+		notes.data.TransactionNotes[txID] = entry.Note
+		if !entry.Metadata.isZero() {
+			notes.setTransactionMetadata(txID, entry.Metadata)
+		}
+	}
+}
+
+func (metadata TransactionMetadata) isZero() bool {
+	return metadata.ModifiedAt.IsZero()
+}
+
+func (notes *Notes) setTransactionMetadata(txID string, metadata TransactionMetadata) {
+	if !metadata.ModifiedAt.IsZero() {
+		metadata.ModifiedAt = metadata.ModifiedAt.UTC()
+	}
+	if notes.data.TransactionsMetadata == nil {
+		notes.data.TransactionsMetadata = map[string]TransactionMetadata{}
+	}
+	notes.data.TransactionsMetadata[txID] = metadata
+}
+
+func validateTransactionNoteEntries(entries map[string]TransactionNoteEntry) error {
+	var errs []error
+	for _, entry := range entries {
+		if len(entry.Note) > MaxNoteLen {
+			errs = append(errs, transactionNoteTooLongError(len(entry.Note)))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func transactionNoteTooLongError(noteLen int) error {
+	return errp.Newf("Length of note must be at most %d. Got %d", MaxNoteLen, noteLen)
 }

--- a/backend/accounts/notes/notes_test.go
+++ b/backend/accounts/notes/notes_test.go
@@ -6,10 +6,19 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/test"
 	"github.com/stretchr/testify/require"
 )
+
+func transactionNoteStrings(entries map[string]TransactionNoteEntry) map[string]string {
+	noteStrings := make(map[string]string, len(entries))
+	for txID, entry := range entries {
+		noteStrings[txID] = entry.Note
+	}
+	return noteStrings
+}
 
 func TestNotes(t *testing.T) {
 	filename := test.TstTempFile("account-notes")
@@ -19,13 +28,21 @@ func TestNotes(t *testing.T) {
 	require.Equal(t, "", notes.TxNote("tx-id-1"))
 	require.Equal(t, "", notes.TxNote("tx-id-2"))
 
-	changed, err := notes.SetTxNote("tx-id-1", "note for tx-id-1")
+	changed, err := notes.SetTxNote("tx-id-missing", "")
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.NotContains(t, notes.TransactionNoteEntries(), "tx-id-missing")
+
+	changed, err = notes.SetTxNote("tx-id-1", "note for tx-id-1")
 	require.NoError(t, err)
 	require.True(t, changed)
+	firstModifiedAt := notes.TransactionNoteEntries()["tx-id-1"].Metadata.ModifiedAt
+	require.False(t, firstModifiedAt.IsZero())
 
 	changed, err = notes.SetTxNote("tx-id-1", "note for tx-id-1")
 	require.NoError(t, err)
 	require.False(t, changed)
+	require.True(t, firstModifiedAt.Equal(notes.TransactionNoteEntries()["tx-id-1"].Metadata.ModifiedAt))
 
 	require.Equal(t, "note for tx-id-1", notes.TxNote("tx-id-1"))
 	require.Equal(t, "", notes.TxNote("tx-id-2"))
@@ -35,14 +52,22 @@ func TestNotes(t *testing.T) {
 	require.Equal(t, "note for tx-id-1", notes.TxNote("tx-id-1"))
 	require.Equal(t, "note for tx-id-2", notes.TxNote("tx-id-2"))
 
+	changed, err = notes.SetTxNote("tx-id-1", "")
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "", notes.TxNote("tx-id-1"))
+
+	entries := notes.TransactionNoteEntries()
 	require.Equal(t,
-		&Data{
-			TransactionNotes: map[string]string{
-				"tx-id-1": "note for tx-id-1",
-				"tx-id-2": "note for tx-id-2",
-			},
+		map[string]string{
+			"tx-id-1": "",
+			"tx-id-2": "note for tx-id-2",
 		},
-		notes.Data())
+		transactionNoteStrings(entries))
+	require.Contains(t, entries, "tx-id-1")
+	require.False(t, entries["tx-id-1"].Metadata.ModifiedAt.IsZero())
+	require.Contains(t, entries, "tx-id-2")
+	require.False(t, entries["tx-id-2"].Metadata.ModifiedAt.IsZero())
 }
 
 // TestNotesPersisted checks that notes are persisted.
@@ -58,6 +83,7 @@ func TestNotesPersisted(t *testing.T) {
 	notes, err = LoadNotes(filename)
 	require.NoError(t, err)
 	require.Equal(t, "note for some-tx-id", notes.TxNote("some-tx-id"))
+	require.False(t, notes.TransactionNoteEntries()["some-tx-id"].Metadata.ModifiedAt.IsZero())
 
 	require.NoError(t, os.Remove(filename))
 	notes, err = LoadNotes(filename)
@@ -93,26 +119,106 @@ func TestMergeLegacy(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, notes.MergeLegacy(legacyNotes))
+	entries := notes.TransactionNoteEntries()
 	require.Equal(t,
-		&Data{
-			TransactionNotes: map[string]string{
-				"tx-id-1": "note for tx-id-1",
-				"tx-id-2": "note for tx-id-2",
-				"tx-id-3": "legacy note for tx-id-3",
-			},
+		map[string]string{
+			"tx-id-1": "note for tx-id-1",
+			"tx-id-2": "note for tx-id-2",
+			"tx-id-3": "legacy note for tx-id-3",
 		},
-		notes.Data())
+		transactionNoteStrings(entries))
+	require.Contains(t, entries, "tx-id-3")
+	require.False(t, entries["tx-id-3"].Metadata.ModifiedAt.IsZero())
 
 	// Check that the merged notes were persisted.
 	notes, err = LoadNotes(filename)
 	require.NoError(t, err)
+	entries = notes.TransactionNoteEntries()
 	require.Equal(t,
-		&Data{
-			TransactionNotes: map[string]string{
-				"tx-id-1": "note for tx-id-1",
-				"tx-id-2": "note for tx-id-2",
-				"tx-id-3": "legacy note for tx-id-3",
-			},
+		map[string]string{
+			"tx-id-1": "note for tx-id-1",
+			"tx-id-2": "note for tx-id-2",
+			"tx-id-3": "legacy note for tx-id-3",
 		},
-		notes.Data())
+		transactionNoteStrings(entries))
+	require.Contains(t, entries, "tx-id-3")
+	require.False(t, entries["tx-id-3"].Metadata.ModifiedAt.IsZero())
+}
+
+func TestMergeLegacyLeavesUnknownModifiedAtUnset(t *testing.T) {
+	filename := test.TstTempFile("account-notes")
+	notes, err := LoadNotes(filename)
+	require.NoError(t, err)
+
+	legacyFilename := test.TstTempFile("legacy-notes")
+	require.NoError(t, os.WriteFile(legacyFilename, []byte(`{
+  "transactions": {
+    "tx-id": "legacy note"
+  }
+}`), 0600))
+	legacyNotes, err := LoadNotes(legacyFilename)
+	require.NoError(t, err)
+
+	require.NoError(t, notes.MergeLegacy(legacyNotes))
+
+	entry := notes.TransactionNoteEntries()["tx-id"]
+	require.Equal(t, "legacy note", entry.Note)
+	require.True(t, entry.Metadata.ModifiedAt.IsZero())
+}
+
+func TestLoadLegacyNotesWithoutModifiedAt(t *testing.T) {
+	filename := test.TstTempFile("account-notes")
+	require.NoError(t, os.WriteFile(filename, []byte(`{
+  "transactions": {
+    "tx-id": "legacy note"
+  }
+}`), 0600))
+
+	notes, err := LoadNotes(filename)
+	require.NoError(t, err)
+
+	require.Equal(t, "legacy note", notes.TxNote("tx-id"))
+	require.True(t, notes.TransactionNoteEntries()["tx-id"].Metadata.ModifiedAt.IsZero())
+}
+
+func TestLoadNotesWithTransactionsMetadata(t *testing.T) {
+	filename := test.TstTempFile("account-notes")
+	require.NoError(t, os.WriteFile(filename, []byte(`{
+  "transactions": {
+    "tx-id": "note"
+  },
+  "transactionsMetadata": {
+    "tx-id": {
+      "modifiedAt": "2026-05-11T10:24:00Z"
+    }
+  }
+}`), 0600))
+
+	notes, err := LoadNotes(filename)
+	require.NoError(t, err)
+
+	entry := notes.TransactionNoteEntries()["tx-id"]
+	require.Equal(t, "note", entry.Note)
+	require.True(t, time.Date(2026, 5, 11, 10, 24, 0, 0, time.UTC).Equal(entry.Metadata.ModifiedAt))
+}
+
+func TestUpdateTransactionNoteEntries(t *testing.T) {
+	filename := test.TstTempFile("account-notes")
+	notes, err := LoadNotes(filename)
+	require.NoError(t, err)
+	modifiedAt := time.Date(2026, 5, 11, 10, 24, 0, 0, time.UTC)
+
+	changed, err := notes.UpdateTransactionNoteEntries(func(entries map[string]TransactionNoteEntry) (bool, error) {
+		entries["tx-id"] = TransactionNoteEntry{
+			Note: "synced note",
+			Metadata: TransactionMetadata{
+				ModifiedAt: modifiedAt,
+			},
+		}
+		return true, nil
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "synced note", notes.TxNote("tx-id"))
+	require.True(t, modifiedAt.Equal(notes.TransactionNoteEntries()["tx-id"].Metadata.ModifiedAt))
 }

--- a/backend/notes.go
+++ b/backend/notes.go
@@ -114,12 +114,14 @@ func (backend *Backend) exportNotes(writer io.Writer) error {
 			}
 		}
 
-		notesData := account.Notes().Data()
-		for txID, note := range notesData.TransactionNotes {
+		for txID, noteEntry := range account.Notes().TransactionNoteEntries() {
+			if noteEntry.Note == "" {
+				continue
+			}
 			entry := bip329Entry{
 				Type:  bip329TypeTx,
 				Ref:   txID,
-				Label: note,
+				Label: noteEntry.Note,
 				// We use this to aid the import back into the BitBoxApp, as the same txID can be in
 				// multiple accounts with different labels (e.g. and ERC20 token in the ERC20 token
 				// account as well as in the parent ETH account), and the origin label is not a good


### PR DESCRIPTION
Empty notes become tombstones, and we add modified timestamps. This is necessary so BitBoxSync can merge conflicts and sync deletions.
