### PR TITLE
lightning: default account unit to sats

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -90,6 +90,8 @@ type Backend struct {
 
 	// BtcUnit is the unit used to represent Bitcoin amounts. See `coin.BtcUnit` for details.
 	BtcUnit coin.BtcUnit `json:"btcUnit"`
+	// LightningUnit is the unit used to represent Lightning amounts.
+	LightningUnit coin.BtcUnit `json:"lightningUnit"`
 
 	// StartInTestnet represents whether the app should launch in testnet on the next start.
 	// It resets to `false` after the app starts.
@@ -226,9 +228,10 @@ func NewDefaultAppConfig() AppConfig {
 				DeprecatedActiveERC20Tokens: []string{},
 			},
 			// Copied from frontend/web/src/components/rates/rates.tsx.
-			FiatList: []string{rates.USD.String(), rates.EUR.String(), rates.CHF.String()},
-			MainFiat: rates.USD.String(),
-			BtcUnit:  coin.BtcUnitDefault,
+			FiatList:      []string{rates.USD.String(), rates.EUR.String(), rates.CHF.String()},
+			MainFiat:      rates.USD.String(),
+			BtcUnit:       coin.BtcUnitDefault,
+			LightningUnit: coin.BtcUnitSats,
 		},
 		Frontend: make(map[string]interface{}),
 	}

--- a/backend/config/config_test.go
+++ b/backend/config/config_test.go
@@ -55,7 +55,9 @@ func TestSetAppConfig(t *testing.T) {
 
 	appCfg := cfg.AppConfig()
 	require.Equal(t, coin.BtcUnitDefault, appCfg.Backend.BtcUnit)
+	require.Equal(t, coin.BtcUnitSats, appCfg.Backend.LightningUnit)
 	appCfg.Backend.BtcUnit = coin.BtcUnitSats
+	appCfg.Backend.LightningUnit = coin.BtcUnitDefault
 	appCfg.Frontend = map[string]interface{}{"foo": "bar"}
 	require.NoError(t, cfg.SetAppConfig(appCfg))
 
@@ -63,7 +65,24 @@ func TestSetAppConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cfg, cfg2)
 	require.Equal(t, coin.BtcUnitSats, cfg2.AppConfig().Backend.BtcUnit)
+	require.Equal(t, coin.BtcUnitDefault, cfg2.AppConfig().Backend.LightningUnit)
 	require.Equal(t, map[string]interface{}{"foo": "bar"}, cfg2.AppConfig().Frontend)
