### PR TITLE
lightning: refresh lightning balance across views

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -411,6 +411,7 @@ func (backend *Backend) newRatesUpdater() *rates.RateUpdater {
 				Subject: "lightning/list-payments",
 				Action:  action.Reload,
 			})
+			backend.lightning.NotifyBalanceReload()
 		}
 	})
 	return updater

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -937,6 +937,8 @@ func (handlers *Handlers) postBtcFormatUnit(r *http.Request) interface{} {
 	}
 	btcCoin.(*btc.Coin).SetFormatUnit(unit)
 
+	handlers.backend.Lightning().NotifyBalanceReload()
+
 	return response{Success: true}
 }
 

--- a/backend/lightning/address_test.go
+++ b/backend/lightning/address_test.go
@@ -648,44 +648,107 @@ func TestLightningAddressChangedEventNotifiesSubscribers(t *testing.T) {
 }
 
 func TestDepositEventsReloadPayments(t *testing.T) {
+	newBalanceLightning := func(t *testing.T) *Lightning {
+		t.Helper()
+		lightning := newTestLightning(t, nil)
+		activateLightningAddressTest(t, lightning)
+		coinLightning := makeTestLightning()
+		lightning.btcCoin = coinLightning.btcCoin
+		lightning.ratesUpdater = coinLightning.ratesUpdater
+		lightning.sdkService = &testBreezSDK{
+			getInfo: func(breez_sdk_spark.GetInfoRequest) (breez_sdk_spark.GetInfoResponse, error) {
+				return breez_sdk_spark.GetInfoResponse{BalanceSats: 100}, nil
+			},
+			listUnclaimedDeposits: func(breez_sdk_spark.ListUnclaimedDepositsRequest) (breez_sdk_spark.ListUnclaimedDepositsResponse, error) {
+				return breez_sdk_spark.ListUnclaimedDepositsResponse{}, nil
+			},
+		}
+		return lightning
+	}
+
+	listPaymentsReload := observable.Event{
+		Subject: "lightning/list-payments",
+		Action:  action.Reload,
+	}
+
 	testCases := []struct {
-		name  string
-		event breez_sdk_spark.SdkEvent
+		name        string
+		event       breez_sdk_spark.SdkEvent
+		otherEvents []observable.Event
 	}{
 		{
 			name: "new deposits",
 			event: breez_sdk_spark.SdkEventNewDeposits{
 				NewDeposits: []breez_sdk_spark.DepositInfo{{Txid: "txid"}},
 			},
+			otherEvents: []observable.Event{listPaymentsReload},
 		},
 		{
 			name: "unclaimed deposits",
 			event: breez_sdk_spark.SdkEventUnclaimedDeposits{
 				UnclaimedDeposits: []breez_sdk_spark.DepositInfo{{Txid: "txid"}},
 			},
+			otherEvents: []observable.Event{listPaymentsReload},
 		},
 		{
 			name: "claimed deposits",
 			event: breez_sdk_spark.SdkEventClaimedDeposits{
 				ClaimedDeposits: []breez_sdk_spark.DepositInfo{{Txid: "txid"}},
 			},
+			otherEvents: []observable.Event{listPaymentsReload},
+		},
+		{
+			name:  "synced",
+			event: breez_sdk_spark.SdkEventSynced{},
+		},
+		{
+			name: "payment succeeded",
+			event: breez_sdk_spark.SdkEventPaymentSucceeded{
+				Payment: breez_sdk_spark.Payment{Id: "payment-id"},
+			},
+			otherEvents: []observable.Event{listPaymentsReload},
+		},
+		{
+			name: "payment pending",
+			event: breez_sdk_spark.SdkEventPaymentPending{
+				Payment: breez_sdk_spark.Payment{Id: "payment-id"},
+			},
+			otherEvents: []observable.Event{listPaymentsReload},
+		},
+		{
+			name: "payment failed",
+			event: breez_sdk_spark.SdkEventPaymentFailed{
+				Payment: breez_sdk_spark.Payment{Id: "payment-id"},
+			},
+			otherEvents: []observable.Event{listPaymentsReload},
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			lightning := newTestLightning(t, nil)
-			events := make(chan observable.Event, 1)
+			lightning := newBalanceLightning(t)
+
+			expectedBalance, err := lightning.formattedBalance()
+			require.NoError(t, err)
+			expected := append([]observable.Event{}, testCase.otherEvents...)
+			expected = append(expected, observable.Event{
+				Subject: "lightning/balance",
+				Action:  action.Replace,
+				Object:  expectedBalance,
+			})
+
+			events := make(chan observable.Event, len(expected))
 			lightning.Observe(func(event observable.Event) {
 				events <- event
 			})
 
 			lightning.OnEvent(testCase.event)
 
-			require.Equal(t, observable.Event{
-				Subject: "lightning/list-payments",
-				Action:  action.Reload,
-			}, <-events)
+			var notified []observable.Event
+			for range expected {
+				notified = append(notified, <-events)
+			}
+			require.ElementsMatch(t, expected, notified)
 		})
 	}
 }