+}
+
+func TestMissingLightningUnitDefaultsToSats(t *testing.T) {
+	appConfigFilename := test.TstTempFile("appConfig")
+	accountsConfigFilename := test.TstTempFile("accountsConfig")
+	lightningConfigFilename := test.TstTempFile("lightningConfig")
+
+	require.NoError(t, os.WriteFile(
+		appConfigFilename,
+		[]byte(`{"backend":{"btcUnit":"default"},"frontend":{}}`),
+		0o600,
+	))
+
+	cfg, err := NewConfig(appConfigFilename, accountsConfigFilename, lightningConfigFilename)
+	require.NoError(t, err)
+	require.Equal(t, coin.BtcUnitSats, cfg.AppConfig().Backend.LightningUnit)
 }
 
 func TestModifyAccountsConfig(t *testing.T) {

--- a/backend/lightning.go
+++ b/backend/lightning.go
@@ -4,7 +4,7 @@ package backend
 
 import coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 
-// coinCodeLightning is a portfolio-only pseudo coin code. Use BTC for formatting and conversions;
+// coinCodeLightning is a portfolio-only pseudo coin code. Use BTC rates for conversions;
 // backend.Coin(coinCodeLightning) does not resolve.
 const coinCodeLightning coinpkg.Code = "lightning"
 
@@ -20,16 +20,11 @@ func (backend *Backend) lightningFormattedBalance() (*coinFormattedAmount, error
 	if err != nil {
 		return nil, err
 	}
-	btcCoin, err := backend.Coin(coinpkg.CodeBTC)
-	if err != nil {
-		return nil, err
+	formattedBalance := coinFormattedAmount{
+		CoinCode:        coinCodeLightning,
+		CoinName:        "Lightning",
+		FormattedAmount: backend.lightning.FormatAmountWithConversions(lightningBalance.Available(), false),
 	}
-	formattedBalance := backend.formattedCoinBalance(
-		coinCodeLightning,
-		"Lightning",
-		btcCoin,
-		lightningBalance.Available().BigInt(),
-	)
 	return &formattedBalance, nil
 }
 

--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -163,18 +163,13 @@ func (lightning *Lightning) GetBalance(_ *http.Request) interface{} {
 		return errorResponse(err)
 	}
 
-	btcCoin := lightning.btcCoin
-
-	formattedAvailableAmount := coin.FormattedAmountWithConversions{
-		Amount:      btcCoin.FormatAmount(balance.Available(), false),
-		Unit:        btcCoin.GetFormatUnit(false),
-		Conversions: coin.Conversions(balance.Available(), btcCoin, false, lightning.ratesUpdater),
-	}
-	formattedIncomingAmount := coin.FormattedAmountWithConversions{
-		Amount:      btcCoin.FormatAmount(balance.Incoming(), false),
-		Unit:        btcCoin.GetFormatUnit(false),
-		Conversions: coin.Conversions(balance.Incoming(), btcCoin, false, lightning.ratesUpdater),
-	}
+	formattingCoin := lightning.formattingCoin()
+	formattedAvailableAmount := lightning.FormatAmountWithConversions(balance.Available(), false)
+	formattedAvailableAmount.UnformattedConversions = coin.UnformattedConversions(
+		balance.Available(), formattingCoin, false, lightning.ratesUpdater)
+	formattedIncomingAmount := lightning.FormatAmountWithConversions(balance.Incoming(), false)
+	formattedIncomingAmount.UnformattedConversions = coin.UnformattedConversions(
+		balance.Incoming(), formattingCoin, false, lightning.ratesUpdater)
 
 	return responseDto{
 		Success: true,

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -9,11 +9,13 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"io"
+	"math/big"
 	"net/http"
 	"os"
 	"path"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
@@ -85,6 +87,44 @@ type Lightning struct {
 
 	// Serializes lazy lightning address registration.
 	lightningAddressLock sync.Mutex
+}
+
+type formattingCoin struct {
+	coin.Coin
+	unit coin.BtcUnit
+}
+
+func (formatCoin formattingCoin) GetFormatUnit(isFee bool) string {
+	if formatCoin.unit == coin.BtcUnitSats {
+		return "sat"
+	}
+	return formatCoin.Coin.Unit(isFee)
+}
+
+func (formatCoin formattingCoin) FormatAmount(amount coin.Amount, isFee bool) string {
+	if formatCoin.unit == coin.BtcUnitSats {
+		return amount.BigInt().String()
+	}
+	return new(big.Rat).
+		SetFrac(amount.BigInt(), coin.DecimalsExp(formatCoin.Coin, isFee)).
+		FloatString(int(formatCoin.Coin.Decimals(isFee)))
+}
+
+func (lightning *Lightning) formattingCoin() coin.Coin {
+	unit := coin.BtcUnitSats
+	if lightning.backendConfig != nil && lightning.backendConfig.AppConfig().Backend.LightningUnit == coin.BtcUnitDefault {
+		unit = coin.BtcUnitDefault
+	}
+	return formattingCoin{Coin: lightning.btcCoin, unit: unit}
+}
+
+// FormatAmountWithConversions formats a Lightning amount using the independently configured unit.
+func (lightning *Lightning) FormatAmountWithConversions(amount coin.Amount, isFee bool) coin.FormattedAmountWithConversions {
+	return amount.FormatWithConversions(lightning.formattingCoin(), isFee, lightning.ratesUpdater)
+}
+
+func (lightning *Lightning) formatAmountAtTime(amount coin.Amount, timestamp *time.Time) coin.FormattedAmountWithConversions {
+	return amount.FormatWithConversionsAtTime(lightning.formattingCoin(), timestamp, lightning.ratesUpdater)
 }
 
 // NewLightning creates a new instance of the Lightning struct.

--- a/backend/lightning/payments.go
+++ b/backend/lightning/payments.go
@@ -286,10 +286,10 @@ func (lightning *Lightning) toLightningPayment(payment breez_sdk_spark.Payment) 
 		Type:                 paymentType,
 		Status:               toLightningPaymentStatus(payment.Status),
 		Time:                 formattedTime,
-		Amount:               amount.FormatWithConversions(lightning.btcCoin, false, lightning.ratesUpdater),
-		AmountAtTime:         amount.FormatWithConversionsAtTime(lightning.btcCoin, timestamp, lightning.ratesUpdater),
-		DeductedAmountAtTime: deductedAmount.FormatWithConversionsAtTime(lightning.btcCoin, timestamp, lightning.ratesUpdater),
-		Fee:                  fee.FormatWithConversions(lightning.btcCoin, true, lightning.ratesUpdater),
+		Amount:               lightning.FormatAmountWithConversions(amount, false),
+		AmountAtTime:         lightning.formatAmountAtTime(amount, timestamp),
+		DeductedAmountAtTime: lightning.formatAmountAtTime(deductedAmount, timestamp),
+		Fee:                  lightning.FormatAmountWithConversions(fee, true),
 	}
 	// Claimed Bitcoin deposits appear in ListPayments, sometimes without payment details. Mark them
 	// as complete top-ups based on the payment method so the frontend can identify them reliably.
@@ -397,10 +397,10 @@ func (lightning *Lightning) toBitcoinDepositPayment(deposit breez_sdk_spark.Depo
 		ID:                   fmt.Sprintf("bitcoin-deposit:%s:%d", deposit.Txid, deposit.Vout),
 		Type:                 accounts.TxTypeReceive,
 		Status:               accounts.TxStatusPending,
-		Amount:               amount.FormatWithConversions(lightning.btcCoin, false, lightning.ratesUpdater),
-		AmountAtTime:         amount.FormatWithConversionsAtTime(lightning.btcCoin, nil, lightning.ratesUpdater),
-		DeductedAmountAtTime: coin.NewAmountFromInt64(0).FormatWithConversionsAtTime(lightning.btcCoin, nil, lightning.ratesUpdater),
-		Fee:                  coin.NewAmountFromInt64(0).FormatWithConversions(lightning.btcCoin, true, lightning.ratesUpdater),
+		Amount:               lightning.FormatAmountWithConversions(amount, false),
+		AmountAtTime:         lightning.formatAmountAtTime(amount, nil),
+		DeductedAmountAtTime: lightning.formatAmountAtTime(coin.NewAmountFromInt64(0), nil),
+		Fee:                  lightning.FormatAmountWithConversions(coin.NewAmountFromInt64(0), true),
 		BitcoinDeposit:       depositInfo,
 	}
 }

--- a/backend/lightning/payments_test.go
+++ b/backend/lightning/payments_test.go
@@ -40,6 +40,26 @@ func makeTestLightning() *Lightning {
 	}
 }
 