--- a/backend/lightning/address_test.go
+++ b/backend/lightning/address_test.go
@@ -653,44 +653,107 @@ func TestLightningAddressChangedEventNotifiesSubscribers(t *testing.T) {
 }
 
 func TestDepositEventsReloadPayments(t *testing.T) {
+	newBalanceLightning := func(t *testing.T) *Lightning {
+		t.Helper()
+		lightning := newTestLightning(t, nil)
+		activateLightningAddressTest(t, lightning)
+		coinLightning := makeTestLightning()
+		lightning.btcCoin = coinLightning.btcCoin
+		lightning.ratesUpdater = coinLightning.ratesUpdater
+		lightning.sdkService = &testBreezSDK{
+			getInfo: func(breez_sdk_spark.GetInfoRequest) (breez_sdk_spark.GetInfoResponse, error) {
+				return breez_sdk_spark.GetInfoResponse{BalanceSats: 100}, nil
+			},
+			listUnclaimedDeposits: func(breez_sdk_spark.ListUnclaimedDepositsRequest) (breez_sdk_spark.ListUnclaimedDepositsResponse, error) {
+				return breez_sdk_spark.ListUnclaimedDepositsResponse{}, nil
+			},
+		}
+		return lightning
+	}
+
+	listPaymentsReload := observable.Event{
+		Subject: "lightning/list-payments",
+		Action:  action.Reload,
+	}
+
 	testCases := []struct {
-		name  string
-		event breez_sdk_spark.SdkEvent
+		name        string
+		event       breez_sdk_spark.SdkEvent
+		otherEvents []observable.Event
 	}{
 		{
 			name: "new deposits",
 			event: breez_sdk_spark.SdkEventNewDeposits{
 				NewDeposits: []breez_sdk_spark.DepositInfo{{Txid: "txid"}},
 			},
+			otherEvents: []observable.Event{listPaymentsReload},
 		},
 		{
 			name: "unclaimed deposits",
 			event: breez_sdk_spark.SdkEventUnclaimedDeposits{
 				UnclaimedDeposits: []breez_sdk_spark.DepositInfo{{Txid: "txid"}},
 			},
+			otherEvents: []observable.Event{listPaymentsReload},
 		},
 		{
 			name: "claimed deposits",
 			event: breez_sdk_spark.SdkEventClaimedDeposits{
 				ClaimedDeposits: []breez_sdk_spark.DepositInfo{{Txid: "txid"}},
 			},
+			otherEvents: []observable.Event{listPaymentsReload},
+		},
+		{
+			name:  "synced",
+			event: breez_sdk_spark.SdkEventSynced{},
+		},
+		{
+			name: "payment succeeded",
+			event: breez_sdk_spark.SdkEventPaymentSucceeded{
+				Payment: breez_sdk_spark.Payment{Id: "payment-id"},
+			},
+			otherEvents: []observable.Event{listPaymentsReload},
+		},
+		{
+			name: "payment pending",
+			event: breez_sdk_spark.SdkEventPaymentPending{
+				Payment: breez_sdk_spark.Payment{Id: "payment-id"},
+			},
+			otherEvents: []observable.Event{listPaymentsReload},
+		},
+		{
+			name: "payment failed",
+			event: breez_sdk_spark.SdkEventPaymentFailed{
+				Payment: breez_sdk_spark.Payment{Id: "payment-id"},
+			},
+			otherEvents: []observable.Event{listPaymentsReload},
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			lightning := newTestLightning(t, nil)
-			events := make(chan observable.Event, 1)
+			lightning := newBalanceLightning(t)
+
+			expectedBalance, err := lightning.formattedBalance()
+			require.NoError(t, err)
+			expected := append([]observable.Event{}, testCase.otherEvents...)
+			expected = append(expected, observable.Event{
+				Subject: "lightning/balance",
+				Action:  action.Replace,
+				Object:  expectedBalance,
+			})
+
+			events := make(chan observable.Event, len(expected))
 			lightning.Observe(func(event observable.Event) {
 				events <- event
 			})
 
 			lightning.OnEvent(testCase.event)
 
-			require.Equal(t, observable.Event{
-				Subject: "lightning/list-payments",
-				Action:  action.Reload,
-			}, <-events)
+			var notified []observable.Event
+			for range expected {
+				notified = append(notified, <-events)
+			}
+			require.ElementsMatch(t, expected, notified)
 		})
 	}
 }

--- a/backend/lightning/event.go
+++ b/backend/lightning/event.go
@@ -15,28 +15,50 @@ func (lightning *Lightning) notifyListPaymentsReload() {
 	})
 }
 
+// NotifyBalanceReload computes the current lightning balance and notifies observers.
+func (lightning *Lightning) NotifyBalanceReload() {
+	if !lightning.Ready() {
+		return
+	}
+
+	balance, err := lightning.formattedBalance()
+	if err != nil {
+		lightning.log.Errorf("failed to compute lightning balance for notification: %v", err)
+		return
+	}
+	lightning.Notify(observable.Event{
+		Subject: "lightning/balance",
+		Action:  action.Replace,
+		Object:  balance,
+	})
+}
+
 // OnEvent handles Breez SDK events and forwards relevant updates to observers.
 func (lightning *Lightning) OnEvent(e breez_sdk_spark.SdkEvent) {
 	switch event := e.(type) {
 	case breez_sdk_spark.SdkEventSynced:
 		// Wallet has been synchronized with the network
+		lightning.NotifyBalanceReload()
 		lightning.log.Infof("Spark: Wallet has been synchronized with the network. Event: %v", e)
 	case breez_sdk_spark.SdkEventUnclaimedDeposits:
 		// SDK was unable to claim some deposits automatically
 		unclaimedDeposits := event.UnclaimedDeposits
 		_ = unclaimedDeposits
 		lightning.notifyListPaymentsReload()
+		lightning.NotifyBalanceReload()
 		lightning.log.Infof("Spark: unable to claim some deposit automatically. Event: %v", e)
 	case breez_sdk_spark.SdkEventClaimedDeposits:
 		// Deposits were successfully claimed
 		claimedDeposits := event.ClaimedDeposits
 		_ = claimedDeposits
 		lightning.notifyListPaymentsReload()
+		lightning.NotifyBalanceReload()
 		lightning.log.Infof("Spark: deposit successfully claimed. Event: %v", e)
 	case breez_sdk_spark.SdkEventNewDeposits:
 		newDeposits := event.NewDeposits
 		_ = newDeposits
 		lightning.notifyListPaymentsReload()
+		lightning.NotifyBalanceReload()
 		lightning.log.Infof("Spark: new deposit detected. Event: %v", e)
 	case breez_sdk_spark.SdkEventPaymentSucceeded:
 		// A payment completed successfully
@@ -44,18 +66,21 @@ func (lightning *Lightning) OnEvent(e breez_sdk_spark.SdkEvent) {
 		_ = payment
 
 		lightning.notifyListPaymentsReload()
+		lightning.NotifyBalanceReload()
 		lightning.log.Infof("Spark: payment completed successfully. Event: %v", e)
 	case breez_sdk_spark.SdkEventPaymentPending:
 		// A payment is pending (waiting for confirmation)
 		pendingPayment := event.Payment
 		_ = pendingPayment
 		lightning.notifyListPaymentsReload()
+		lightning.NotifyBalanceReload()
 		lightning.log.Infof("Spark: payment waiting for confirmation. Event: %v", e)
 	case breez_sdk_spark.SdkEventPaymentFailed:
 		// A payment failed
 		failedPayment := event.Payment
 		_ = failedPayment
 		lightning.notifyListPaymentsReload()
+		lightning.NotifyBalanceReload()
 		lightning.log.Infof("Spark: payment failed. Event: %v", e)
 	case breez_sdk_spark.SdkEventLightningAddressChanged:
 		lightning.Notify(observable.Event{

--- a/backend/lightning/event_test.go
+++ b/backend/lightning/event_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package lightning
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
+	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotifyBalanceReloadNotReady(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*testing.T, *Lightning)
+	}{
+		{
+			name: "no account",
+		},
+		{
+			name: "SDK disconnected",
+			configure: func(t *testing.T, lightning *Lightning) {
+				t.Helper()
+				require.NoError(t, lightning.SetAccount(&config.LightningAccountConfig{
+					Code: "v0-deadbeef-ln-0",
+				}))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lightning := newTestLightning(t, nil)
+			if test.configure != nil {
+				test.configure(t, lightning)
+			}
+
+			var logOutput bytes.Buffer
+			logger := logrus.New()
+			logger.SetOutput(&logOutput)
+			lightning.log = logrus.NewEntry(logger)
+
+			var events []observable.Event
+			lightning.Observe(func(event observable.Event) {
+				events = append(events, event)
+			})
+
+			lightning.NotifyBalanceReload()
+
+			require.Empty(t, events)
+			require.Empty(t, logOutput.String())
+		})
+	}
+}
+
+func TestNotifyBalanceReloadLogsReadyFailure(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	require.NoError(t, lightning.SetAccount(&config.LightningAccountConfig{
+		Code: "v0-deadbeef-ln-0",
+	}))
+	lightning.sdkService = &testBreezSDK{
+		getInfo: func(breez_sdk_spark.GetInfoRequest) (breez_sdk_spark.GetInfoResponse, error) {
+			return breez_sdk_spark.GetInfoResponse{}, errors.New("get info failed")
+		},
+	}
+
+	var logOutput bytes.Buffer
+	logger := logrus.New()
+	logger.SetOutput(&logOutput)
+	lightning.log = logrus.NewEntry(logger)
+
+	var events []observable.Event
+	lightning.Observe(func(event observable.Event) {
+		events = append(events, event)
+	})
+
+	lightning.NotifyBalanceReload()
+
+	require.Empty(t, events)
+	require.Contains(t, logOutput.String(), "failed to compute lightning balance for notification")
+	require.Contains(t, logOutput.String(), "get info failed")
+}

--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -216,11 +216,16 @@ func (lightning *Lightning) PostDeactivate(_ *http.Request) interface{} {
 	return responseDto{Success: true}
 }
 
-// GetBalance handles the GET request to retrieve the balance and its fiat conversions.
-func (lightning *Lightning) GetBalance(_ *http.Request) interface{} {
+type formattedLightningBalance struct {
+	accounts.FormattedAccountBalance
+	FundingLimit fundingLimit `json:"fundingLimit"`
+}
+
+// formattedBalance returns the lightning balance with its fiat conversions.
+func (lightning *Lightning) formattedBalance() (*formattedLightningBalance, error) {
 	balance, limit, err := lightning.balanceWithFundingLimit()
 	if err != nil {
-		return errorResponse(err)
+		return nil, err
 	}
 
 	btcCoin := lightning.btcCoin
@@ -238,20 +243,27 @@ func (lightning *Lightning) GetBalance(_ *http.Request) interface{} {
 		UnformattedConversions: coin.UnformattedConversions(balance.Incoming(), btcCoin, false, lightning.ratesUpdater),
 	}
 
+	return &formattedLightningBalance{
+		FormattedAccountBalance: accounts.FormattedAccountBalance{
+			HasAvailable: balance.Available().BigInt().Sign() > 0,
+			Available:    formattedAvailableAmount,
+			HasIncoming:  balance.Incoming().BigInt().Sign() > 0,
+			Incoming:     formattedIncomingAmount,
+		},
+		FundingLimit: limit,
+	}, nil
+}
+
+// GetBalance handles the GET request to retrieve the balance and its fiat conversions.
+func (lightning *Lightning) GetBalance(_ *http.Request) interface{} {
+	balance, err := lightning.formattedBalance()
+	if err != nil {
+		return errorResponse(err)
+	}
+
 	return responseDto{
 		Success: true,
-		Data: struct {
-			accounts.FormattedAccountBalance
-			FundingLimit fundingLimit `json:"fundingLimit"`
-		}{
-			FormattedAccountBalance: accounts.FormattedAccountBalance{
-				HasAvailable: balance.Available().BigInt().Sign() > 0,
-				Available:    formattedAvailableAmount,
-				HasIncoming:  balance.Incoming().BigInt().Sign() > 0,
-				Incoming:     formattedIncomingAmount,
-			},
-			FundingLimit: limit,
-		},
+		Data:    balance,
 	}
 }
 

--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -158,11 +158,11 @@ func (lightning *Lightning) PostDeactivate(_ *http.Request) interface{} {
 	return responseDto{Success: true}
 }
 
-// GetBalance handles the GET request to retrieve the balance and its fiat conversions.
-func (lightning *Lightning) GetBalance(_ *http.Request) interface{} {
+// formattedBalance returns the lightning balance with its fiat conversions.
+func (lightning *Lightning) formattedBalance() (*accounts.FormattedAccountBalance, error) {
 	balance, err := lightning.Balance()
 	if err != nil {
-		return errorResponse(err)
+		return nil, err
 	}
 
 	btcCoin := lightning.btcCoin
@@ -180,14 +180,24 @@ func (lightning *Lightning) GetBalance(_ *http.Request) interface{} {
 		UnformattedConversions: coin.UnformattedConversions(balance.Incoming(), btcCoin, false, lightning.ratesUpdater),
 	}
 
+	return &accounts.FormattedAccountBalance{
+		HasAvailable: balance.Available().BigInt().Sign() > 0,
+		Available:    formattedAvailableAmount,
+		HasIncoming:  balance.Incoming().BigInt().Sign() > 0,
+		Incoming:     formattedIncomingAmount,
+	}, nil
+}
+
+// GetBalance handles the GET request to retrieve the balance and its fiat conversions.
+func (lightning *Lightning) GetBalance(_ *http.Request) interface{} {
+	balance, err := lightning.formattedBalance()
+	if err != nil {
+		return errorResponse(err)
+	}
+
 	return responseDto{
 		Success: true,
-		Data: accounts.FormattedAccountBalance{
-			HasAvailable: balance.Available().BigInt().Sign() > 0,
-			Available:    formattedAvailableAmount,
-			HasIncoming:  balance.Incoming().BigInt().Sign() > 0,
-			Incoming:     formattedIncomingAmount,
-		},
+		Data:    balance,
 	}
 }
 

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -389,6 +389,7 @@ func (lightning *Lightning) connect() error {
 
 		lightning.sdkService = sdk
 		lightning.notifyReady()
+		lightning.NotifyBalanceReload()
 		if _, err := lightning.ensureLightningAddress(); err != nil {
 			lightning.log.WithError(err).Warn("BreezSDK: Error ensuring lightning address")
 		}

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -423,6 +423,7 @@ func (lightning *Lightning) connect() error {
 
 		lightning.sdkService = sdk
 		lightning.notifyReady()
+		lightning.NotifyBalanceReload()
 		if _, err := lightning.ensureLightningAddress(); err != nil {
 			lightning.log.WithError(err).Warn("BreezSDK: Error ensuring lightning address")
 		}

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -302,3 +302,9 @@ export const subscribeLightningReady = (cb: TSubscriptionCallback<boolean>): TUn
 export const subscribeListPayments = (cb: TSubscriptionCallback<TLightningPayment[]>) => {
   return subscribeEndpoint('lightning/list-payments', cb);
 };
+
+export const subscribeLightningBalance = (
+  cb: TSubscriptionCallback<TBalance>,
+): TUnsubscribe => {
+  return subscribeEndpoint('lightning/balance', cb);
+};

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -411,3 +411,9 @@ export const subscribeLightningReady = (cb: TSubscriptionCallback<boolean>): TUn
 export const subscribeListPayments = (cb: TSubscriptionCallback<TLightningPayment[]>) => {
   return subscribeEndpoint('lightning/list-payments', cb);
 };
+
+export const subscribeLightningBalance = (
+  cb: TSubscriptionCallback<TLightningBalance>,
+): TUnsubscribe => {
+  return subscribeEndpoint('lightning/balance', cb);
+};

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import * as accountApi from '@/api/account';
 import { TDevices } from '@/api/devices';
 import { statusChanged, syncdone } from '@/api/accountsync';
-import { subscribeListPayments } from '@/api/lightning';
+import { subscribeLightningBalance } from '@/api/lightning';
 import { unsubscribe } from '@/utils/subscriptions';
 import { TUnsubscribe } from '@/utils/transport-common';
 import { useMountedRef } from '@/hooks/mount';
@@ -143,7 +143,7 @@ export const AccountsSummary = ({
       ));
     });
     if (lightningAccount !== null) {
-      subscriptions.push(subscribeListPayments(() => {
+      subscriptions.push(subscribeLightningBalance(() => {
         if (mounted.current) {
           getChartData();
           getAccountsBalanceSummary();

--- a/frontends/web/src/routes/accounts/all-accounts.tsx
+++ b/frontends/web/src/routes/accounts/all-accounts.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 import { useOnlyVisitableOnMobile } from '@/hooks/onlyvisitableonmobile';
 import * as accountApi from '@/api/account';
 import { getBalance } from '@/api/account';
-import { getLightningBalance } from '@/api/lightning';
+import { getLightningBalance, subscribeLightningBalance } from '@/api/lightning';
 import { Logo } from '@/components/icon/logo';
 import { View, ViewContent } from '@/components/view/view';
 import { getAccountsByKeystore } from '@/routes/account/utils';
@@ -17,6 +17,7 @@ import { AllAccountsGuide } from '@/routes/accounts/all-accounts-guide';
 import { useMountedRef } from '@/hooks/mount';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import { ConnectedKeystore } from '@/components/keystore/connected-keystore';
+import { useSync } from '@/hooks/api';
 import { useLightning } from '@/hooks/lightning';
 import styles from './all-accounts.module.css';
 
@@ -87,33 +88,11 @@ const AccountItem = ({ account }: TAccountItemProp) => {
 
 const LightningItem = () => {
   const { t } = useTranslation();
-  const { isLightningReady } = useLightning();
-  const [balance, setBalance] = useState<accountApi.TAmountWithConversions>();
-  const mounted = useMountedRef();
-
-  useEffect(() => {
-    if (!isLightningReady) {
-      return;
-    }
-
-    const fetchBalance = async () => {
-      try {
-        const response = await getLightningBalance();
-        if (!mounted.current) {
-          return;
-        }
-        setBalance(response.available);
-      } catch (error) {
-        console.error('Failed to fetch lightning balance', error);
-      }
-    };
-
-    fetchBalance();
-  }, [isLightningReady, mounted]);
+  const balance = useSync(getLightningBalance, subscribeLightningBalance);
 
   return (
     <AccountRow
-      balance={balance}
+      balance={balance?.available}
       coinCode="lightning"
       name={t('lightning.accountLabel')}
       to="/lightning"

--- a/frontends/web/src/routes/lightning/lightning.test.tsx
+++ b/frontends/web/src/routes/lightning/lightning.test.tsx
@@ -25,6 +25,10 @@ vi.mock('@/components/banners', () => ({
   GlobalBanners: () => null,
 }));
 
+vi.mock('@/components/banners/lightning-tor-proxy-warning', () => ({
+  LightningTorProxyWarning: () => null,
+}));
+
 vi.mock('@/components/hideamountsbutton/hideamountsbutton', () => ({
   HideAmountsButton: () => null,
 }));
@@ -90,6 +94,7 @@ describe('Lightning funding limit', () => {
     vi.spyOn(lightningApi, 'getLightningBalance').mockResolvedValue(balance);
     vi.spyOn(lightningApi, 'getListPayments').mockResolvedValue([]);
     vi.spyOn(lightningApi, 'getSparkStatus').mockResolvedValue({ status: 'operational' });
+    vi.spyOn(lightningApi, 'subscribeLightningBalance').mockReturnValue(vi.fn());
     vi.spyOn(lightningApi, 'subscribeListPayments').mockReturnValue(vi.fn());
   });
 

--- a/frontends/web/src/routes/lightning/lightning.tsx
+++ b/frontends/web/src/routes/lightning/lightning.tsx
@@ -9,6 +9,7 @@ import {
   getBlockExplorerTxPrefix,
   getLightningBalance,
   getListPayments,
+  subscribeLightningBalance,
   subscribeListPayments,
   getSparkStatus,
   TSparkStatus,
@@ -25,7 +26,7 @@ import { Status } from '../../components/status/status';
 import { HideAmountsButton } from '../../components/hideamountsbutton/hideamountsbutton';
 import { PaymentDetails } from './components/payment-details';
 import { RatesContext } from '@/contexts/RatesContext';
-import { useLoad } from '@/hooks/api';
+import { useLoad, useSync } from '@/hooks/api';
 import { useMountedRef } from '@/hooks/mount';
 import { useLightning } from '@/hooks/lightning';
 import { TransactionList } from '@/routes/account/components/transaction-list';
@@ -283,7 +284,7 @@ export const Lightning = () => {
   const { t } = useTranslation();
   const { btcUnit } = useContext(RatesContext);
   const { isLightningReady, lightningAccount } = useLightning();
-  const [balance, setBalance] = useState<accountApi.TBalance>();
+  const balance = useSync(getLightningBalance, subscribeLightningBalance);
   const [syncedAddressesCount] = useState<number>();
   const [payments, setPayments] = useState<TLightningPayment[]>();
   const [sparkStatus, setSparkStatus] = useState<TSparkStatus>();
@@ -295,14 +296,10 @@ export const Lightning = () => {
   const onStateChange = useCallback(async () => {
     try {
       setError(undefined);
-      const [balance, payments] = await Promise.all([
-        getLightningBalance(),
-        getListPayments(),
-      ]);
+      const payments = await getListPayments();
       if (!mounted.current) {
         return;
       }
-      setBalance(balance);
       setPayments(payments);
     } catch (err: any) {
       if (!mounted.current) {

--- a/frontends/web/src/routes/lightning/lightning.tsx
+++ b/frontends/web/src/routes/lightning/lightning.tsx
@@ -10,6 +10,7 @@ import {
   getBlockExplorerTxPrefix,
   getLightningBalance,
   getListPayments,
+  subscribeLightningBalance,
   subscribeListPayments,
   getSparkStatus,
   TSparkStatus,
@@ -27,7 +28,7 @@ import { Status } from '../../components/status/status';
 import { HideAmountsButton } from '../../components/hideamountsbutton/hideamountsbutton';
 import { PaymentDetails } from './components/payment-details';
 import { RatesContext } from '@/contexts/RatesContext';
-import { useLoad } from '@/hooks/api';
+import { useLoad, useSync } from '@/hooks/api';
 import { useMountedRef } from '@/hooks/mount';
 import { useLightning } from '@/hooks/lightning';
 import { Link } from 'react-router-dom';
@@ -303,7 +304,7 @@ export const Lightning = () => {
   const { t } = useTranslation();
   const { btcUnit } = useContext(RatesContext);
   const { isLightningReady, lightningAccount } = useLightning();
-  const [balance, setBalance] = useState<TLightningBalance>();
+  const balance = useSync(getLightningBalance, subscribeLightningBalance);
   const [syncedAddressesCount] = useState<number>();
   const [payments, setPayments] = useState<TLightningPayment[]>();
   const [sparkStatus, setSparkStatus] = useState<TSparkStatus>();
@@ -315,14 +316,10 @@ export const Lightning = () => {
   const onStateChange = useCallback(async () => {
     try {
       setError(undefined);
-      const [balance, payments] = await Promise.all([
-        getLightningBalance(),
-        getListPayments(),
-      ]);
+      const payments = await getListPayments();
       if (!mounted.current) {
         return;
       }
-      setBalance(balance);
       setPayments(payments);
     } catch (err: any) {
       if (!mounted.current) {

--- a/frontends/web/src/routes/lightning/receive/receive.test.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.test.tsx
@@ -88,6 +88,7 @@ describe('Lightning receive funding limit', () => {
     vi.spyOn(lightningApi, 'subscribeLightningAddress').mockReturnValue(vi.fn());
     vi.spyOn(lightningApi, 'getLightningBalance').mockResolvedValue(balance);
     vi.spyOn(lightningApi, 'getReceivePayment').mockResolvedValue({ invoice: 'lnbc1invoice' });
+    vi.spyOn(lightningApi, 'subscribeLightningBalance').mockReturnValue(vi.fn());
   });
 
   it('warns on the form and generated invoice without blocking creation', async () => {

--- a/frontends/web/src/routes/lightning/receive/receive.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.tsx
@@ -10,6 +10,7 @@ import {
   getLightningBalance,
   getLightningAddress,
   getReceivePayment,
+  subscribeLightningBalance,
   subscribeLightningAddress,
 } from '@/api/lightning';
 import { Status } from '@/components/status/status';
@@ -20,7 +21,7 @@ import { FormattedAmount } from '@/components/amount/amount';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import { useNavigate } from 'react-router-dom';
 import { RatesContext } from '@/contexts/RatesContext';
-import { useLoad, useSync } from '@/hooks/api';
+import { useSync } from '@/hooks/api';
 import { toLightningErrorMessage } from '@/api/lightning-errors';
 import { useSatFiatAmount } from '../hooks/use-sat-fiat-amount';
 import { type TReceiveStep, useReceivePaymentSuccess } from './use-receive-payment-success';
@@ -49,8 +50,7 @@ export function Receive() {
   const [receivePaymentResponse, setReceivePaymentResponse] = useState<TReceivePaymentResponse>();
   const [receiveError, setReceiveError] = useState<string>();
   const [step, setStep] = useState<TReceiveStep>('address');
-  const [balanceLoadAttempt, setBalanceLoadAttempt] = useState(0);
-  const lightningBalance = useLoad(getLightningBalance, [balanceLoadAttempt]);
+  const lightningBalance = useSync(getLightningBalance, subscribeLightningBalance);
   const lightningAddress = useSync(getLightningAddress, subscribeLightningAddress);
   const fundingLimit = lightningBalance?.fundingLimit;
   const fundingLimitError = getLightningFundingLimitError(fundingLimit, invoiceAmountSat);
@@ -59,7 +59,6 @@ export function Receive() {
     : lightningBalance?.available.unformattedConversions?.sat;
   const hasLightningBalance = lightningBalance !== undefined;
   const onReceivePaymentSuccess = useCallback(() => {
-    setBalanceLoadAttempt(attempt => attempt + 1);
     setStep('success');
   }, []);
   const { receivedPayment, resetReceivedPayment } = useReceivePaymentSuccess({

--- a/frontends/web/src/routes/lightning/receive/receive.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.tsx
@@ -10,6 +10,7 @@ import {
   getLightningBalance,
   getLightningAddress,
   getReceivePayment,
+  subscribeLightningBalance,
   subscribeLightningAddress,
 } from '@/api/lightning';
 import { Status } from '@/components/status/status';
@@ -20,7 +21,7 @@ import { FormattedAmount } from '@/components/amount/amount';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import { useNavigate } from 'react-router-dom';
 import { RatesContext } from '@/contexts/RatesContext';
-import { useLoad, useSync } from '@/hooks/api';
+import { useSync } from '@/hooks/api';
 import { toLightningErrorMessage } from '@/api/lightning-errors';
 import { useSatFiatAmount } from '../hooks/use-sat-fiat-amount';
 import { type TReceiveStep, useReceivePaymentSuccess } from './use-receive-payment-success';
@@ -44,15 +45,13 @@ export function Receive() {
   const [receivePaymentResponse, setReceivePaymentResponse] = useState<TReceivePaymentResponse>();
   const [receiveError, setReceiveError] = useState<string>();
   const [step, setStep] = useState<TReceiveStep>('address');
-  const [balanceLoadAttempt, setBalanceLoadAttempt] = useState(0);
-  const lightningBalance = useLoad(getLightningBalance, [balanceLoadAttempt]);
+  const lightningBalance = useSync(getLightningBalance, subscribeLightningBalance);
   const lightningAddress = useSync(getLightningAddress, subscribeLightningAddress);
   const satsBalance = lightningBalance?.available.unit === 'sat'
     ? lightningBalance.available.amount
     : lightningBalance?.available.unformattedConversions?.sat;
   const hasLightningBalance = lightningBalance !== undefined;
   const onReceivePaymentSuccess = useCallback(() => {
-    setBalanceLoadAttempt(attempt => attempt + 1);
     setStep('success');
   }, []);
   const { receivedPayment, resetReceivedPayment } = useReceivePaymentSuccess({

--- a/frontends/web/src/routes/lightning/send/components/custom-payment-amount.tsx
+++ b/frontends/web/src/routes/lightning/send/components/custom-payment-amount.tsx
@@ -2,11 +2,11 @@
 
 import { type ReactNode, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getLightningBalance } from '@/api/lightning';
+import { getLightningBalance, subscribeLightningBalance } from '@/api/lightning';
 import { Balance } from '@/components/balance/balance';
 import { NumberInput } from '@/components/forms';
 import { RatesContext } from '@/contexts/RatesContext';
-import { useLoad } from '@/hooks/api';
+import { useSync } from '@/hooks/api';
 import { useSatFiatAmount } from '../../hooks/use-sat-fiat-amount';
 import styles from '../send.module.css';
 
@@ -18,8 +18,7 @@ type TProps = {
 };
 
 export const PaymentBalance = () => {
-  const { btcUnit } = useContext(RatesContext);
-  const balance = useLoad(getLightningBalance, [btcUnit]);
+  const balance = useSync(getLightningBalance, subscribeLightningBalance);
 
   return (
     <div className={styles.availableBalance}>

--- a/frontends/web/src/routes/lightning/send/components/custom-payment-amount.tsx
+++ b/frontends/web/src/routes/lightning/send/components/custom-payment-amount.tsx
@@ -2,11 +2,11 @@
 
 import { useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getLightningBalance } from '@/api/lightning';
+import { getLightningBalance, subscribeLightningBalance } from '@/api/lightning';
 import { Balance } from '@/components/balance/balance';
 import { NumberInput } from '@/components/forms';
 import { RatesContext } from '@/contexts/RatesContext';
-import { useLoad } from '@/hooks/api';
+import { useSync } from '@/hooks/api';
 import { useSatFiatAmount } from '../../hooks/use-sat-fiat-amount';
 import styles from '../send.module.css';
 
@@ -17,8 +17,7 @@ type TProps = {
 };
 
 export const PaymentBalance = () => {
-  const { btcUnit } = useContext(RatesContext);
-  const balance = useLoad(getLightningBalance, [btcUnit]);
+  const balance = useSync(getLightningBalance, subscribeLightningBalance);
 
   return (
     <div className={styles.availableBalance}>

--- a/frontends/web/src/routes/lightning/topup/topup.test.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup.test.tsx
@@ -100,6 +100,7 @@ describe('LightningTopUp', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(accountApi, 'getBalance').mockResolvedValue({ success: true, balance: lightningBalance() });
+    vi.spyOn(lightningApi, 'subscribeLightningBalance').mockReturnValue(vi.fn());
   });
 
   it('prepares and sends a top-up through the dedicated endpoint', async () => {

--- a/frontends/web/src/routes/lightning/topup/topup.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup.tsx
@@ -5,9 +5,9 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import * as accountApi from '@/api/account';
 import { convertFromCurrency, convertToCurrency } from '@/api/coins';
-import { getBoardingAddress, getLightningBalance } from '@/api/lightning';
+import { getBoardingAddress, getLightningBalance, subscribeLightningBalance } from '@/api/lightning';
 import { connectKeystore } from '@/api/keystores';
-import { useLoad } from '@/hooks/api';
+import { useLoad, useSync } from '@/hooks/api';
 import { useMountedRef } from '@/hooks/mount';
 import { usePrevious } from '@/hooks/previous';
 import { getDisplayedCoinUnit, isBitcoinOnly } from '@/routes/account/utils';
@@ -23,34 +23,6 @@ type TProps = {
 };
 
 type TStep = 'form' | 'confirming' | 'success' | 'aborted';
-
-const useLightningBalance = () => {
-  const mounted = useMountedRef();
-  const balanceRequest = useRef(0);
-  const [balance, setBalance] = useState<accountApi.TBalance>();
-
-  const reloadBalance = useCallback(() => {
-    const request = ++balanceRequest.current;
-    getLightningBalance().then((nextBalance) => {
-      if (request === balanceRequest.current && mounted.current) {
-        setBalance(nextBalance);
-      }
-    }).catch(() => {
-      if (request === balanceRequest.current && mounted.current) {
-        setBalance(undefined);
-      }
-    });
-  }, [mounted]);
-
-  useEffect(() => {
-    reloadBalance();
-  }, [reloadBalance]);
-
-  return {
-    balance,
-    reloadBalance,
-  };
-};
 
 const getTopUpAccounts = async (accounts: accountApi.TAccount[]) => {
   const accountHasBalance = await Promise.all(accounts.map(async (account) => {
@@ -84,7 +56,7 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
   const topUpAccounts = useLoad(() => getTopUpAccounts(btcAccounts), [btcAccounts]);
   const [sourceAccountCode, setSourceAccountCode] = useState<accountApi.AccountCode>('');
   const sourceAccount = topUpAccounts?.find(account => account.code === sourceAccountCode);
-  const { balance: lightningBalance, reloadBalance: reloadLightningBalance } = useLightningBalance();
+  const lightningBalance = useSync(getLightningBalance, subscribeLightningBalance);
   const sourceAmountUnit = sourceAccount
     ? getDisplayedCoinUnit(sourceAccount.coinCode, sourceAccount.coinUnit, btcUnit)
     : 'BTC';
@@ -344,7 +316,6 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
       setIsSubmitting(false);
       return;
     }
-    reloadLightningBalance();
 
     try {
       setStep('confirming');

--- a/frontends/web/src/routes/lightning/topup/topup.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup.tsx
@@ -9,10 +9,11 @@ import {
   getLightningBalance,
   lightningBalanceLimitErrorCode,
   postPrepareTopUp,
+  subscribeLightningBalance,
   type TPrepareTopUpResult,
 } from '@/api/lightning';
 import { connectKeystore } from '@/api/keystores';
-import { useLoad } from '@/hooks/api';
+import { useLoad, useSync } from '@/hooks/api';
 import { useMountedRef } from '@/hooks/mount';
 import { usePrevious } from '@/hooks/previous';
 import { getDisplayedCoinUnit, isBitcoinOnly } from '@/routes/account/utils';
@@ -64,7 +65,7 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
   const topUpAccounts = useLoad(() => getTopUpAccounts(btcAccounts), [btcAccounts]);
   const [sourceAccountCode, setSourceAccountCode] = useState<accountApi.AccountCode>('');
   const sourceAccount = topUpAccounts?.find(account => account.code === sourceAccountCode);
-  const lightningBalance = useLoad(() => getLightningBalance().catch(() => undefined));
+  const lightningBalance = useSync(getLightningBalance, subscribeLightningBalance);
   const sourceAmountUnit = sourceAccount
     ? getDisplayedCoinUnit(sourceAccount.coinCode, sourceAccount.coinUnit, btcUnit)
     : 'BTC';
@@ -320,6 +321,7 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
       setIsSubmitting(false);
       return;
     }
+
     try {
       setSendError(undefined);
       setStep('confirming');

--- a/frontends/web/src/routes/settings/lightning-settings.tsx
+++ b/frontends/web/src/routes/settings/lightning-settings.tsx
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { getLightningBalance, subscribeListPayments } from '@/api/lightning';
+import { getLightningBalance, subscribeLightningBalance } from '@/api/lightning';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { GlobalBanners } from '@/components/banners';
 import { Header, Main } from '@/components/layout';
@@ -11,7 +10,7 @@ import { View, ViewContent } from '@/components/view/view';
 import { Checked } from '@/components/icon';
 import { SubTitle } from '@/components/title';
 import { getKeystoreName } from '@/api/keystores';
-import { useLoad } from '@/hooks/api';
+import { useLoad, useSubscribe } from '@/hooks/api';
 import { useLightning } from '@/hooks/lightning';
 import { SettingsItem } from './components/settingsItem/settingsItem';
 import { MobileHeader } from './components/mobile-header';
@@ -32,20 +31,14 @@ export const LightningSettings = ({
       : null,
     [lightningAccount?.rootFingerprint]
   );
-  const [balanceLoadAttempt, setBalanceLoadAttempt] = useState(0);
-  const lightningBalance = useLoad(
+  const loadedLightningBalance = useLoad(
     lightningAccount && isLightningReady ? getLightningBalance : null,
-    [balanceLoadAttempt, isLightningReady, lightningAccount]
+    [isLightningReady, lightningAccount]
   );
-
-  useEffect(() => {
-    if (!lightningAccount || !isLightningReady) {
-      return;
-    }
-    return subscribeListPayments(() => {
-      setBalanceLoadAttempt(current => current + 1);
-    });
-  }, [isLightningReady, lightningAccount]);
+  const subscribedLightningBalance = useSubscribe(subscribeLightningBalance);
+  const lightningBalance = lightningAccount && isLightningReady
+    ? subscribedLightningBalance ?? loadedLightningBalance
+    : undefined;
 
   const renderContent = () => {
     if (lightningAccount === undefined) {


### PR DESCRIPTION
Lightning balances were fetched only when a view loaded,
so the view could keep showing a stale balance after a
payment was received.

Publish balance notifications from the backend whenever
the balance or its displayed value changes, and consume
them with useSync wherever the frontend displays a
Lightning balance. This preserves the initial load
while keeping the current view updated as the balance
changes.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