+func TestFormatAmountWithConversionsUsesLightningUnit(t *testing.T) {
+	lightning := makeTestLightning()
+	lightning.backendConfig = newTestLightning(t, nil).backendConfig
+	btcCoin := lightning.btcCoin.(*btccoin.Coin)
+
+	btcCoin.SetFormatUnit(coin.BtcUnitDefault)
+	formatted := lightning.FormatAmountWithConversions(coin.NewAmountFromInt64(123), false)
+	require.Equal(t, "123", formatted.Amount)
+	require.Equal(t, "sat", formatted.Unit)
+
+	require.NoError(t, lightning.backendConfig.ModifyAppConfig(func(cfg *config.AppConfig) error {
+		cfg.Backend.LightningUnit = coin.BtcUnitDefault
+		return nil
+	}))
+	btcCoin.SetFormatUnit(coin.BtcUnitSats)
+	formatted = lightning.FormatAmountWithConversions(coin.NewAmountFromInt64(123), false)
+	require.Equal(t, "0.00000123", formatted.Amount)
+	require.Equal(t, "BTC", formatted.Unit)
+}
+
 type testPaymentsBreezSDK struct {
 	breezSDK
 
@@ -79,16 +99,16 @@ func TestToLightningPayment(t *testing.T) {
 		Time:        stringPointer("1970-01-01T00:00:42Z"),
 		Description: "invoice description",
 		Amount: coinAmountWithConversions(
-			"0.00000123",
+			"123",
 		),
 		AmountAtTime: coinAmountWithConversions(
-			"0.00000123",
+			"123",
 		),
 		DeductedAmountAtTime: coinAmountWithConversions(
-			"0.00000000",
+			"0",
 		),
 		Fee: coinAmountWithConversions(
-			"0.00000004",
+			"4",
 		),
 		Invoice: "lnbc1invoice",
 	}, payment)
@@ -200,16 +220,16 @@ func TestToLightningPaymentSparkInvoiceDetails(t *testing.T) {
 		Time:        stringPointer("1970-01-01T00:00:42Z"),
 		Description: "spark description",
 		Amount: coinAmountWithConversions(
-			"0.00000123",
+			"123",
 		),
 		AmountAtTime: coinAmountWithConversions(
-			"0.00000123",
+			"123",
 		),
 		DeductedAmountAtTime: coinAmountWithConversions(
-			"0.00000000",
+			"0",
 		),
 		Fee: coinAmountWithConversions(
-			"0.00000004",
+			"4",
 		),
 		Invoice: "lnsb1invoice",
 	}, payment)
@@ -237,8 +257,8 @@ func TestToLightningPaymentSparkNilInvoiceDetails(t *testing.T) {
 		require.Equal(t, accounts.TxTypeReceive, payment.Type)
 		require.Equal(t, accounts.TxStatusComplete, payment.Status)
 		require.Equal(t, stringPointer("1970-01-01T00:00:42Z"), payment.Time)
-		require.Equal(t, coinAmountWithConversions("0.00000123"), payment.Amount)
-		require.Equal(t, coinAmountWithConversions("0.00000004"), payment.Fee)
+		require.Equal(t, coinAmountWithConversions("123"), payment.Amount)
+		require.Equal(t, coinAmountWithConversions("4"), payment.Fee)
 	})
 }
 
@@ -309,7 +329,7 @@ func TestToBitcoinDepositPayment(t *testing.T) {
 				State: bitcoinDepositStateConfirming,
 			},
 			expectedID:  "bitcoin-deposit:txid-confirming:1",
-			expectedAmt: "0.00000123",
+			expectedAmt: "123",
 		},
 		{
 			name: "claiming deposit",
@@ -325,7 +345,7 @@ func TestToBitcoinDepositPayment(t *testing.T) {
 				State: bitcoinDepositStateClaiming,
 			},
 			expectedID:  "bitcoin-deposit:txid-claiming:2",
-			expectedAmt: "0.00000456",
+			expectedAmt: "456",
 		},
 		{
 			name: "unclaimed deposit",
@@ -343,7 +363,7 @@ func TestToBitcoinDepositPayment(t *testing.T) {
 				ClaimError: "claim failed",
 			},
 			expectedID:  "bitcoin-deposit:txid-unclaimed:3",
-			expectedAmt: "0.00000789",
+			expectedAmt: "789",
 		},
 	}
 
@@ -375,9 +395,9 @@ func TestToLightningPaymentSendWithMissingTimestamp(t *testing.T) {
 	require.Nil(t, payment.Time)
 	require.Equal(t, accounts.TxTypeSend, payment.Type)
 	require.Equal(t, accounts.TxStatusPending, payment.Status)
-	require.Equal(t, "0.00000100", payment.Amount.Amount)
-	require.Equal(t, "0.00000105", payment.DeductedAmountAtTime.Amount)
-	require.Equal(t, "0.00000005", payment.Fee.Amount)
+	require.Equal(t, "100", payment.Amount.Amount)
+	require.Equal(t, "105", payment.DeductedAmountAtTime.Amount)
+	require.Equal(t, "5", payment.Fee.Amount)
 	require.True(t, payment.AmountAtTime.Estimated)
 	require.True(t, payment.DeductedAmountAtTime.Estimated)
 }
@@ -725,7 +745,7 @@ func TestValidateApprovedLightningFee(t *testing.T) {
 func coinAmountWithConversions(amount string) coin.FormattedAmountWithConversions {
 	return coin.FormattedAmountWithConversions{
 		Amount:      amount,
-		Unit:        "BTC",
+		Unit:        "sat",
 		Conversions: coin.ConversionsMap{},
 		Estimated:   false,
 	}

--- a/frontends/web/src/api/config.ts
+++ b/frontends/web/src/api/config.ts
@@ -107,6 +107,7 @@ export type TConfigBackend = Readonly<{
   mainFiat: Fiat;
   userLanguage: string;
   btcUnit: BtcUnit;
+  lightningUnit: BtcUnit;
   startInTestnet: boolean;
   gapLimitReceive: number;
   gapLimitChange: number;

--- a/frontends/web/src/components/amount/amount-with-unit.tsx
+++ b/frontends/web/src/components/amount/amount-with-unit.tsx
@@ -17,6 +17,7 @@ type TAmountWithUnitProps = {
   amountClassName?: string;
   unitClassName?: string;
   maxDecimals?: number;
+  onRotateUnit?: () => Promise<void>;
 };
 
 export const AmountWithUnit = ({
@@ -29,6 +30,7 @@ export const AmountWithUnit = ({
   amountClassName = '',
   unitClassName = '',
   maxDecimals,
+  onRotateUnit,
 }: TAmountWithUnitProps) => {
   const { rotateDefaultCurrency, defaultCurrency, rotateBtcUnit } = useContext(RatesContext);
 
@@ -49,7 +51,7 @@ export const AmountWithUnit = ({
   } else {
     displayedAmount = amount.amount;
     displayedUnit = amount.unit;
-    onClick = rotateBtcUnit;
+    onClick = onRotateUnit || rotateBtcUnit;
   }
 
   const enableClick = enableRotateUnit && (convertToFiat || isBitcoinCoin(amount.unit));

--- a/frontends/web/src/components/balance/balance.test.tsx
+++ b/frontends/web/src/components/balance/balance.test.tsx
@@ -3,7 +3,7 @@
 import '../../../__mocks__/i18n';
 import { useContext } from 'react';
 import { Mock, afterEach, describe, expect, it, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { TBalance } from '@/api/account';
 import { Balance } from './balance';
 
@@ -22,6 +22,39 @@ vi.mock('react', () => ({
 }));
 
 describe('components/balance/balance', () => {
+  it('uses a custom unit rotator', () => {
+    const rotateBtcUnit = vi.fn();
+    const onRotateUnit = vi.fn();
+    (useContext as Mock).mockReturnValue({
+      defaultCurrency: 'USD',
+      decimal: '.',
+      group: ',',
+      rotateBtcUnit,
+    });
+    const amount = {
+      amount: '123',
+      unit: 'sat' as const,
+      estimated: false,
+      conversions: { USD: '1' },
+    };
+
+    const { getByTestId } = render(
+      <Balance
+        balance={{
+          available: amount,
+          hasAvailable: true,
+          hasIncoming: false,
+          incoming: amount,
+        }}
+        onRotateUnit={onRotateUnit}
+      />
+    );
+    fireEvent.click(getByTestId('amount-unit-sat'));
+
+    expect(onRotateUnit).toHaveBeenCalledOnce();
+    expect(rotateBtcUnit).not.toHaveBeenCalled();
+  });
+
   it('renders balance properly', () => {
     (useContext as Mock).mockReturnValue({
       btcUnit: 'default',

--- a/frontends/web/src/components/balance/balance.tsx
+++ b/frontends/web/src/components/balance/balance.tsx
@@ -9,10 +9,12 @@ import style from './balance.module.css';
 
 type TProps = {
   balance?: TBalance;
+  onRotateUnit?: () => Promise<void>;
 };
 
 export const Balance = ({
   balance,
+  onRotateUnit,
 }: TProps) => {
   const { t } = useTranslation();
   if (!balance) {
@@ -31,6 +33,7 @@ export const Balance = ({
           amount={balance.available}
           maxDecimals={9}
           enableRotateUnit
+          onRotateUnit={onRotateUnit}
           unitClassName={style.unit}
         />
         {' '}

--- a/frontends/web/src/contexts/RatesContext.tsx
+++ b/frontends/web/src/contexts/RatesContext.tsx
@@ -8,8 +8,10 @@ type RatesContextProps = {
   defaultCurrency: Fiat;
   activeCurrencies: Fiat[];
   btcUnit?: BtcUnit;
+  lightningUnit?: BtcUnit;
   rotateDefaultCurrency: () => Promise<void>;
   rotateBtcUnit: () => Promise<void>;
+  rotateLightningUnit: () => Promise<void>;
   addToActiveCurrencies: (fiat: Fiat) => Promise<void>;
   updateDefaultCurrency: (fiat: Fiat) => void;
   removeFromActiveCurrencies: (fiat: Fiat) => Promise<void>;

--- a/frontends/web/src/contexts/RatesProvider.tsx
+++ b/frontends/web/src/contexts/RatesProvider.tsx
@@ -17,6 +17,7 @@ export const RatesProvider = ({ children }: TProps) => {
   const [defaultCurrency, setDefaultCurrency] = useState<Fiat>('USD');
   const [activeCurrencies, setActiveCurrencies] = useState<Fiat[]>(['USD', 'EUR', 'CHF']);
   const [btcUnit, setBtcUnit] = useState<BtcUnit>('default');
+  const [lightningUnit, setLightningUnit] = useState<BtcUnit>('sat');
 
   useEffect(() => {
     if (config === undefined) {
@@ -25,6 +26,7 @@ export const RatesProvider = ({ children }: TProps) => {
     setDefaultCurrency(config.backend.mainFiat);
     setActiveCurrencies(config.backend.fiatList);
     setBtcUnit(config.backend.btcUnit);
+    setLightningUnit(config.backend.lightningUnit);
   }, [config]);
 
   const rotateDefaultCurrency = async () => {
@@ -51,6 +53,12 @@ export const RatesProvider = ({ children }: TProps) => {
     if (!response.success) {
       console.log('setBackendBtcUnit failed.');
     }
+  };
+
+  const rotateLightningUnit = async () => {
+    const unit: BtcUnit = lightningUnit === 'default' ? 'sat' : 'default';
+    await setConfig({ backend: { lightningUnit: unit } });
+    setLightningUnit(unit);
   };
 
   // this is a method to select / add a currency
@@ -82,11 +90,13 @@ export const RatesProvider = ({ children }: TProps) => {
         defaultCurrency,
         activeCurrencies,
         btcUnit,
+        lightningUnit,
         rotateDefaultCurrency,
         addToActiveCurrencies,
         updateDefaultCurrency,
         removeFromActiveCurrencies,
         rotateBtcUnit,
+        rotateLightningUnit,
       }}
     >
       {children}

--- a/frontends/web/src/routes/lightning/lightning.tsx
+++ b/frontends/web/src/routes/lightning/lightning.tsx
@@ -71,6 +71,7 @@ const LightningPageLayout = ({
   statusBanners,
 }: TLightningPageLayoutProps) => {
   const { t } = useTranslation();
+  const { rotateLightningUnit } = useContext(RatesContext);
 
   return (
     <GuideWrapper>
@@ -91,7 +92,7 @@ const LightningPageLayout = ({
           <View>
             <ViewHeader>
               <div className={accountStyle.balanceHeader}>
-                <Balance balance={balance} />
+                <Balance balance={balance} onRotateUnit={rotateLightningUnit} />
                 <ActionButtons
                   accountDataLoaded={accountDataLoaded}
                   canSend={canSend}
@@ -281,7 +282,7 @@ const LightningInner = ({
 
 export const Lightning = () => {
   const { t } = useTranslation();
-  const { btcUnit } = useContext(RatesContext);
+  const { lightningUnit } = useContext(RatesContext);
   const { isLightningReady, lightningAccount } = useLightning();
   const [balance, setBalance] = useState<accountApi.TBalance>();
   const [syncedAddressesCount] = useState<number>();
@@ -321,7 +322,7 @@ export const Lightning = () => {
     onStateChange();
 
     return subscribeListPayments(onStateChange);
-  }, [btcUnit, isLightningReady, lightningAccount, onStateChange]);
+  }, [lightningUnit, isLightningReady, lightningAccount, onStateChange]);
 
   const loadSparkStatus = useCallback(async () => {
     try {

--- a/frontends/web/src/routes/lightning/receive/receive.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.tsx
@@ -30,7 +30,7 @@ import styles from './receive.module.css';
 export function Receive() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { defaultCurrency } = useContext(RatesContext);
+  const { defaultCurrency, lightningUnit } = useContext(RatesContext);
   const {
     amount: invoiceAmount,
     amountSat: invoiceAmountSat,
@@ -45,7 +45,7 @@ export function Receive() {
   const [receiveError, setReceiveError] = useState<string>();
   const [step, setStep] = useState<TReceiveStep>('address');
   const [balanceLoadAttempt, setBalanceLoadAttempt] = useState(0);
-  const lightningBalance = useLoad(getLightningBalance, [balanceLoadAttempt]);
+  const lightningBalance = useLoad(getLightningBalance, [balanceLoadAttempt, lightningUnit]);
   const lightningAddress = useSync(getLightningAddress, subscribeLightningAddress);
   const satsBalance = lightningBalance?.available.unit === 'sat'
     ? lightningBalance.available.amount

--- a/frontends/web/src/routes/lightning/send/components/custom-payment-amount.tsx
+++ b/frontends/web/src/routes/lightning/send/components/custom-payment-amount.tsx
@@ -17,12 +17,12 @@ type TProps = {
 };
 
 export const PaymentBalance = () => {
-  const { btcUnit } = useContext(RatesContext);
-  const balance = useLoad(getLightningBalance, [btcUnit]);
+  const { lightningUnit, rotateLightningUnit } = useContext(RatesContext);
+  const balance = useLoad(getLightningBalance, [lightningUnit]);
 
   return (
     <div className={styles.availableBalance}>
-      <Balance balance={balance} />
+      <Balance balance={balance} onRotateUnit={rotateLightningUnit} />
     </div>
   );
 };

--- a/frontends/web/src/routes/market/swap/swap.test.tsx
+++ b/frontends/web/src/routes/market/swap/swap.test.tsx
@@ -241,6 +241,7 @@ describe('routes/market/swap', () => {
             removeFromActiveCurrencies: vi.fn(),
             rotateBtcUnit: vi.fn(),
             rotateDefaultCurrency: vi.fn(),
+            rotateLightningUnit: vi.fn(),
             updateDefaultCurrency: vi.fn(),
           }}>
           <MemoryRouter>
@@ -297,6 +298,7 @@ describe('routes/market/swap', () => {
             removeFromActiveCurrencies: vi.fn(),
             rotateBtcUnit: vi.fn(),
             rotateDefaultCurrency: vi.fn(),
+            rotateLightningUnit: vi.fn(),
             updateDefaultCurrency: vi.fn(),
           }}>
           <MemoryRouter>
@@ -339,6 +341,7 @@ describe('routes/market/swap', () => {
             removeFromActiveCurrencies: vi.fn(),
             rotateBtcUnit: vi.fn(),
             rotateDefaultCurrency: vi.fn(),
+            rotateLightningUnit: vi.fn(),
             updateDefaultCurrency: vi.fn(),
           }}>
           <MemoryRouter>
@@ -383,6 +386,7 @@ describe('routes/market/swap', () => {
             removeFromActiveCurrencies: vi.fn(),
             rotateBtcUnit: vi.fn(),
             rotateDefaultCurrency: vi.fn(),
+            rotateLightningUnit: vi.fn(),
             updateDefaultCurrency: vi.fn(),
           }}>
           <MemoryRouter>
@@ -428,6 +432,7 @@ describe('routes/market/swap', () => {
             removeFromActiveCurrencies: vi.fn(),
             rotateBtcUnit: vi.fn(),
             rotateDefaultCurrency: vi.fn(),
+            rotateLightningUnit: vi.fn(),
             updateDefaultCurrency: vi.fn(),
           }}>
           <MemoryRouter>


### PR DESCRIPTION
Lightning amounts previously used the global Bitcoin display unit. This made Lightning and on-chain accounts switch units together.

Add a separate persisted Lightning unit that defaults to sats while keeping BTC available. Use it for balances, payment history and portfolio totals so changing either unit no longer affects the other.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
