### PR TITLE
lightning: support on-chain payments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,14 @@ Functions in `src/api/` should stay as thin wrappers around the underlying reque
 should only type the function arguments and the returned promise, and should not add extra client
 side control flow or business logic on top of the request.
 
+### UUID Generation
+Do not call `crypto.randomUUID()` directly in bundled frontend code. Some Qt WebEngine builds may
+not expose it. Use `randomUUID()` from `src/utils/uuid.ts`, which falls back to
+`crypto.getRandomValues()`.
+
+Standalone files under `frontends/web/public/` that are not bundled with the React app must provide
+the same fallback locally.
+
 ### Data Loading Hooks
 Key custom hooks in `src/hooks/` handle all async data:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,9 @@ Functions in `src/api/` should stay as thin wrappers around the underlying reque
 should only type the function arguments and the returned promise, and should not add extra client
 side control flow or business logic on top of the request.
 
+Standalone files under `frontends/web/public/` that are not bundled with the React app must provide
+the same fallback locally.
+
 ### Data Loading Hooks
 Key custom hooks in `src/hooks/` handle all async data:
 

--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -4,6 +4,7 @@ package lightning
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -17,10 +18,11 @@ import (
 )
 
 type responseDto struct {
-	Success      bool        `json:"success"`
-	Data         interface{} `json:"data"`
-	ErrorMessage string      `json:"errorMessage,omitempty"`
-	ErrorCode    string      `json:"errorCode,omitempty"`
+	Success      bool                   `json:"success"`
+	Data         interface{}            `json:"data"`
+	ErrorData    map[string]interface{} `json:"errorData,omitempty"`
+	ErrorMessage string                 `json:"errorMessage,omitempty"`
+	ErrorCode    string                 `json:"errorCode,omitempty"`
 }
 
 // NewHandlers creates a new Handlers instance.
@@ -52,7 +54,14 @@ func NewHandlers(
 
 func errorResponse(err error) responseDto {
 	if errCode, ok := errp.Cause(err).(errp.ErrorCode); ok {
-		return responseDto{Success: false, ErrorCode: string(errCode)}
+		response := responseDto{Success: false, ErrorCode: string(errCode)}
+		var amountBelowMinimum *lightningAmountBelowMinimumError
+		if errors.As(err, &amountBelowMinimum) {
+			response.ErrorData = map[string]interface{}{
+				"minAmountSat": amountBelowMinimum.minAmountSat,
+			}
+		}
+		return response
 	}
 	return responseDto{Success: false, ErrorMessage: err.Error()}
 }
@@ -308,9 +317,10 @@ func (lightning *Lightning) PostSendPayment(r *http.Request) interface{} {
 		return errorResponse(err)
 	}
 
-	if err := lightning.SendPayment(jsonBody); err != nil {
+	payment, err := lightning.SendPayment(jsonBody)
+	if err != nil {
 		return errorResponse(err)
 	}
 
-	return responseDto{Success: true}
+	return responseDto{Success: true, Data: payment}
 }

--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -4,6 +4,7 @@ package lightning
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -17,10 +18,11 @@ import (
 )
 
 type responseDto struct {
-	Success      bool        `json:"success"`
-	Data         interface{} `json:"data"`
-	ErrorMessage string      `json:"errorMessage,omitempty"`
-	ErrorCode    string      `json:"errorCode,omitempty"`
+	Success      bool                   `json:"success"`
+	Data         interface{}            `json:"data"`
+	ErrorData    map[string]interface{} `json:"errorData,omitempty"`
+	ErrorMessage string                 `json:"errorMessage,omitempty"`
+	ErrorCode    string                 `json:"errorCode,omitempty"`
 }
 
 // NewHandlers creates a new Handlers instance.
@@ -54,9 +56,28 @@ func NewHandlers(
 
 func errorResponse(err error) responseDto {
 	if errCode, ok := errp.Cause(err).(errp.ErrorCode); ok {
-		return responseDto{Success: false, ErrorCode: string(errCode)}
+		response := responseDto{Success: false, ErrorCode: string(errCode)}
+		var amountBelowMinimum *lightningAmountBelowMinimumError
+		if errors.As(err, &amountBelowMinimum) {
+			response.ErrorData = map[string]interface{}{
+				"minAmountSat": amountBelowMinimum.minAmountSat,
+			}
+		}
+		return response
 	}
 	return responseDto{Success: false, ErrorMessage: err.Error()}
+}
+
+func preparePaymentErrorResponse(err error, fee *paymentFee) responseDto {
+	response := errorResponse(err)
+	if fee != nil && response.ErrorCode == string(errLightningInsufficientFunds) {
+		response.ErrorData = map[string]interface{}{
+			"amountSat":     fee.AmountSat,
+			"feeSat":        fee.FeeSat,
+			"totalDebitSat": fee.TotalDebitSat,
+		}
+	}
+	return response
 }
 
 // GetAccount handles the GET request to retrieve the configured lightning account.
@@ -325,7 +346,7 @@ func (lightning *Lightning) PostPreparePayment(r *http.Request) interface{} {
 
 	fee, err := lightning.PreparePayment(jsonBody)
 	if err != nil {
-		return errorResponse(err)
+		return preparePaymentErrorResponse(err, fee)
 	}
 
 	return responseDto{Success: true, Data: fee}

--- a/backend/lightning/payments.go
+++ b/backend/lightning/payments.go
@@ -17,15 +17,31 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
+	"github.com/btcsuite/btcd/mempool"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/google/uuid"
 )
 
 const (
 	errPaymentApprovalRequired      errp.ErrorCode = "paymentApprovalRequired"
+	errLightningAmountBelowMinimum  errp.ErrorCode = "lightningAmountBelowMinimum"
 	errLightningInvalidAmount       errp.ErrorCode = "lightningInvalidAmount"
 	errLightningInvalidPaymentInput errp.ErrorCode = "lightningInvalidPaymentInput"
 	errLightningInsufficientFunds   errp.ErrorCode = "lightningInsufficientFunds"
 	errLightningInvoiceAlreadyUsed  errp.ErrorCode = "lightningInvoiceAlreadyUsed"
 )
+
+type lightningAmountBelowMinimumError struct {
+	minAmountSat uint64
+}
+
+func (err *lightningAmountBelowMinimumError) Error() string {
+	return errLightningAmountBelowMinimum.Error()
+}
+
+func (err *lightningAmountBelowMinimumError) Cause() error {
+	return errLightningAmountBelowMinimum
+}
 
 type lightningBolt11Invoice struct {
 	Invoice     string  `json:"invoice"`
@@ -42,10 +58,16 @@ type lightningLNURLPay struct {
 	MaxAmountSat uint64  `json:"maxAmountSat"`
 }
 
+type lightningBitcoinPaymentInput struct {
+	Address   string  `json:"address"`
+	AmountSat *uint64 `json:"amountSat,omitempty"`
+}
+
 type paymentInput struct {
-	Type     string                  `json:"type"`
-	Bolt11   *lightningBolt11Invoice `json:"invoice,omitempty"`
-	LNURLPay *lightningLNURLPay      `json:"lnurlPay,omitempty"`
+	Type           string                        `json:"type"`
+	Bolt11         *lightningBolt11Invoice       `json:"invoice,omitempty"`
+	LNURLPay       *lightningLNURLPay            `json:"lnurlPay,omitempty"`
+	BitcoinAddress *lightningBitcoinPaymentInput `json:"bitcoinAddress,omitempty"`
 }
 
 type bitcoinDepositState string
@@ -76,6 +98,7 @@ type lightningPayment struct {
 	DeductedAmountAtTime coin.FormattedAmountWithConversions `json:"deductedAmountAtTime"`
 	Fee                  coin.FormattedAmountWithConversions `json:"fee"`
 	Invoice              string                              `json:"invoice,omitempty"`
+	TxID                 string                              `json:"txId,omitempty"`
 	BitcoinDeposit       *bitcoinDeposit                     `json:"bitcoinDeposit,omitempty"`
 }
 
@@ -84,9 +107,10 @@ type receivePaymentResponse struct {
 }
 
 type preparePaymentRequest struct {
-	Type         string  `json:"type"`
-	PaymentInput string  `json:"paymentInput"`
-	AmountSat    *uint64 `json:"amountSat,omitempty"`
+	Type           string  `json:"type"`
+	PaymentInput   string  `json:"paymentInput"`
+	AmountSat      *uint64 `json:"amountSat,omitempty"`
+	IdempotencyKey string  `json:"idempotencyKey,omitempty"`
 }
 
 type sendPaymentRequest struct {
@@ -94,12 +118,14 @@ type sendPaymentRequest struct {
 	PaymentInput   string  `json:"paymentInput"`
 	AmountSat      *uint64 `json:"amountSat"`
 	ApprovedFeeSat uint64  `json:"approvedFeeSat"`
+	IdempotencyKey string  `json:"idempotencyKey,omitempty"`
 }
 
 type paymentFee struct {
-	AmountSat     uint64 `json:"amountSat"`
-	FeeSat        uint64 `json:"feeSat"`
-	TotalDebitSat uint64 `json:"totalDebitSat"`
+	AmountSat      uint64 `json:"amountSat"`
+	FeeSat         uint64 `json:"feeSat"`
+	TotalDebitSat  uint64 `json:"totalDebitSat"`
+	IdempotencyKey string `json:"idempotencyKey,omitempty"`
 }
 
 type closeWithdrawQuote struct {
@@ -115,8 +141,9 @@ type closeWithdrawResult struct {
 }
 
 const (
-	paymentInputTypeBolt11   = "bolt11"
-	paymentInputTypeLNURLPay = "lnurlPay"
+	paymentInputTypeBitcoinAddress = "bitcoinAddress"
+	paymentInputTypeBolt11         = "bolt11"
+	paymentInputTypeLNURLPay       = "lnurlPay"
 )
 
 type msatToSatRounding int
@@ -186,6 +213,12 @@ func (lightning *Lightning) ParsePaymentInput(inputStr string) (*paymentInput, e
 	switch inputType := input.(type) {
 	case breez_sdk_spark.InputTypeBitcoinAddress:
 		lightning.log.Printf("Input is Bitcoin address %s", inputType.Field0.Address)
+		return &paymentInput{
+			Type: paymentInputTypeBitcoinAddress,
+			BitcoinAddress: &lightningBitcoinPaymentInput{
+				Address: inputType.Field0.Address,
+			},
+		}, nil
 
 	case breez_sdk_spark.InputTypeBolt11Invoice:
 		amount := "unknown"
@@ -335,6 +368,8 @@ func (lightning *Lightning) toLightningPayment(payment breez_sdk_spark.Payment) 
 		if result.BitcoinDeposit != nil {
 			result.BitcoinDeposit.TxID = details.TxId
 		}
+	case breez_sdk_spark.PaymentDetailsWithdraw:
+		result.TxID = details.TxId
 	}
 
 	return result
@@ -529,11 +564,15 @@ func checkApprovedPaymentFee(fee uint64, approvedFee uint64) error {
 	return nil
 }
 
-func checkPaymentBalance(fee *paymentFee, availableBalance coin.Amount) error {
-	if new(big.Int).SetUint64(fee.TotalDebitSat).Cmp(availableBalance.BigInt()) > 0 {
+func checkAvailableBalance(amountSat uint64, availableBalance coin.Amount) error {
+	if new(big.Int).SetUint64(amountSat).Cmp(availableBalance.BigInt()) > 0 {
 		return errLightningInsufficientFunds
 	}
 	return nil
+}
+
+func checkPaymentBalance(fee *paymentFee, availableBalance coin.Amount) error {
+	return checkAvailableBalance(fee.TotalDebitSat, availableBalance)
 }
 
 func lightningPaymentError(err error) error {
@@ -571,6 +610,28 @@ func (lightning *Lightning) parseLNURLPayRequest(inputStr string) (*breez_sdk_sp
 // PreparePayment computes the fee quote for the provided payment input.
 func (lightning *Lightning) PreparePayment(request preparePaymentRequest) (*paymentFee, error) {
 	switch request.Type {
+	case paymentInputTypeBitcoinAddress:
+		if request.AmountSat == nil {
+			return nil, errLightningInvalidAmount
+		}
+		_, fee, err := lightning.prepareBitcoinPayment(
+			request.PaymentInput,
+			*request.AmountSat,
+			breez_sdk_spark.FeePolicyFeesExcluded,
+		)
+		if err != nil {
+			return fee, err
+		}
+		idempotencyKey := request.IdempotencyKey
+		if idempotencyKey == "" {
+			generatedKey, err := uuid.NewRandom()
+			if err != nil {
+				return nil, errp.Wrap(err, "generate idempotency key")
+			}
+			idempotencyKey = generatedKey.String()
+		}
+		fee.IdempotencyKey = idempotencyKey
+		return fee, nil
 	case paymentInputTypeBolt11:
 		return lightning.prepareBolt11Payment(request.PaymentInput, request.AmountSat)
 	case paymentInputTypeLNURLPay:
@@ -642,6 +703,8 @@ func (lightning *Lightning) prepareLNURLPay(inputStr string, amountSat *uint64) 
 // SendPayment executes the provided payment input.
 func (lightning *Lightning) SendPayment(request sendPaymentRequest) error {
 	switch request.Type {
+	case paymentInputTypeBitcoinAddress:
+		return lightning.sendBitcoinPayment(request)
 	case paymentInputTypeBolt11:
 		return lightning.sendBolt11Payment(request)
 	case paymentInputTypeLNURLPay:
@@ -649,6 +712,49 @@ func (lightning *Lightning) SendPayment(request sendPaymentRequest) error {
 	default:
 		return errp.New("Payment type not supported")
 	}
+}
+
+func (lightning *Lightning) sendBitcoinPayment(request sendPaymentRequest) error {
+	if request.AmountSat == nil || *request.AmountSat == 0 {
+		return errLightningInvalidAmount
+	}
+	if request.IdempotencyKey == "" {
+		return errp.WithMessage(errLightningInvalidPaymentInput, "idempotency key missing")
+	}
+
+	prepareResponse, fee, err := lightning.prepareBitcoinPayment(
+		request.PaymentInput,
+		*request.AmountSat,
+		breez_sdk_spark.FeePolicyFeesExcluded,
+	)
+	if err != nil {
+		return err
+	}
+	if err := lightning.validateBitcoinPaymentAmount(
+		request.PaymentInput,
+		bitcoinPaymentOutputAmountSat(fee, prepareResponse.FeePolicy),
+	); err != nil {
+		return err
+	}
+	if err := checkApprovedPaymentFee(fee.FeeSat, request.ApprovedFeeSat); err != nil {
+		return err
+	}
+
+	var options breez_sdk_spark.SendPaymentOptions = breez_sdk_spark.SendPaymentOptionsBitcoinAddress{
+		// RBF would require the Spark Entity to co-sign, which the SDK does not support.
+		// Use the fastest fee to minimize the risk of the transaction getting stuck in the mempool.
+		ConfirmationSpeed: breez_sdk_spark.OnchainConfirmationSpeedFast,
+	}
+	_, err = lightning.sdkService.SendPayment(breez_sdk_spark.SendPaymentRequest{
+		PrepareResponse: prepareResponse,
+		Options:         &options,
+		IdempotencyKey:  &request.IdempotencyKey,
+	})
+	if err != nil {
+		lightning.log.WithError(err).Error("Send Bitcoin payment failed")
+		return lightningPaymentError(err)
+	}
+	return nil
 }
 
 func (lightning *Lightning) sendBolt11Payment(request sendPaymentRequest) error {
@@ -745,6 +851,41 @@ func (lightning *Lightning) sendLNURLPay(request sendPaymentRequest) error {
 	return nil
 }
 
+type bitcoinAddressToPkScripter interface {
+	AddressToPkScript(string) ([]byte, error)
+}
+
+func (lightning *Lightning) validateBitcoinPaymentAmount(
+	destinationAddress string,
+	amountSat uint64,
+) error {
+	btcCoin, ok := lightning.btcCoin.(bitcoinAddressToPkScripter)
+	if !ok {
+		return errp.New("Bitcoin coin does not support address-to-script conversion")
+	}
+	pkScript, err := btcCoin.AddressToPkScript(destinationAddress)
+	if err != nil {
+		return errp.WithMessage(errLightningInvalidPaymentInput, err.Error())
+	}
+
+	minAmountSat := uint64(mempool.GetDustThreshold(wire.NewTxOut(0, pkScript)))
+	if amountSat < minAmountSat {
+		return &lightningAmountBelowMinimumError{minAmountSat: minAmountSat}
+	}
+	return nil
+}
+
+func bitcoinPaymentOutputAmountSat(fee *paymentFee, feePolicy breez_sdk_spark.FeePolicy) uint64 {
+	amountSat := fee.AmountSat
+	if feePolicy == breez_sdk_spark.FeePolicyFeesIncluded {
+		if fee.FeeSat >= amountSat {
+			return 0
+		}
+		return amountSat - fee.FeeSat
+	}
+	return amountSat
+}
+
 func (lightning *Lightning) prepareBitcoinPayment(
 	destinationAddress string,
 	amountSat uint64,
@@ -756,6 +897,18 @@ func (lightning *Lightning) prepareBitcoinPayment(
 	if amountSat == 0 {
 		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil, errLightningInvalidAmount
 	}
+	// The SDK rejects dust outputs during preparation with a generic error. Validate first so
+	// callers receive the actionable minimum amount instead.
+	if err := lightning.validateBitcoinPaymentAmount(destinationAddress, amountSat); err != nil {
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil, err
+	}
+	availableBalance, err := lightning.availableBalance()
+	if err != nil {
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil, err
+	}
+	if err := checkAvailableBalance(amountSat, availableBalance); err != nil {
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil, err
+	}
 
 	prepareResponse, err := lightning.sdkService.PrepareSendPayment(
 		prepareBitcoinPaymentRequest(destinationAddress, amountSat, feePolicy),
@@ -766,10 +919,6 @@ func (lightning *Lightning) prepareBitcoinPayment(
 	}
 
 	fee, err := preparedBitcoinPaymentFee(prepareResponse)
-	if err != nil {
-		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil, err
-	}
-	availableBalance, err := lightning.availableBalance()
 	if err != nil {
 		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil, err
 	}
@@ -880,6 +1029,12 @@ func (lightning *Lightning) CloseWithdraw(
 		breez_sdk_spark.FeePolicyFeesIncluded,
 	)
 	if err != nil {
+		return nil, err
+	}
+	if err := lightning.validateBitcoinPaymentAmount(
+		destinationAddress,
+		bitcoinPaymentOutputAmountSat(fee, prepareResponse.FeePolicy),
+	); err != nil {
 		return nil, err
 	}
 	if err := checkApprovedPaymentFee(fee.FeeSat, approvedFeeSat); err != nil {

--- a/backend/lightning/payments.go
+++ b/backend/lightning/payments.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -17,15 +18,29 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
+	"github.com/google/uuid"
 )
 
 const (
 	errPaymentApprovalRequired      errp.ErrorCode = "paymentApprovalRequired"
+	errLightningAmountBelowMinimum  errp.ErrorCode = "lightningAmountBelowMinimum"
 	errLightningInvalidAmount       errp.ErrorCode = "lightningInvalidAmount"
 	errLightningInvalidPaymentInput errp.ErrorCode = "lightningInvalidPaymentInput"
 	errLightningInsufficientFunds   errp.ErrorCode = "lightningInsufficientFunds"
 	errLightningInvoiceAlreadyUsed  errp.ErrorCode = "lightningInvoiceAlreadyUsed"
 )
+
+type lightningAmountBelowMinimumError struct {
+	minAmountSat uint64
+}
+
+func (err *lightningAmountBelowMinimumError) Error() string {
+	return errLightningAmountBelowMinimum.Error()
+}
+
+func (err *lightningAmountBelowMinimumError) Cause() error {
+	return errLightningAmountBelowMinimum
+}
 
 type lightningBolt11Invoice struct {
 	Invoice     string  `json:"invoice"`
@@ -42,10 +57,16 @@ type lightningLNURLPay struct {
 	MaxAmountSat uint64  `json:"maxAmountSat"`
 }
 
+type lightningBitcoinAddress struct {
+	Address   string  `json:"address"`
+	AmountSat *uint64 `json:"amountSat,omitempty"`
+}
+
 type paymentInput struct {
-	Type     string                  `json:"type"`
-	Bolt11   *lightningBolt11Invoice `json:"invoice,omitempty"`
-	LNURLPay *lightningLNURLPay      `json:"lnurlPay,omitempty"`
+	Type           string                   `json:"type"`
+	Bolt11         *lightningBolt11Invoice  `json:"invoice,omitempty"`
+	LNURLPay       *lightningLNURLPay       `json:"lnurlPay,omitempty"`
+	BitcoinAddress *lightningBitcoinAddress `json:"bitcoinAddress,omitempty"`
 }
 
 type bitcoinDepositState string
@@ -75,6 +96,7 @@ type lightningPayment struct {
 	DeductedAmountAtTime coin.FormattedAmountWithConversions `json:"deductedAmountAtTime"`
 	Fee                  coin.FormattedAmountWithConversions `json:"fee"`
 	Invoice              string                              `json:"invoice,omitempty"`
+	TxID                 string                              `json:"txId,omitempty"`
 	BitcoinDeposit       *bitcoinDeposit                     `json:"bitcoinDeposit,omitempty"`
 }
 
@@ -93,12 +115,14 @@ type sendPaymentRequest struct {
 	PaymentInput   string  `json:"paymentInput"`
 	AmountSat      *uint64 `json:"amountSat"`
 	ApprovedFeeSat uint64  `json:"approvedFeeSat"`
+	IdempotencyKey string  `json:"idempotencyKey,omitempty"`
 }
 
 type paymentFee struct {
-	AmountSat     uint64 `json:"amountSat"`
-	FeeSat        uint64 `json:"feeSat"`
-	TotalDebitSat uint64 `json:"totalDebitSat"`
+	AmountSat      uint64 `json:"amountSat"`
+	FeeSat         uint64 `json:"feeSat"`
+	TotalDebitSat  uint64 `json:"totalDebitSat"`
+	IdempotencyKey string `json:"idempotencyKey,omitempty"`
 }
 
 type closeWithdrawQuote struct {
@@ -114,8 +138,9 @@ type closeWithdrawResult struct {
 }
 
 const (
-	paymentInputTypeBolt11   = "bolt11"
-	paymentInputTypeLNURLPay = "lnurlPay"
+	paymentInputTypeBitcoinAddress = "bitcoinAddress"
+	paymentInputTypeBolt11         = "bolt11"
+	paymentInputTypeLNURLPay       = "lnurlPay"
 )
 
 type msatToSatRounding int
@@ -185,24 +210,34 @@ func (lightning *Lightning) ParsePaymentInput(inputStr string) (*paymentInput, e
 	switch inputType := input.(type) {
 	case breez_sdk_spark.InputTypeBitcoinAddress:
 		lightning.log.Printf("Input is Bitcoin address %s", inputType.Field0.Address)
-
-	case breez_sdk_spark.InputTypeBolt11Invoice:
-		amount := "unknown"
-		var amountSat *uint64
-		if inputType.Field0.AmountMsat != nil {
-			amount = strconv.FormatUint(*inputType.Field0.AmountMsat, 10)
-			value := msatToSat(*inputType.Field0.AmountMsat, roundToCeil)
-			amountSat = &value
-		}
-		lightning.log.Printf("Input is BOLT11 invoice for %s msats", amount)
 		return &paymentInput{
-			Type: paymentInputTypeBolt11,
-			Bolt11: &lightningBolt11Invoice{
-				Invoice:     inputType.Field0.Invoice.Bolt11,
-				Description: inputType.Field0.Description,
-				AmountSat:   amountSat,
+			Type: paymentInputTypeBitcoinAddress,
+			BitcoinAddress: &lightningBitcoinAddress{
+				Address: inputType.Field0.Address,
 			},
 		}, nil
+
+	case breez_sdk_spark.InputTypeBip21:
+		for _, paymentMethod := range inputType.Field0.PaymentMethods {
+			if bolt11Invoice, ok := paymentMethod.(breez_sdk_spark.InputTypeBolt11Invoice); ok {
+				return lightning.bolt11PaymentInput(bolt11Invoice), nil
+			}
+		}
+		for _, paymentMethod := range inputType.Field0.PaymentMethods {
+			if bitcoinAddress, ok := paymentMethod.(breez_sdk_spark.InputTypeBitcoinAddress); ok {
+				lightning.log.Printf("Input is BIP21 Bitcoin address %s", bitcoinAddress.Field0.Address)
+				return &paymentInput{
+					Type: paymentInputTypeBitcoinAddress,
+					BitcoinAddress: &lightningBitcoinAddress{
+						Address:   bitcoinAddress.Field0.Address,
+						AmountSat: inputType.Field0.AmountSat,
+					},
+				}, nil
+			}
+		}
+
+	case breez_sdk_spark.InputTypeBolt11Invoice:
+		return lightning.bolt11PaymentInput(inputType), nil
 
 	case breez_sdk_spark.InputTypeLnurlPay:
 		lightning.log.Printf("Input is LNURL-Pay/Lightning address accepting min/max %d/%d msats",
@@ -255,6 +290,25 @@ func (lightning *Lightning) ParsePaymentInput(inputStr string) (*paymentInput, e
 		lightning.log.Errorf("Input type not supported %T", input)
 	}
 	return nil, errp.New("Invoice format not supported")
+}
+
+func (lightning *Lightning) bolt11PaymentInput(inputType breez_sdk_spark.InputTypeBolt11Invoice) *paymentInput {
+	amount := "unknown"
+	var amountSat *uint64
+	if inputType.Field0.AmountMsat != nil {
+		amount = strconv.FormatUint(*inputType.Field0.AmountMsat, 10)
+		value := msatToSat(*inputType.Field0.AmountMsat, roundToCeil)
+		amountSat = &value
+	}
+	lightning.log.Printf("Input is BOLT11 invoice for %s msats", amount)
+	return &paymentInput{
+		Type: paymentInputTypeBolt11,
+		Bolt11: &lightningBolt11Invoice{
+			Invoice:     inputType.Field0.Invoice.Bolt11,
+			Description: inputType.Field0.Description,
+			AmountSat:   amountSat,
+		},
+	}
 }
 
 func toLightningPaymentType(paymentType breez_sdk_spark.PaymentType) accounts.TxType {
@@ -334,6 +388,8 @@ func (lightning *Lightning) toLightningPayment(payment breez_sdk_spark.Payment) 
 		if result.BitcoinDeposit != nil {
 			result.BitcoinDeposit.TxID = details.TxId
 		}
+	case breez_sdk_spark.PaymentDetailsWithdraw:
+		result.TxID = details.TxId
 	}
 
 	return result
@@ -525,12 +581,59 @@ func checkPaymentBalance(fee *paymentFee, availableBalance coin.Amount) error {
 	return nil
 }
 
+// Breez SDK v0.13.1 emits on-chain minimum-amount failures as SdkErrorInvalidInput
+// strings from its vendored native payments implementation. The Go binding has no
+// structured minimum field. Examples:
+//   - "Amount is below the minimum of 294 sats required for this address"
+//   - "Amount is below the minimum of 5 sats required for this address after lowest fees of 2 sats"
+//
+// The fee-included wording also contains the fee in sats, so this matches only
+// the minimum amount and intentionally ignores the rest of the message.
+// TestPinnedBreezSDKMinimumAmountErrorMessage scans the pinned SDK blob so
+// SDK/vendor updates fail tests if this message shape disappears.
+var sdkMinimumSatAmountPattern = regexp.MustCompile(`(?i)\bamount\s+is\s+below\s+the\s+minimum\s+of\s+([0-9][0-9,_]*)\s+(?:sat|sats|satoshis)\b`)
+
+func parseLightningAmountBelowMinimum(message string) (uint64, bool, error) {
+	lowerMessage := strings.ToLower(message)
+	if !strings.Contains(lowerMessage, "amount") || !strings.Contains(lowerMessage, "minimum") {
+		return 0, false, nil
+	}
+
+	match := sdkMinimumSatAmountPattern.FindStringSubmatch(message)
+	if len(match) == 0 {
+		return 0, true, errp.Newf(
+			"unexpected SDK InvalidInput minimum-amount format %q: expected minimum sat amount",
+			message,
+		)
+	}
+	minimum := strings.NewReplacer(",", "", "_", "").Replace(match[1])
+	minAmountSat, err := strconv.ParseUint(minimum, 10, 64)
+	if err != nil {
+		return 0, true, errp.Newf(
+			"unexpected SDK InvalidInput minimum-amount format %q: %v",
+			message,
+			err,
+		)
+	}
+	return minAmountSat, true, nil
+}
+
 func lightningPaymentError(err error) error {
 	if err == nil {
 		return nil
 	}
 	if errors.Is(err, breez_sdk_spark.ErrSdkErrorInsufficientFunds) {
 		return errp.WithMessage(errLightningInsufficientFunds, err.Error())
+	}
+	var invalidInput *breez_sdk_spark.SdkErrorInvalidInput
+	if errors.As(err, &invalidInput) {
+		minAmountSat, isAmountBelowMinimum, parseErr := parseLightningAmountBelowMinimum(invalidInput.Field0)
+		if parseErr != nil {
+			return parseErr
+		}
+		if isAmountBelowMinimum {
+			return &lightningAmountBelowMinimumError{minAmountSat: minAmountSat}
+		}
 	}
 	errString := strings.ToLower(err.Error())
 	if strings.Contains(errString, "preimage request already exists") ||
@@ -560,6 +663,24 @@ func (lightning *Lightning) parseLNURLPayRequest(inputStr string) (*breez_sdk_sp
 // PreparePayment computes the fee quote for the provided payment input.
 func (lightning *Lightning) PreparePayment(request preparePaymentRequest) (*paymentFee, error) {
 	switch request.Type {
+	case paymentInputTypeBitcoinAddress:
+		if request.AmountSat == nil {
+			return nil, errLightningInvalidAmount
+		}
+		_, fee, err := lightning.prepareBitcoinPayment(
+			request.PaymentInput,
+			*request.AmountSat,
+			breez_sdk_spark.FeePolicyFeesExcluded,
+		)
+		if err != nil {
+			return fee, err
+		}
+		idempotencyKey, err := uuid.NewRandom()
+		if err != nil {
+			return nil, errp.Wrap(err, "generate idempotency key")
+		}
+		fee.IdempotencyKey = idempotencyKey.String()
+		return fee, nil
 	case paymentInputTypeBolt11:
 		return lightning.prepareBolt11Payment(request.PaymentInput, request.AmountSat)
 	case paymentInputTypeLNURLPay:
@@ -629,20 +750,58 @@ func (lightning *Lightning) prepareLNURLPay(inputStr string, amountSat *uint64) 
 }
 
 // SendPayment executes the provided payment input.
-func (lightning *Lightning) SendPayment(request sendPaymentRequest) error {
+func (lightning *Lightning) SendPayment(request sendPaymentRequest) (*lightningPayment, error) {
 	switch request.Type {
+	case paymentInputTypeBitcoinAddress:
+		return lightning.sendBitcoinPayment(request)
 	case paymentInputTypeBolt11:
 		return lightning.sendBolt11Payment(request)
 	case paymentInputTypeLNURLPay:
 		return lightning.sendLNURLPay(request)
 	default:
-		return errp.New("Payment type not supported")
+		return nil, errp.New("Payment type not supported")
 	}
 }
 
-func (lightning *Lightning) sendBolt11Payment(request sendPaymentRequest) error {
+func (lightning *Lightning) sendBitcoinPayment(request sendPaymentRequest) (*lightningPayment, error) {
+	if request.AmountSat == nil || *request.AmountSat == 0 {
+		return nil, errLightningInvalidAmount
+	}
+	if request.IdempotencyKey == "" {
+		return nil, errp.WithMessage(errLightningInvalidPaymentInput, "idempotency key missing")
+	}
+
+	prepareResponse, fee, err := lightning.prepareBitcoinPayment(
+		request.PaymentInput,
+		*request.AmountSat,
+		breez_sdk_spark.FeePolicyFeesExcluded,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkApprovedPaymentFee(fee.FeeSat, request.ApprovedFeeSat); err != nil {
+		return nil, err
+	}
+
+	var options breez_sdk_spark.SendPaymentOptions = breez_sdk_spark.SendPaymentOptionsBitcoinAddress{
+		ConfirmationSpeed: breez_sdk_spark.OnchainConfirmationSpeedFast,
+	}
+	response, err := lightning.sdkService.SendPayment(breez_sdk_spark.SendPaymentRequest{
+		PrepareResponse: prepareResponse,
+		Options:         &options,
+		IdempotencyKey:  &request.IdempotencyKey,
+	})
+	if err != nil {
+		lightning.log.WithError(err).Error("Send Bitcoin payment failed")
+		return nil, lightningPaymentError(err)
+	}
+	payment := lightning.toLightningPayment(response.Payment)
+	return &payment, nil
+}
+
+func (lightning *Lightning) sendBolt11Payment(request sendPaymentRequest) (*lightningPayment, error) {
 	if err := lightning.CheckActive(); err != nil {
-		return err
+		return nil, err
 	}
 	lightning.log.Infof("Sending payment to %+v", request.PaymentInput)
 	if request.AmountSat != nil {
@@ -652,22 +811,22 @@ func (lightning *Lightning) sendBolt11Payment(request sendPaymentRequest) error 
 	prepareResponse, err := lightning.sdkService.PrepareSendPayment(prepareBolt11PaymentRequest(request.PaymentInput, request.AmountSat))
 	if err != nil {
 		lightning.log.WithError(err).Error("Prepare send lightning payment failed")
-		return lightningPaymentError(err)
+		return nil, lightningPaymentError(err)
 	}
 
 	fee, err := preparedBolt11PaymentFee(prepareResponse)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := checkApprovedPaymentFee(fee.FeeSat, request.ApprovedFeeSat); err != nil {
-		return err
+		return nil, err
 	}
 	availableBalance, err := lightning.availableBalance()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := checkPaymentBalance(fee, availableBalance); err != nil {
-		return err
+		return nil, err
 	}
 
 	var options breez_sdk_spark.SendPaymentOptions = breez_sdk_spark.SendPaymentOptionsBolt11Invoice{
@@ -678,21 +837,22 @@ func (lightning *Lightning) sendBolt11Payment(request sendPaymentRequest) error 
 		PrepareResponse: prepareResponse,
 		Options:         &options,
 	}
-	_, err = lightning.sdkService.SendPayment(payRequest)
+	response, err := lightning.sdkService.SendPayment(payRequest)
 
 	if err != nil {
 		lightning.log.WithError(err).Error("Send lightning payment failed")
-		return lightningPaymentError(err)
+		return nil, lightningPaymentError(err)
 	}
-	return nil
+	payment := lightning.toLightningPayment(response.Payment)
+	return &payment, nil
 }
 
-func (lightning *Lightning) sendLNURLPay(request sendPaymentRequest) error {
+func (lightning *Lightning) sendLNURLPay(request sendPaymentRequest) (*lightningPayment, error) {
 	if err := lightning.CheckActive(); err != nil {
-		return err
+		return nil, err
 	}
 	if request.AmountSat == nil || *request.AmountSat == 0 {
-		return errLightningInvalidAmount
+		return nil, errLightningInvalidAmount
 	}
 
 	lightning.log.Infof("Sending LNURL-Pay payment to %+v", request.PaymentInput)
@@ -700,38 +860,39 @@ func (lightning *Lightning) sendLNURLPay(request sendPaymentRequest) error {
 
 	payRequest, err := lightning.parseLNURLPayRequest(request.PaymentInput)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := validateLNURLPayAmount(*payRequest, *request.AmountSat); err != nil {
-		return err
+		return nil, err
 	}
 
 	prepareResponse, err := lightning.sdkService.PrepareLnurlPay(prepareLNURLPayRequest(*payRequest, *request.AmountSat))
 	if err != nil {
 		lightning.log.WithError(err).Error("Prepare LNURL-Pay failed")
-		return lightningPaymentError(err)
+		return nil, lightningPaymentError(err)
 	}
 
 	fee := preparedLNURLPayFee(prepareResponse)
 	if err := checkApprovedPaymentFee(fee.FeeSat, request.ApprovedFeeSat); err != nil {
-		return err
+		return nil, err
 	}
 	availableBalance, err := lightning.availableBalance()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := checkPaymentBalance(fee, availableBalance); err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = lightning.sdkService.LnurlPay(breez_sdk_spark.LnurlPayRequest{
+	response, err := lightning.sdkService.LnurlPay(breez_sdk_spark.LnurlPayRequest{
 		PrepareResponse: prepareResponse,
 	})
 	if err != nil {
 		lightning.log.WithError(err).Error("Send LNURL-Pay failed")
-		return lightningPaymentError(err)
+		return nil, lightningPaymentError(err)
 	}
-	return nil
+	payment := lightning.toLightningPayment(response.Payment)
+	return &payment, nil
 }
 
 func (lightning *Lightning) prepareBitcoinPayment(

--- a/backend/lightning/payments_test.go
+++ b/backend/lightning/payments_test.go
@@ -3,6 +3,7 @@
 package lightning
 
 import (
+	"bytes"
 	"errors"
 	"math/big"
 	"os"
@@ -23,6 +24,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/test"
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -287,6 +289,25 @@ func TestToLightningPaymentSparkNilInvoiceDetails(t *testing.T) {
 		require.Equal(t, coinAmountWithConversions("0.00000123"), payment.Amount)
 		require.Equal(t, coinAmountWithConversions("0.00000004"), payment.Fee)
 	})
+}
+
+func TestToLightningPaymentWithdraw(t *testing.T) {
+	lightning := makeTestLightning()
+	details := breez_sdk_spark.PaymentDetails(breez_sdk_spark.PaymentDetailsWithdraw{
+		TxId: "withdraw-txid",
+	})
+
+	payment := lightning.toLightningPayment(breez_sdk_spark.Payment{
+		Id:          "spark-payment-id",
+		PaymentType: breez_sdk_spark.PaymentTypeSend,
+		Status:      breez_sdk_spark.PaymentStatusCompleted,
+		Amount:      big.NewInt(123),
+		Fees:        big.NewInt(4),
+		Details:     &details,
+	})
+
+	require.Equal(t, "spark-payment-id", payment.ID)
+	require.Equal(t, "withdraw-txid", payment.TxID)
 }
 
 func TestToLightningPaymentBitcoinDeposit(t *testing.T) {
@@ -637,6 +658,148 @@ func TestToLightningLNURLPay(t *testing.T) {
 	require.Equal(t, uint64(9), lnurlPay.MaxAmountSat)
 }
 
+func TestParseBitcoinPaymentInput(t *testing.T) {
+	t.Parallel()
+
+	amountSat := uint64(5_000)
+	testCases := []struct {
+		name            string
+		input           string
+		parsed          breez_sdk_spark.InputType
+		expectedAddress string
+		expectedAmount  *uint64
+	}{
+		{
+			name:  "raw address",
+			input: "bc1qraw",
+			parsed: breez_sdk_spark.InputTypeBitcoinAddress{
+				Field0: breez_sdk_spark.BitcoinAddressDetails{Address: "bc1qraw"},
+			},
+			expectedAddress: "bc1qraw",
+		},
+		{
+			name:  "BIP21 URI without amount",
+			input: "bitcoin:bc1qnoamount",
+			parsed: breez_sdk_spark.InputTypeBip21{
+				Field0: breez_sdk_spark.Bip21Details{
+					PaymentMethods: []breez_sdk_spark.InputType{
+						breez_sdk_spark.InputTypeBitcoinAddress{
+							Field0: breez_sdk_spark.BitcoinAddressDetails{Address: "bc1qnoamount"},
+						},
+					},
+				},
+			},
+			expectedAddress: "bc1qnoamount",
+		},
+		{
+			name:  "BIP21 URI with amount",
+			input: "bitcoin:bc1qdestination?amount=0.00005",
+			parsed: breez_sdk_spark.InputTypeBip21{
+				Field0: breez_sdk_spark.Bip21Details{
+					AmountSat: &amountSat,
+					PaymentMethods: []breez_sdk_spark.InputType{
+						breez_sdk_spark.InputTypeBitcoinAddress{
+							Field0: breez_sdk_spark.BitcoinAddressDetails{Address: "bc1qdestination"},
+						},
+					},
+				},
+			},
+			expectedAddress: "bc1qdestination",
+			expectedAmount:  &amountSat,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			sdk := &testPaymentSDK{}
+			sdk.parseInput = func(input string) (breez_sdk_spark.InputType, error) {
+				require.Equal(t, testCase.input, input)
+				return testCase.parsed, nil
+			}
+			lightning := newActivePaymentTestLightning(t, sdk)
+
+			input, err := lightning.ParsePaymentInput(testCase.input)
+
+			require.NoError(t, err)
+			require.Equal(t, paymentInputTypeBitcoinAddress, input.Type)
+			require.NotNil(t, input.BitcoinAddress)
+			require.Equal(t, testCase.expectedAddress, input.BitcoinAddress.Address)
+			require.Equal(t, testCase.expectedAmount, input.BitcoinAddress.AmountSat)
+		})
+	}
+}
+
+func TestParseBip21PrefersBolt11PaymentInput(t *testing.T) {
+	t.Parallel()
+
+	amountMsat := uint64(5_000_000)
+	amountSat := uint64(5_000)
+	description := "invoice description"
+	bolt11PaymentMethod := breez_sdk_spark.InputTypeBolt11Invoice{
+		Field0: breez_sdk_spark.Bolt11InvoiceDetails{
+			AmountMsat:  &amountMsat,
+			Description: stringPointer(description),
+			Invoice: breez_sdk_spark.Bolt11Invoice{
+				Bolt11: "lnbc1invoice",
+			},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		input          string
+		paymentMethods []breez_sdk_spark.InputType
+	}{
+		{
+			name:  "BIP21 URI with on-chain fallback and BOLT11 invoice",
+			input: "bitcoin:bc1qfallback?lightning=lnbc1invoice",
+			paymentMethods: []breez_sdk_spark.InputType{
+				breez_sdk_spark.InputTypeBitcoinAddress{
+					Field0: breez_sdk_spark.BitcoinAddressDetails{Address: "bc1qfallback"},
+				},
+				bolt11PaymentMethod,
+			},
+		},
+		{
+			name:  "BIP21 URI with BOLT11 invoice only",
+			input: "bitcoin:?lightning=lnbc1invoice",
+			paymentMethods: []breez_sdk_spark.InputType{
+				bolt11PaymentMethod,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			sdk := &testPaymentSDK{}
+			sdk.parseInput = func(input string) (breez_sdk_spark.InputType, error) {
+				require.Equal(t, testCase.input, input)
+				return breez_sdk_spark.InputTypeBip21{
+					Field0: breez_sdk_spark.Bip21Details{
+						AmountSat:      &amountSat,
+						PaymentMethods: testCase.paymentMethods,
+					},
+				}, nil
+			}
+			lightning := newActivePaymentTestLightning(t, sdk)
+
+			input, err := lightning.ParsePaymentInput(testCase.input)
+
+			require.NoError(t, err)
+			require.Equal(t, paymentInputTypeBolt11, input.Type)
+			require.Nil(t, input.BitcoinAddress)
+			require.NotNil(t, input.Bolt11)
+			require.Equal(t, "lnbc1invoice", input.Bolt11.Invoice)
+			require.Equal(t, description, *input.Bolt11.Description)
+			require.Equal(t, amountSat, *input.Bolt11.AmountSat)
+		})
+	}
+}
+
 func TestPrepareBolt11PaymentRequest(t *testing.T) {
 	t.Parallel()
 
@@ -825,6 +988,7 @@ type testPaymentSDK struct {
 	breezSDK
 
 	balanceSats      uint64
+	parseInput       func(string) (breez_sdk_spark.InputType, error)
 	prepareSend      func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error)
 	send             func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error)
 	disconnectCalled bool
@@ -833,6 +997,10 @@ type testPaymentSDK struct {
 
 func (sdk *testPaymentSDK) GetInfo(breez_sdk_spark.GetInfoRequest) (breez_sdk_spark.GetInfoResponse, error) {
 	return breez_sdk_spark.GetInfoResponse{BalanceSats: sdk.balanceSats}, nil
+}
+
+func (sdk *testPaymentSDK) Parse(input string) (breez_sdk_spark.InputType, error) {
+	return sdk.parseInput(input)
 }
 
 func (sdk *testPaymentSDK) PrepareSendPayment(
@@ -899,6 +1067,127 @@ func testBitcoinPrepareResponse(feeSat uint64) breez_sdk_spark.PrepareSendPaymen
 		Amount:    big.NewInt(10_000),
 		FeePolicy: breez_sdk_spark.FeePolicyFeesIncluded,
 	}
+}
+
+func testStandardBitcoinPrepareResponse(amountSat uint64, feeSat uint64) breez_sdk_spark.PrepareSendPaymentResponse {
+	return breez_sdk_spark.PrepareSendPaymentResponse{
+		PaymentMethod: breez_sdk_spark.SendPaymentMethodBitcoinAddress{
+			FeeQuote: breez_sdk_spark.SendOnchainFeeQuote{
+				SpeedFast: breez_sdk_spark.SendOnchainSpeedFeeQuote{
+					UserFeeSat:        feeSat - 1,
+					L1BroadcastFeeSat: 1,
+				},
+			},
+		},
+		Amount:    new(big.Int).SetUint64(amountSat),
+		FeePolicy: breez_sdk_spark.FeePolicyFeesExcluded,
+	}
+}
+
+func TestPrepareBitcoinPayment(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(request breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		require.Equal(t, "bc1qdestination", request.PaymentRequest)
+		require.NotNil(t, request.Amount)
+		require.Zero(t, (*request.Amount).Cmp(big.NewInt(5_000)))
+		require.NotNil(t, request.FeePolicy)
+		require.Equal(t, breez_sdk_spark.FeePolicyFeesExcluded, *request.FeePolicy)
+		return testStandardBitcoinPrepareResponse(5_000, 1_000), nil
+	}
+	sdk.send = func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		t.Fatal("prepare must not send payment")
+		return breez_sdk_spark.SendPaymentResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(5_000)
+
+	fee, err := lightning.PreparePayment(preparePaymentRequest{
+		Type:         paymentInputTypeBitcoinAddress,
+		PaymentInput: "bc1qdestination",
+		AmountSat:    &amountSat,
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, fee.IdempotencyKey)
+	idempotencyKey, err := uuid.Parse(fee.IdempotencyKey)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, idempotencyKey)
+	fee.IdempotencyKey = ""
+	require.Equal(t, &paymentFee{
+		AmountSat:     5_000,
+		FeeSat:        1_000,
+		TotalDebitSat: 6_000,
+	}, fee)
+}
+
+func TestSendBitcoinPayment(t *testing.T) {
+	t.Parallel()
+
+	prepareResponse := testStandardBitcoinPrepareResponse(5_000, 1_000)
+	idempotencyKey := "00000000-0000-4000-8000-000000000001"
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(request breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		return prepareResponse, nil
+	}
+	sdk.send = func(request breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		require.Equal(t, prepareResponse, request.PrepareResponse)
+		require.NotNil(t, request.Options)
+		options, ok := (*request.Options).(breez_sdk_spark.SendPaymentOptionsBitcoinAddress)
+		require.True(t, ok)
+		require.Equal(t, breez_sdk_spark.OnchainConfirmationSpeedFast, options.ConfirmationSpeed)
+		require.NotNil(t, request.IdempotencyKey)
+		require.Equal(t, idempotencyKey, *request.IdempotencyKey)
+		details := breez_sdk_spark.PaymentDetails(breez_sdk_spark.PaymentDetailsWithdraw{TxId: "tx-id"})
+		return breez_sdk_spark.SendPaymentResponse{
+			Payment: breez_sdk_spark.Payment{
+				Id:      "payment-id",
+				Details: &details,
+			},
+		}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(5_000)
+
+	payment, err := lightning.SendPayment(sendPaymentRequest{
+		Type:           paymentInputTypeBitcoinAddress,
+		PaymentInput:   "bc1qdestination",
+		AmountSat:      &amountSat,
+		ApprovedFeeSat: 1_000,
+		IdempotencyKey: idempotencyKey,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, payment)
+	require.Equal(t, "payment-id", payment.ID)
+	require.Equal(t, "tx-id", payment.TxID)
+}
+
+func TestSendBitcoinPaymentRequiresIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		t.Fatal("payment must not be prepared without an idempotency key")
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil
+	}
+	sdk.send = func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		t.Fatal("payment must not be sent without an idempotency key")
+		return breez_sdk_spark.SendPaymentResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(5_000)
+
+	payment, err := lightning.SendPayment(sendPaymentRequest{
+		Type:           paymentInputTypeBitcoinAddress,
+		PaymentInput:   "bc1qdestination",
+		AmountSat:      &amountSat,
+		ApprovedFeeSat: 1_000,
+	})
+
+	require.Nil(t, payment)
+	require.ErrorIs(t, err, errLightningInvalidPaymentInput)
 }
 
 func TestPrepareCloseWithdraw(t *testing.T) {
@@ -1112,10 +1401,12 @@ func TestLightningPaymentError(t *testing.T) {
 	t.Parallel()
 
 	unrelatedErr := errors.New("network unavailable")
+	unrelatedInvalidInputErr := breez_sdk_spark.NewSdkErrorInvalidInput("Malformed payment request")
 	testCases := []struct {
 		name                  string
 		err                   error
 		expectedErr           error
+		expectedMinAmountSat  uint64
 		expectedErrorContains []string
 	}{
 		{
@@ -1125,10 +1416,27 @@ func TestLightningPaymentError(t *testing.T) {
 			expectedErrorContains: []string{"SdkError: InsufficientFunds", "lightningInsufficientFunds"},
 		},
 		{
+			name:                 "on-chain amount below address minimum",
+			err:                  breez_sdk_spark.NewSdkErrorInvalidInput("Amount is below the minimum of 294 sats required for this address"),
+			expectedErr:          errLightningAmountBelowMinimum,
+			expectedMinAmountSat: 294,
+		},
+		{
+			name:                 "on-chain amount below fee-included address minimum",
+			err:                  breez_sdk_spark.NewSdkErrorInvalidInput("Amount is below the minimum of 5 sats required for this address after lowest fees of 2 sats"),
+			expectedErr:          errLightningAmountBelowMinimum,
+			expectedMinAmountSat: 5,
+		},
+		{
 			name:                  "Spark already used invoice",
 			err:                   breez_sdk_spark.NewSdkErrorSparkError("Service error: status: AlreadyExists, message: preimage request already exists for paymentHash abc, details: DUPLICATE_OPERATION"),
 			expectedErr:           errLightningInvoiceAlreadyUsed,
 			expectedErrorContains: []string{"preimage request already exists", "lightningInvoiceAlreadyUsed"},
+		},
+		{
+			name:        "unrelated SDK invalid input",
+			err:         unrelatedInvalidInputErr,
+			expectedErr: unrelatedInvalidInputErr,
 		},
 		{
 			name:        "unrelated error",
@@ -1143,9 +1451,54 @@ func TestLightningPaymentError(t *testing.T) {
 
 			err := lightningPaymentError(testCase.err)
 			require.Equal(t, testCase.expectedErr, errp.Cause(err))
+			if testCase.expectedMinAmountSat > 0 {
+				var amountBelowMinimum *lightningAmountBelowMinimumError
+				require.ErrorAs(t, err, &amountBelowMinimum)
+				require.Equal(t, testCase.expectedMinAmountSat, amountBelowMinimum.minAmountSat)
+			}
 			for _, expectedText := range testCase.expectedErrorContains {
 				require.Contains(t, err.Error(), expectedText)
 			}
 		})
 	}
+}
+
+func TestPinnedBreezSDKMinimumAmountErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	const sdkBlob = "../../vendor/github.com/breez/breez-sdk-spark-go/breez_sdk_spark/lib/linux-amd64/libbreez_sdk_spark_bindings.so"
+
+	blob, err := os.ReadFile(sdkBlob)
+	require.NoError(t, err)
+
+	for _, fragment := range [][]byte{
+		[]byte("Amount is below the minimum of"),
+		[]byte("sats required for this address"),
+	} {
+		require.True(t, bytes.Contains(blob, fragment), "missing SDK error fragment %q", fragment)
+	}
+}
+
+func TestLightningPaymentErrorRejectsMalformedMinimumAmount(t *testing.T) {
+	t.Parallel()
+
+	const message = "Amount is below the minimum required for this address"
+	err := lightningPaymentError(breez_sdk_spark.NewSdkErrorInvalidInput(message))
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected SDK InvalidInput minimum-amount format")
+	require.Contains(t, err.Error(), message)
+	var amountBelowMinimum *lightningAmountBelowMinimumError
+	require.False(t, errors.As(err, &amountBelowMinimum))
+}
+
+func TestErrorResponseAmountBelowMinimum(t *testing.T) {
+	t.Parallel()
+
+	response := errorResponse(&lightningAmountBelowMinimumError{minAmountSat: 294})
+
+	require.False(t, response.Success)
+	require.Equal(t, string(errLightningAmountBelowMinimum), response.ErrorCode)
+	require.Equal(t, map[string]interface{}{"minAmountSat": uint64(294)}, response.ErrorData)
+	require.Empty(t, response.ErrorMessage)
 }

--- a/backend/lightning/payments_test.go
+++ b/backend/lightning/payments_test.go
@@ -23,12 +23,15 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/test"
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
 const testCloseWithdrawDestinationAccountCode accountsTypes.Code = "btc-0"
 
 const (
+	testP2PKHAddress  = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+	testP2SHAddress   = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"
 	testP2TRAddress   = "bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297"
 	testP2WPKHAddress = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
 )
@@ -280,6 +283,25 @@ func TestToLightningPaymentSparkNilInvoiceDetails(t *testing.T) {
 		require.Equal(t, coinAmountWithConversions("0.00000123"), payment.Amount)
 		require.Equal(t, coinAmountWithConversions("0.00000004"), payment.Fee)
 	})
+}
+
+func TestToLightningPaymentWithdraw(t *testing.T) {
+	lightning := makeTestLightning()
+	details := breez_sdk_spark.PaymentDetails(breez_sdk_spark.PaymentDetailsWithdraw{
+		TxId: "withdraw-txid",
+	})
+
+	payment := lightning.toLightningPayment(breez_sdk_spark.Payment{
+		Id:          "spark-payment-id",
+		PaymentType: breez_sdk_spark.PaymentTypeSend,
+		Status:      breez_sdk_spark.PaymentStatusCompleted,
+		Amount:      big.NewInt(123),
+		Fees:        big.NewInt(4),
+		Details:     &details,
+	})
+
+	require.Equal(t, "spark-payment-id", payment.ID)
+	require.Equal(t, "withdraw-txid", payment.TxID)
 }
 
 func TestToLightningPaymentBitcoinDeposit(t *testing.T) {
@@ -635,6 +657,27 @@ func TestToLightningLNURLPay(t *testing.T) {
 	require.Equal(t, uint64(9), lnurlPay.MaxAmountSat)
 }
 
+func TestParseBitcoinPaymentInput(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{}
+	sdk.parseInput = func(input string) (breez_sdk_spark.InputType, error) {
+		require.Equal(t, "bc1qraw", input)
+		return breez_sdk_spark.InputTypeBitcoinAddress{
+			Field0: breez_sdk_spark.BitcoinAddressDetails{Address: "bc1qraw"},
+		}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+
+	input, err := lightning.ParsePaymentInput("bc1qraw")
+
+	require.NoError(t, err)
+	require.Equal(t, paymentInputTypeBitcoinAddress, input.Type)
+	require.NotNil(t, input.BitcoinAddress)
+	require.Equal(t, "bc1qraw", input.BitcoinAddress.Address)
+	require.Nil(t, input.BitcoinAddress.AmountSat)
+}
+
 func TestPrepareBolt11PaymentRequest(t *testing.T) {
 	t.Parallel()
 
@@ -762,12 +805,12 @@ func TestPrepareBitcoinPaymentRequest(t *testing.T) {
 	t.Parallel()
 
 	request := prepareBitcoinPaymentRequest(
-		"bc1qdestination",
+		testP2WPKHAddress,
 		10_000,
 		breez_sdk_spark.FeePolicyFeesIncluded,
 	)
 
-	require.Equal(t, breez_sdk_spark.PaymentRequestInput{Input: "bc1qdestination"}, request.PaymentRequest)
+	require.Equal(t, breez_sdk_spark.PaymentRequestInput{Input: testP2WPKHAddress}, request.PaymentRequest)
 	require.NotNil(t, request.Amount)
 	require.Zero(t, (*request.Amount).Cmp(big.NewInt(10_000)))
 	require.NotNil(t, request.FeePolicy)
@@ -823,6 +866,7 @@ type testPaymentSDK struct {
 	breezSDK
 
 	balanceSats           uint64
+	parseInput            func(string) (breez_sdk_spark.InputType, error)
 	prepareSend           func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error)
 	send                  func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error)
 	listUnclaimedDeposits func(breez_sdk_spark.ListUnclaimedDepositsRequest) (breez_sdk_spark.ListUnclaimedDepositsResponse, error)
@@ -835,6 +879,10 @@ type testPaymentSDK struct {
 
 func (sdk *testPaymentSDK) GetInfo(breez_sdk_spark.GetInfoRequest) (breez_sdk_spark.GetInfoResponse, error) {
 	return breez_sdk_spark.GetInfoResponse{BalanceSats: sdk.balanceSats}, nil
+}
+
+func (sdk *testPaymentSDK) Parse(input string) (breez_sdk_spark.InputType, error) {
+	return sdk.parseInput(input)
 }
 
 func (sdk *testPaymentSDK) PrepareSendPayment(
@@ -1162,6 +1210,230 @@ func TestRefundTopUpRejectsIncreasedFeeRate(t *testing.T) {
 	require.Equal(t, errPaymentApprovalRequired, errp.Cause(err))
 }
 
+func testStandardBitcoinPrepareResponse(amountSat uint64, feeSat uint64) breez_sdk_spark.PrepareSendPaymentResponse {
+	return breez_sdk_spark.PrepareSendPaymentResponse{
+		PaymentMethod: breez_sdk_spark.SendPaymentMethodBitcoinAddress{
+			FeeQuote: breez_sdk_spark.SendOnchainFeeQuote{
+				SpeedFast: breez_sdk_spark.SendOnchainSpeedFeeQuote{
+					UserFeeSat:        feeSat - 1,
+					L1BroadcastFeeSat: 1,
+				},
+			},
+		},
+		Amount:    new(big.Int).SetUint64(amountSat),
+		FeePolicy: breez_sdk_spark.FeePolicyFeesExcluded,
+	}
+}
+
+func TestPrepareBitcoinPayment(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(request breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		require.Equal(t, breez_sdk_spark.PaymentRequestInput{Input: testP2WPKHAddress}, request.PaymentRequest)
+		require.NotNil(t, request.Amount)
+		require.Zero(t, (*request.Amount).Cmp(big.NewInt(5_000)))
+		require.NotNil(t, request.FeePolicy)
+		require.Equal(t, breez_sdk_spark.FeePolicyFeesExcluded, *request.FeePolicy)
+		return testStandardBitcoinPrepareResponse(5_000, 1_000), nil
+	}
+	sdk.send = func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		t.Fatal("prepare must not send payment")
+		return breez_sdk_spark.SendPaymentResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(5_000)
+
+	fee, err := lightning.PreparePayment(preparePaymentRequest{
+		Type:         paymentInputTypeBitcoinAddress,
+		PaymentInput: testP2WPKHAddress,
+		AmountSat:    &amountSat,
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, fee.IdempotencyKey)
+	idempotencyKey, err := uuid.Parse(fee.IdempotencyKey)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, idempotencyKey)
+	fee.IdempotencyKey = ""
+	require.Equal(t, &paymentFee{
+		AmountSat:     5_000,
+		FeeSat:        1_000,
+		TotalDebitSat: 6_000,
+	}, fee)
+
+	const existingIdempotencyKey = "00000000-0000-4000-8000-000000000001"
+	fee, err = lightning.PreparePayment(preparePaymentRequest{
+		Type:           paymentInputTypeBitcoinAddress,
+		PaymentInput:   testP2WPKHAddress,
+		AmountSat:      &amountSat,
+		IdempotencyKey: existingIdempotencyKey,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, existingIdempotencyKey, fee.IdempotencyKey)
+}
+
+func TestPrepareBitcoinPaymentRejectsBelowMinimum(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		t.Fatal("amount below minimum must not be passed to the SDK")
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(293)
+
+	fee, err := lightning.PreparePayment(preparePaymentRequest{
+		Type:         paymentInputTypeBitcoinAddress,
+		PaymentInput: testP2WPKHAddress,
+		AmountSat:    &amountSat,
+	})
+
+	require.Nil(t, fee)
+	var amountBelowMinimum *lightningAmountBelowMinimumError
+	require.ErrorAs(t, err, &amountBelowMinimum)
+	require.Equal(t, uint64(294), amountBelowMinimum.minAmountSat)
+}
+
+func TestPrepareBitcoinPaymentRejectsAmountAboveAvailableBalance(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		t.Fatal("amount above available balance must not be passed to the SDK")
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(10_001)
+
+	fee, err := lightning.PreparePayment(preparePaymentRequest{
+		Type:         paymentInputTypeBitcoinAddress,
+		PaymentInput: testP2WPKHAddress,
+		AmountSat:    &amountSat,
+	})
+
+	require.Nil(t, fee)
+	require.ErrorIs(t, err, errLightningInsufficientFunds)
+	require.Equal(t, string(errLightningInsufficientFunds), errorResponse(err).ErrorCode)
+}
+
+func TestPrepareBitcoinPaymentReturnsFeeWhenTotalExceedsAvailableBalance(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		return testStandardBitcoinPrepareResponse(9_500, 1_000), nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(9_500)
+
+	fee, err := lightning.PreparePayment(preparePaymentRequest{
+		Type:         paymentInputTypeBitcoinAddress,
+		PaymentInput: testP2WPKHAddress,
+		AmountSat:    &amountSat,
+	})
+
+	require.ErrorIs(t, err, errLightningInsufficientFunds)
+	require.Equal(t, &paymentFee{
+		AmountSat:     9_500,
+		FeeSat:        1_000,
+		TotalDebitSat: 10_500,
+	}, fee)
+	require.Equal(t, map[string]interface{}{
+		"amountSat":     uint64(9_500),
+		"feeSat":        uint64(1_000),
+		"totalDebitSat": uint64(10_500),
+	}, preparePaymentErrorResponse(err, fee).ErrorData)
+}
+
+func TestSendBitcoinPayment(t *testing.T) {
+	t.Parallel()
+
+	prepareResponse := testStandardBitcoinPrepareResponse(5_000, 1_000)
+	idempotencyKey := "00000000-0000-4000-8000-000000000001"
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(request breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		return prepareResponse, nil
+	}
+	sdk.send = func(request breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		require.Equal(t, prepareResponse, request.PrepareResponse)
+		require.NotNil(t, request.Options)
+		options, ok := (*request.Options).(breez_sdk_spark.SendPaymentOptionsBitcoinAddress)
+		require.True(t, ok)
+		require.Equal(t, breez_sdk_spark.OnchainConfirmationSpeedFast, options.ConfirmationSpeed)
+		require.NotNil(t, request.IdempotencyKey)
+		require.Equal(t, idempotencyKey, *request.IdempotencyKey)
+		return breez_sdk_spark.SendPaymentResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(5_000)
+
+	err := lightning.SendPayment(sendPaymentRequest{
+		Type:           paymentInputTypeBitcoinAddress,
+		PaymentInput:   testP2WPKHAddress,
+		AmountSat:      &amountSat,
+		ApprovedFeeSat: 1_000,
+		IdempotencyKey: idempotencyKey,
+	})
+
+	require.NoError(t, err)
+}
+
+func TestSendBitcoinPaymentRejectsBelowMinimum(t *testing.T) {
+	t.Parallel()
+
+	const feeSat = uint64(1)
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		return testStandardBitcoinPrepareResponse(293, feeSat), nil
+	}
+	sdk.send = func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		t.Fatal("amount below minimum must not be sent")
+		return breez_sdk_spark.SendPaymentResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(293)
+
+	err := lightning.SendPayment(sendPaymentRequest{
+		Type:           paymentInputTypeBitcoinAddress,
+		PaymentInput:   testP2WPKHAddress,
+		AmountSat:      &amountSat,
+		ApprovedFeeSat: feeSat,
+		IdempotencyKey: "00000000-0000-4000-8000-000000000001",
+	})
+
+	var amountBelowMinimum *lightningAmountBelowMinimumError
+	require.ErrorAs(t, err, &amountBelowMinimum)
+	require.Equal(t, uint64(294), amountBelowMinimum.minAmountSat)
+}
+
+func TestSendBitcoinPaymentRequiresIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		t.Fatal("payment must not be prepared without an idempotency key")
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil
+	}
+	sdk.send = func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		t.Fatal("payment must not be sent without an idempotency key")
+		return breez_sdk_spark.SendPaymentResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(5_000)
+
+	err := lightning.SendPayment(sendPaymentRequest{
+		Type:           paymentInputTypeBitcoinAddress,
+		PaymentInput:   testP2WPKHAddress,
+		AmountSat:      &amountSat,
+		ApprovedFeeSat: 1_000,
+	})
+
+	require.ErrorIs(t, err, errLightningInvalidPaymentInput)
+}
+
 func TestPrepareCloseWithdraw(t *testing.T) {
 	t.Parallel()
 
@@ -1217,6 +1489,37 @@ func TestCloseWithdraw(t *testing.T) {
 	require.Nil(t, lightning.Account())
 	require.True(t, sdk.disconnectCalled)
 	require.True(t, sdk.destroyCalled)
+}
+
+func TestCloseWithdrawRejectsBelowMinimumAfterFees(t *testing.T) {
+	t.Parallel()
+
+	const (
+		amountSat = uint64(336)
+		feeSat    = uint64(7)
+	)
+	sdk := &testPaymentSDK{balanceSats: amountSat}
+	sdk.prepareSend = func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		response := testBitcoinPrepareResponse(feeSat)
+		response.Amount = new(big.Int).SetUint64(amountSat)
+		return response, nil
+	}
+	sdk.send = func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		t.Fatal("amount below minimum after fees must not be sent")
+		return breez_sdk_spark.SendPaymentResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+
+	result, err := lightning.CloseWithdraw(
+		testCloseWithdrawDestinationAccountCode,
+		amountSat,
+		feeSat,
+	)
+
+	require.Nil(t, result)
+	var amountBelowMinimum *lightningAmountBelowMinimumError
+	require.ErrorAs(t, err, &amountBelowMinimum)
+	require.Equal(t, uint64(330), amountBelowMinimum.minAmountSat)
 }
 
 func TestCloseWithdrawReturnsResultWhenSetAccountFails(t *testing.T) {
@@ -1369,10 +1672,62 @@ func TestCheckPaymentBalance(t *testing.T) {
 	}
 }
 
+func TestValidateBitcoinPaymentAmount(t *testing.T) {
+	t.Parallel()
+
+	lightning := makeTestLightning()
+	testCases := []struct {
+		name         string
+		address      string
+		minAmountSat uint64
+	}{
+		{
+			name:         "P2PKH",
+			address:      testP2PKHAddress,
+			minAmountSat: 546,
+		},
+		{
+			name:         "P2SH",
+			address:      testP2SHAddress,
+			minAmountSat: 540,
+		},
+		{
+			name:         "P2TR",
+			address:      testP2TRAddress,
+			minAmountSat: 330,
+		},
+		{
+			name:         "P2WPKH",
+			address:      testP2WPKHAddress,
+			minAmountSat: 294,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := lightning.validateBitcoinPaymentAmount(
+				testCase.address,
+				testCase.minAmountSat-1,
+			)
+			var amountBelowMinimum *lightningAmountBelowMinimumError
+			require.ErrorAs(t, err, &amountBelowMinimum)
+			require.Equal(t, testCase.minAmountSat, amountBelowMinimum.minAmountSat)
+
+			require.NoError(t, lightning.validateBitcoinPaymentAmount(
+				testCase.address,
+				testCase.minAmountSat,
+			))
+		})
+	}
+}
+
 func TestLightningPaymentError(t *testing.T) {
 	t.Parallel()
 
 	unrelatedErr := errors.New("network unavailable")
+	unrelatedInvalidInputErr := breez_sdk_spark.NewSdkErrorInvalidInput("Malformed payment request")
 	testCases := []struct {
 		name                  string
 		err                   error
@@ -1392,6 +1747,11 @@ func TestLightningPaymentError(t *testing.T) {
 			expectedErrorContains: []string{"preimage request already exists", "lightningInvoiceAlreadyUsed"},
 		},
 		{
+			name:        "unrelated SDK invalid input",
+			err:         unrelatedInvalidInputErr,
+			expectedErr: unrelatedInvalidInputErr,
+		},
+		{
 			name:        "unrelated error",
 			err:         unrelatedErr,
 			expectedErr: unrelatedErr,
@@ -1409,4 +1769,15 @@ func TestLightningPaymentError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestErrorResponseAmountBelowMinimum(t *testing.T) {
+	t.Parallel()
+
+	response := errorResponse(&lightningAmountBelowMinimumError{minAmountSat: 294})
+
+	require.False(t, response.Success)
+	require.Equal(t, string(errLightningAmountBelowMinimum), response.ErrorCode)
+	require.Equal(t, map[string]interface{}{"minAmountSat": uint64(294)}, response.ErrorData)
+	require.Empty(t, response.ErrorMessage)
 }

--- a/frontends/web/src/api/lightning-errors.ts
+++ b/frontends/web/src/api/lightning-errors.ts
@@ -4,6 +4,7 @@ import type { TFunction } from 'i18next';
 
 export enum TLightningErrorCode {
   PAYMENT_APPROVAL_REQUIRED = 'paymentApprovalRequired',
+  AMOUNT_BELOW_MINIMUM = 'lightningAmountBelowMinimum',
   INVALID_AMOUNT = 'lightningInvalidAmount',
   INVALID_PAYMENT_INPUT = 'lightningInvalidPaymentInput',
   INSUFFICIENT_FUNDS = 'lightningInsufficientFunds',
@@ -16,6 +17,7 @@ export enum TLightningErrorCode {
 // Backend error codes arrive over JSON, so keep the lookup defensive for unknown runtime values.
 const lightningErrorTranslationKeys: Partial<Record<string, string>> = {
   [TLightningErrorCode.PAYMENT_APPROVAL_REQUIRED]: 'error.paymentApprovalRequired',
+  [TLightningErrorCode.AMOUNT_BELOW_MINIMUM]: 'error.lightningAmountBelowMinimum',
   [TLightningErrorCode.INVALID_AMOUNT]: 'error.lightningInvalidAmount',
   [TLightningErrorCode.INVALID_PAYMENT_INPUT]: 'error.lightningInvalidPaymentInput',
   [TLightningErrorCode.INSUFFICIENT_FUNDS]: 'error.lightningInsufficientFunds',
@@ -25,12 +27,18 @@ const lightningErrorTranslationKeys: Partial<Record<string, string>> = {
   [TLightningErrorCode.ADDRESS_USERNAME_UNAVAILABLE]: 'error.lightningAddressUsernameUnavailable',
 };
 
+export type TLightningErrorData = {
+  minAmountSat?: number;
+};
+
 export class TSdkError extends Error {
   code?: TLightningErrorCode;
+  data?: TLightningErrorData;
 
-  constructor(message: string, code?: TLightningErrorCode) {
+  constructor(message: string, code?: TLightningErrorCode, data?: TLightningErrorData) {
     super(message);
     this.code = code;
+    this.data = data;
 
     Object.setPrototypeOf(this, TSdkError.prototype);
   }
@@ -41,7 +49,7 @@ export const toLightningErrorMessage = (t: TFunction, error: unknown): string =>
     if (error.code) {
       const translationKey = lightningErrorTranslationKeys[error.code];
       if (translationKey) {
-        return t(translationKey);
+        return error.data ? t(translationKey, error.data) : t(translationKey);
       }
     }
     return error.message;

--- a/frontends/web/src/api/lightning-errors.ts
+++ b/frontends/web/src/api/lightning-errors.ts
@@ -4,6 +4,7 @@ import type { TFunction } from 'i18next';
 
 export enum TLightningErrorCode {
   PAYMENT_APPROVAL_REQUIRED = 'paymentApprovalRequired',
+  AMOUNT_BELOW_MINIMUM = 'lightningAmountBelowMinimum',
   INVALID_AMOUNT = 'lightningInvalidAmount',
   INVALID_PAYMENT_INPUT = 'lightningInvalidPaymentInput',
   INSUFFICIENT_FUNDS = 'lightningInsufficientFunds',
@@ -19,6 +20,7 @@ export enum TLightningErrorCode {
 // Backend error codes arrive over JSON, so keep the lookup defensive for unknown runtime values.
 const lightningErrorTranslationKeys: Partial<Record<string, string>> = {
   [TLightningErrorCode.PAYMENT_APPROVAL_REQUIRED]: 'error.paymentApprovalRequired',
+  [TLightningErrorCode.AMOUNT_BELOW_MINIMUM]: 'error.lightningAmountBelowMinimum',
   [TLightningErrorCode.INVALID_AMOUNT]: 'error.lightningInvalidAmount',
   [TLightningErrorCode.INVALID_PAYMENT_INPUT]: 'error.lightningInvalidPaymentInput',
   [TLightningErrorCode.INSUFFICIENT_FUNDS]: 'error.lightningInsufficientFunds',
@@ -31,12 +33,27 @@ const lightningErrorTranslationKeys: Partial<Record<string, string>> = {
   [TLightningErrorCode.ADDRESS_USERNAME_UNAVAILABLE]: 'error.lightningAddressUsernameUnavailable',
 };
 
+export type TLightningErrorDataByCode = {
+  [TLightningErrorCode.AMOUNT_BELOW_MINIMUM]: {
+    minAmountSat: number;
+  };
+  [TLightningErrorCode.INSUFFICIENT_FUNDS]: {
+    amountSat: number;
+    feeSat: number;
+    totalDebitSat: number;
+  };
+};
+
+export type TLightningErrorData = TLightningErrorDataByCode[keyof TLightningErrorDataByCode];
+
 export class TSdkError extends Error {
   code?: TLightningErrorCode;
+  data?: TLightningErrorData;
 
-  constructor(message: string, code?: TLightningErrorCode) {
+  constructor(message: string, code?: TLightningErrorCode, data?: TLightningErrorData) {
     super(message);
     this.code = code;
+    this.data = data;
 
     Object.setPrototypeOf(this, TSdkError.prototype);
   }
@@ -47,7 +64,7 @@ export const toLightningErrorMessage = (t: TFunction, error: unknown): string =>
     if (error.code) {
       const translationKey = lightningErrorTranslationKeys[error.code];
       if (translationKey) {
-        return t(translationKey);
+        return error.data ? t(translationKey, error.data) : t(translationKey);
       }
     }
     return error.message;

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -4,7 +4,7 @@ import type { AccountCode, TAmountWithConversions, TBalance, TTransactionStatus 
 import type { TSubscriptionCallback, TUnsubscribe } from '@/api/subscribe';
 import { subscribeEndpoint } from '@/api/subscribe';
 import { apiGet, apiPost } from '@/utils/request';
-import { type TLightningErrorCode, TSdkError } from './lightning-errors';
+import { type TLightningErrorCode, type TLightningErrorData, TSdkError } from './lightning-errors';
 
 export type TLightningResponse<T> =
   | {
@@ -13,6 +13,7 @@ export type TLightningResponse<T> =
   }
   | {
     success: false;
+    errorData?: TLightningErrorData;
     errorMessage?: string;
     errorCode?: TLightningErrorCode;
   };
@@ -38,6 +39,11 @@ export type TLightningLNURLPay = {
   maxAmountSat: number;
 };
 
+export type TLightningBitcoinAddress = {
+  address: string;
+  amountSat?: number;
+};
+
 export type TBitcoinDepositState = 'confirming' | 'claiming' | 'complete' | 'unclaimed';
 
 export type TBitcoinDeposit = {
@@ -58,6 +64,7 @@ export type TLightningPayment = {
   deductedAmountAtTime: TAmountWithConversions;
   fee: TAmountWithConversions;
   invoice?: string;
+  txId?: string;
   bitcoinDeposit?: TBitcoinDeposit;
 };
 
@@ -94,6 +101,12 @@ export type TGeneratedLightningAddress = {
 };
 
 export type TSendPaymentRequest = {
+  type: TPaymentInputType.BITCOIN_ADDRESS;
+  paymentInput: string;
+  amountSat: number;
+  approvedFeeSat: number;
+  idempotencyKey: string;
+} | {
   type: TPaymentInputType.BOLT11;
   paymentInput: string;
   amountSat?: number;
@@ -106,6 +119,10 @@ export type TSendPaymentRequest = {
 };
 
 export type TPreparePaymentRequest = {
+  type: TPaymentInputType.BITCOIN_ADDRESS;
+  paymentInput: string;
+  amountSat: number;
+} | {
   type: TPaymentInputType.BOLT11;
   paymentInput: string;
   amountSat?: number;
@@ -118,6 +135,7 @@ export type TPreparePaymentRequest = {
 export type TPreparePaymentResponse = {
   amountSat: number;
   feeSat: number;
+  idempotencyKey?: string;
   totalDebitSat: number;
 };
 
@@ -128,11 +146,15 @@ export type TSparkStatus = {
 };
 
 export enum TPaymentInputType {
+  BITCOIN_ADDRESS = 'bitcoinAddress',
   BOLT11 = 'bolt11',
   LNURL_PAY = 'lnurlPay',
 }
 
 export type TPaymentInput = {
+  type: TPaymentInputType.BITCOIN_ADDRESS;
+  bitcoinAddress: TLightningBitcoinAddress;
+} | {
   type: TPaymentInputType.BOLT11;
   invoice: TLightningBolt11Invoice;
 } | {
@@ -157,7 +179,7 @@ const queryString = (params: Record<string, string | number | undefined | null>)
 const getApiResponse = async <T>(url: string, defaultError: string = 'Error'): Promise<T> => {
   const response: TLightningResponse<T> = await apiGet(url);
   if (!response.success) {
-    throw new TSdkError(response.errorMessage || defaultError, response.errorCode);
+    throw new TSdkError(response.errorMessage || defaultError, response.errorCode, response.errorData);
   }
   if (response.data === undefined) {
     throw new TSdkError(defaultError);
@@ -168,7 +190,7 @@ const getApiResponse = async <T>(url: string, defaultError: string = 'Error'): P
 const postApiResponse = async <T, C extends object | undefined>(url: string, data: C, defaultError: string = 'Error'): Promise<T> => {
   const response: TLightningResponse<T> = await apiPost(url, data);
   if (!response.success) {
-    throw new TSdkError(response.errorMessage || defaultError, response.errorCode);
+    throw new TSdkError(response.errorMessage || defaultError, response.errorCode, response.errorData);
   }
   if (response.data === undefined) {
     return undefined as T;
@@ -279,8 +301,12 @@ export const postPreparePayment = async (data: TPreparePaymentRequest): Promise<
   );
 };
 
-export const postSendPayment = async (data: TSendPaymentRequest): Promise<void> => {
-  return postApiResponse<void, TSendPaymentRequest>('lightning/send-payment', data, 'Error calling postSendPayment');
+export const postSendPayment = async (data: TSendPaymentRequest): Promise<TLightningPayment> => {
+  return postApiResponse<TLightningPayment, TSendPaymentRequest>(
+    'lightning/send-payment',
+    data,
+    'Error calling postSendPayment'
+  );
 };
 
 export const getReceivePayment = async (params: TReceivePaymentRequest): Promise<TReceivePaymentResponse> => {

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -4,7 +4,7 @@ import type { AccountCode, TAmountWithConversions, TBalance, TTransactionStatus 
 import type { TSubscriptionCallback, TUnsubscribe } from '@/api/subscribe';
 import { subscribeEndpoint } from '@/api/subscribe';
 import { apiGet, apiPost } from '@/utils/request';
-import { TLightningErrorCode, TSdkError } from './lightning-errors';
+import { TLightningErrorCode, type TLightningErrorData, TSdkError } from './lightning-errors';
 
 export type TLightningResponse<T> =
   | {
@@ -13,6 +13,7 @@ export type TLightningResponse<T> =
   }
   | {
     success: false;
+    errorData?: TLightningErrorData;
     errorMessage?: string;
     errorCode?: TLightningErrorCode;
   };
@@ -38,6 +39,11 @@ export type TLightningLNURLPay = {
   maxAmountSat: number;
 };
 
+export type TLightningBitcoinPaymentInput = {
+  address: string;
+  amountSat?: number;
+};
+
 export type TBitcoinDepositState = 'confirming' | 'claiming' | 'complete' | 'unclaimed';
 
 export type TBitcoinDeposit = {
@@ -59,6 +65,7 @@ export type TLightningPayment = {
   deductedAmountAtTime: TAmountWithConversions;
   fee: TAmountWithConversions;
   invoice?: string;
+  txId?: string;
   bitcoinDeposit?: TBitcoinDeposit;
 };
 
@@ -99,6 +106,12 @@ export type TGeneratedLightningAddress = {
 };
 
 export type TSendPaymentRequest = {
+  type: TPaymentInputType.BITCOIN_ADDRESS;
+  paymentInput: string;
+  amountSat: number;
+  approvedFeeSat: number;
+  idempotencyKey: string;
+} | {
   type: TPaymentInputType.BOLT11;
   paymentInput: string;
   amountSat?: number;
@@ -111,6 +124,11 @@ export type TSendPaymentRequest = {
 };
 
 export type TPreparePaymentRequest = {
+  type: TPaymentInputType.BITCOIN_ADDRESS;
+  paymentInput: string;
+  amountSat: number;
+  idempotencyKey?: string;
+} | {
   type: TPaymentInputType.BOLT11;
   paymentInput: string;
   amountSat?: number;
@@ -123,6 +141,7 @@ export type TPreparePaymentRequest = {
 export type TPreparePaymentResponse = {
   amountSat: number;
   feeSat: number;
+  idempotencyKey?: string;
   totalDebitSat: number;
 };
 
@@ -133,11 +152,15 @@ export type TSparkStatus = {
 };
 
 export enum TPaymentInputType {
+  BITCOIN_ADDRESS = 'bitcoinAddress',
   BOLT11 = 'bolt11',
   LNURL_PAY = 'lnurlPay',
 }
 
 export type TPaymentInput = {
+  type: TPaymentInputType.BITCOIN_ADDRESS;
+  bitcoinAddress: TLightningBitcoinPaymentInput;
+} | {
   type: TPaymentInputType.BOLT11;
   invoice: TLightningBolt11Invoice;
 } | {
@@ -162,7 +185,7 @@ const queryString = (params: Record<string, string | number | undefined | null>)
 const getApiResponse = async <T>(url: string, defaultError: string = 'Error'): Promise<T> => {
   const response: TLightningResponse<T> = await apiGet(url);
   if (!response.success) {
-    throw new TSdkError(response.errorMessage || defaultError, response.errorCode);
+    throw new TSdkError(response.errorMessage || defaultError, response.errorCode, response.errorData);
   }
   if (response.data === undefined) {
     throw new TSdkError(defaultError);
@@ -182,6 +205,7 @@ const postApiResponse = async <T, C extends object | undefined>(
     throw new TSdkError(
       response.errorMessage || defaultErrorMessage,
       response.errorCode || defaultErrorCode,
+      response.errorData,
     );
   }
   if (response.data === undefined) {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -921,6 +921,7 @@
     "lightningAddressChangeCooldown": "Please wait before changing your Lightning address again.",
     "lightningAddressInvalidUsername": "Use only lowercase letters and numbers.",
     "lightningAddressUsernameUnavailable": "This name is not available.",
+    "lightningAmountBelowMinimum": "Enter at least {{minAmountSat}} sats for this address.",
     "lightningInsufficientFunds": "Insufficient funds in your Lightning wallet.",
     "lightningInvalidAmount": "Invalid amount.",
     "lightningInvalidPaymentInput": "Invalid invoice or payment request.",
@@ -1736,16 +1737,18 @@
       "confirm": {
         "amount": "Amount",
         "note": "Note",
+        "receiver": "Receiver",
         "title": "Confirm transaction details"
       },
       "invoice": {
-        "input": "Or paste your invoice here"
+        "input": "Or paste an address or invoice here"
       },
       "lnurlPay": {
         "invalidAmount": "Enter an amount between {{minAmount}} and {{maxAmount}} sats."
       },
+      "onChain": "On-chain",
       "qrCode": {
-        "label": "Scan lightning invoice"
+        "label": "Scan address or invoice"
       },
       "sending": {
         "connecting": "Preparing payment",

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -922,6 +922,7 @@
     "lightningAddressChangeCooldown": "Please wait before changing your Lightning address again.",
     "lightningAddressInvalidUsername": "Use only lowercase letters and numbers.",
     "lightningAddressUsernameUnavailable": "This name is not available.",
+    "lightningAmountBelowMinimum": "The amount must be at least {{minAmountSat}} sats.",
     "lightningInsufficientFunds": "Insufficient funds in your Lightning wallet.",
     "lightningInvalidAmount": "Invalid amount.",
     "lightningInvalidPaymentInput": "Invalid invoice or payment request.",
@@ -1816,16 +1817,18 @@
       "confirm": {
         "amount": "Amount",
         "note": "Note",
+        "receiver": "Receiver",
         "title": "Confirm transaction details"
       },
       "invoice": {
-        "input": "Or paste your invoice here"
+        "input": "Or paste an address or invoice here"
       },
       "lnurlPay": {
         "invalidAmount": "Enter an amount between {{minAmount}} and {{maxAmount}} sats."
       },
+      "onChain": "On-chain",
       "qrCode": {
-        "label": "Scan lightning invoice"
+        "label": "Scan address or invoice"
       },
       "sending": {
         "connecting": "Preparing payment",

--- a/frontends/web/src/routes/lightning/components/payment-details.tsx
+++ b/frontends/web/src/routes/lightning/components/payment-details.tsx
@@ -36,6 +36,7 @@ export const PaymentDetailsDialog = ({
   const statusText = payment.bitcoinDeposit && payment.bitcoinDeposit.state !== 'complete'
     ? t(`lightning.bitcoinDeposit.state.${payment.bitcoinDeposit.state}`)
     : t(`transaction.status.${payment.status}`, { context: payment.type });
+  const txID = payment.bitcoinDeposit?.txid || payment.txId;
 
   return (
     <Dialog
@@ -110,20 +111,20 @@ export const PaymentDetailsDialog = ({
             <p className={styles.label}>{t('transaction.details.status')}</p>
             <span>{statusText}</span>
           </TxDetailRow>
+          {explorerURL && txID && (
+            <div className={styles.explorerLinkContainer}>
+              <A
+                className={styles.explorerLink}
+                href={explorerURL + txID}
+                title={`${t('transaction.explorerTitle')}\n${explorerURL}${txID}`}>
+                <ExternalLink />
+                {' '}
+                {t('transaction.explorerTitle')}
+              </A>
+            </div>
+          )}
           {payment.bitcoinDeposit && (
             <>
-              {explorerURL && payment.bitcoinDeposit.txid && (
-                <div className={styles.explorerLinkContainer}>
-                  <A
-                    className={styles.explorerLink}
-                    href={explorerURL + payment.bitcoinDeposit.txid}
-                    title={`${t('transaction.explorerTitle')}\n${explorerURL}${payment.bitcoinDeposit.txid}`}>
-                    <ExternalLink />
-                    {' '}
-                    {t('transaction.explorerTitle')}
-                  </A>
-                </div>
-              )}
               {payment.bitcoinDeposit.state === 'unclaimed' && (
                 <Button className={paymentStyles.claimButton} primary>
                   {t('lightning.bitcoinDeposit.claim')}

--- a/frontends/web/src/routes/lightning/components/payment-details.tsx
+++ b/frontends/web/src/routes/lightning/components/payment-details.tsx
@@ -39,6 +39,7 @@ export const PaymentDetailsDialog = ({
     ? t(`lightning.bitcoinDeposit.state.${payment.bitcoinDeposit.state}`)
     : t(`transaction.status.${payment.status}`, { context: payment.type });
   const bitcoinDeposit = payment.bitcoinDeposit;
+  const txID = bitcoinDeposit?.txid || payment.txId;
 
   return (
     <Dialog
@@ -113,20 +114,20 @@ export const PaymentDetailsDialog = ({
             <p className={styles.label}>{t('transaction.details.status')}</p>
             <span>{statusText}</span>
           </TxDetailRow>
+          {explorerURL && txID && (
+            <div className={styles.explorerLinkContainer}>
+              <A
+                className={styles.explorerLink}
+                href={explorerURL + txID}
+                title={`${t('transaction.explorerTitle')}\n${explorerURL}${txID}`}>
+                <ExternalLink />
+                {' '}
+                {t('transaction.explorerTitle')}
+              </A>
+            </div>
+          )}
           {bitcoinDeposit && (
             <>
-              {explorerURL && bitcoinDeposit.txid && (
-                <div className={styles.explorerLinkContainer}>
-                  <A
-                    className={styles.explorerLink}
-                    href={explorerURL + bitcoinDeposit.txid}
-                    title={`${t('transaction.explorerTitle')}\n${explorerURL}${bitcoinDeposit.txid}`}>
-                    <ExternalLink />
-                    {' '}
-                    {t('transaction.explorerTitle')}
-                  </A>
-                </div>
-              )}
               {bitcoinDeposit.state === 'unclaimed' && (
                 <Button
                   className={paymentStyles.claimButton}

--- a/frontends/web/src/routes/lightning/lightning.tsx
+++ b/frontends/web/src/routes/lightning/lightning.tsx
@@ -150,7 +150,7 @@ const paymentToTransaction = (
       : undefined,
     time: payment.time,
     type: payment.type,
-    txID: payment.id,
+    txID: payment.bitcoinDeposit?.txid || payment.txId || payment.id,
     vsize: 0,
     weight: 0,
   };

--- a/frontends/web/src/routes/lightning/send/components/bitcoin-address-review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/bitcoin-address-review-step.tsx
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TPaymentInputType, type TLightningBitcoinAddress } from '@/api/lightning';
+import { Button } from '@/components/forms';
+import { Column, Grid } from '@/components/layout';
+import { Status } from '@/components/status/status';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { CustomPaymentAmount } from './custom-payment-amount';
+import { BitcoinAddressRecipientDetails, PaymentAmountDetails, PaymentFeeDetails } from './payment-input-details';
+import { SendingSpinner } from './sending-spinner';
+import { type TPaymentReviewDetails, usePaymentReview } from '../hooks/use-payment-review';
+
+type TProps = {
+  bitcoinAddress: TLightningBitcoinAddress;
+  backToPaymentInput: (nextInputError?: string) => void;
+  onSuccess: () => void;
+};
+
+export const BitcoinAddressReviewStep = ({
+  bitcoinAddress,
+  backToPaymentInput,
+  onSuccess,
+}: TProps) => {
+  const { t } = useTranslation();
+  const needsCustomAmount = bitcoinAddress.amountSat === undefined;
+  const paymentDetails = useMemo<TPaymentReviewDetails>(() => ({
+    type: TPaymentInputType.BITCOIN_ADDRESS,
+    details: bitcoinAddress,
+  }), [bitcoinAddress]);
+  const {
+    amountError,
+    canSend,
+    fees,
+    isSending,
+    preparedPayment,
+    sendError,
+    sendPayment,
+    setCustomAmount,
+  } = usePaymentReview({
+    paymentDetails,
+    backToPaymentInput,
+    onSuccess,
+  });
+
+  if (isSending) {
+    return <SendingSpinner />;
+  }
+
+  const prepareError = amountError || (preparedPayment?.status === 'error' ? preparedPayment.error : undefined);
+
+  return (
+    <View fitContent minHeight="100%">
+      <ViewContent>
+        <Grid col="1">
+          <Column>
+            <Status dismissibleKey="" type="warning" hidden={!sendError}>
+              {sendError}
+            </Status>
+            {needsCustomAmount ? (
+              <CustomPaymentAmount
+                key={bitcoinAddress.address}
+                onAmountChange={setCustomAmount}>
+                <BitcoinAddressRecipientDetails bitcoinAddress={bitcoinAddress} />
+              </CustomPaymentAmount>
+            ) : (
+              <>
+                <BitcoinAddressRecipientDetails bitcoinAddress={bitcoinAddress} />
+                <PaymentAmountDetails amountSat={bitcoinAddress.amountSat} />
+              </>
+            )}
+            <Status dismissibleKey="" type="error" hidden={!prepareError}>
+              {prepareError}
+            </Status>
+            {(preparedPayment?.status === 'preparing' || fees) && (
+              <PaymentFeeDetails fees={fees} totalWithFiat />
+            )}
+          </Column>
+        </Grid>
+      </ViewContent>
+      <ViewButtons>
+        <Button
+          primary
+          onClick={sendPayment}
+          disabled={!canSend}>
+          {t('generic.send')}
+        </Button>
+        <Button secondary onClick={() => backToPaymentInput()}>
+          {t('button.back')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/send/components/bitcoin-address-review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/bitcoin-address-review-step.tsx
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TPaymentInputType, type TLightningBitcoinPaymentInput } from '@/api/lightning';
+import { Button } from '@/components/forms';
+import { Column, Grid } from '@/components/layout';
+import { Status } from '@/components/status/status';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { CustomPaymentAmount } from './custom-payment-amount';
+import { BitcoinAddressRecipientDetails, PaymentAmountDetails, PaymentFeeDetails } from './payment-input-details';
+import { SendingSpinner } from './sending-spinner';
+import { type TPaymentReviewDetails, usePaymentReview } from '../hooks/use-payment-review';
+
+type TProps = {
+  bitcoinAddress: TLightningBitcoinPaymentInput;
+  backToPaymentInput: (nextInputError?: string) => void;
+  onSuccess: () => void;
+};
+
+export const BitcoinAddressReviewStep = ({
+  bitcoinAddress,
+  backToPaymentInput,
+  onSuccess,
+}: TProps) => {
+  const { t } = useTranslation();
+  const needsCustomAmount = bitcoinAddress.amountSat === undefined;
+  const paymentDetails = useMemo<TPaymentReviewDetails>(() => ({
+    type: TPaymentInputType.BITCOIN_ADDRESS,
+    details: bitcoinAddress,
+  }), [bitcoinAddress]);
+  const {
+    amountError,
+    canSend,
+    fees,
+    isSending,
+    preparedPayment,
+    sendError,
+    sendPayment,
+    setCustomAmount,
+  } = usePaymentReview({
+    paymentDetails,
+    backToPaymentInput,
+    onSuccess,
+  });
+
+  if (isSending) {
+    return <SendingSpinner />;
+  }
+
+  const prepareError = amountError || (preparedPayment?.status === 'error' ? preparedPayment.error : undefined);
+
+  return (
+    <View fitContent minHeight="100%">
+      <ViewContent>
+        <Grid col="1">
+          <Column>
+            <Status dismissibleKey="" type="warning" hidden={!sendError}>
+              {sendError}
+            </Status>
+            {needsCustomAmount ? (
+              <CustomPaymentAmount
+                key={bitcoinAddress.address}
+                onAmountChange={setCustomAmount}>
+                <BitcoinAddressRecipientDetails bitcoinAddress={bitcoinAddress} />
+              </CustomPaymentAmount>
+            ) : (
+              <>
+                <BitcoinAddressRecipientDetails bitcoinAddress={bitcoinAddress} />
+                <PaymentAmountDetails amountSat={bitcoinAddress.amountSat} />
+              </>
+            )}
+            <Status dismissibleKey="" type="error" hidden={!prepareError}>
+              {prepareError}
+            </Status>
+            {(preparedPayment?.status === 'preparing' || fees) && (
+              <PaymentFeeDetails fees={fees} totalWithFiat />
+            )}
+          </Column>
+        </Grid>
+      </ViewContent>
+      <ViewButtons>
+        <Button
+          primary
+          onClick={sendPayment}
+          disabled={!canSend}>
+          {t('generic.send')}
+        </Button>
+        <Button secondary onClick={() => backToPaymentInput()}>
+          {t('button.back')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/send/components/custom-payment-amount.tsx
+++ b/frontends/web/src/routes/lightning/send/components/custom-payment-amount.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useContext, useEffect } from 'react';
+import { type ReactNode, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getLightningBalance } from '@/api/lightning';
 import { Balance } from '@/components/balance/balance';
@@ -11,6 +11,7 @@ import { useSatFiatAmount } from '../../hooks/use-sat-fiat-amount';
 import styles from '../send.module.css';
 
 type TProps = {
+  children?: ReactNode;
   maxAmountSat?: number;
   minAmountSat?: number;
   onAmountChange: (amountSat?: number) => void;
@@ -28,6 +29,7 @@ export const PaymentBalance = () => {
 };
 
 export const CustomPaymentAmount = ({
+  children,
   maxAmountSat,
   minAmountSat = 0,
   onAmountChange,
@@ -49,6 +51,7 @@ export const CustomPaymentAmount = ({
   return (
     <>
       <PaymentBalance />
+      {children}
       <NumberInput
         step="1"
         min={minAmountSat}

--- a/frontends/web/src/routes/lightning/send/components/payment-input-details.tsx
+++ b/frontends/web/src/routes/lightning/send/components/payment-input-details.tsx
@@ -4,8 +4,9 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TAmountWithConversions } from '@/api/account';
 import { getBtcSatAmount } from '@/api/coins';
-import { type TLightningLNURLPay, type TPreparePaymentResponse } from '@/api/lightning';
+import { type TLightningBitcoinAddress, type TLightningLNURLPay, type TPreparePaymentResponse } from '@/api/lightning';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
+import { Badge } from '@/components/badge/badge';
 import { Skeleton } from '@/components/skeleton/skeleton';
 import { useMountedRef } from '@/hooks/mount';
 import styles from '../send.module.css';
@@ -87,6 +88,26 @@ type TBolt11PaymentDetailsProps = {
 
 type TLNURLPayRecipientDetailsProps = {
   lnurlPay: TLightningLNURLPay;
+};
+
+type TProps = {
+  bitcoinAddress: TLightningBitcoinAddress;
+};
+
+export const BitcoinAddressRecipientDetails = ({ bitcoinAddress }: TProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.info}>
+      <h2 className={`${styles.label || ''} ${styles.receiverLabel || ''}`}>
+        {t('lightning.send.confirm.receiver')}
+        <Badge className={styles.receiverBadge} type="info">
+          {t('lightning.send.onChain')}
+        </Badge>
+      </h2>
+      <div className={styles.address}>{bitcoinAddress.address}</div>
+    </div>
+  );
 };
 
 export const PaymentAmountDetails = ({ amountSat }: TPaymentAmountDetailsProps) => {

--- a/frontends/web/src/routes/lightning/send/components/payment-input-details.tsx
+++ b/frontends/web/src/routes/lightning/send/components/payment-input-details.tsx
@@ -4,8 +4,9 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TAmountWithConversions } from '@/api/account';
 import { getBtcSatAmount } from '@/api/coins';
-import { type TLightningLNURLPay, type TPreparePaymentResponse } from '@/api/lightning';
+import { type TLightningBitcoinPaymentInput, type TLightningLNURLPay, type TPreparePaymentResponse } from '@/api/lightning';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
+import { Badge } from '@/components/badge/badge';
 import { Skeleton } from '@/components/skeleton/skeleton';
 import { useMountedRef } from '@/hooks/mount';
 import styles from '../send.module.css';
@@ -87,6 +88,26 @@ type TBolt11PaymentDetailsProps = {
 
 type TLNURLPayRecipientDetailsProps = {
   lnurlPay: TLightningLNURLPay;
+};
+
+type TProps = {
+  bitcoinAddress: TLightningBitcoinPaymentInput;
+};
+
+export const BitcoinAddressRecipientDetails = ({ bitcoinAddress }: TProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.info}>
+      <h2 className={`${styles.label || ''} ${styles.receiverLabel || ''}`}>
+        {t('lightning.send.confirm.receiver')}
+        <Badge className={styles.receiverBadge} type="info">
+          {t('lightning.send.onChain')}
+        </Badge>
+      </h2>
+      <div className={styles.address}>{bitcoinAddress.address}</div>
+    </div>
+  );
 };
 
 export const PaymentAmountDetails = ({ amountSat }: TPaymentAmountDetailsProps) => {

--- a/frontends/web/src/routes/lightning/send/components/review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/review-step.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TPaymentInputType, type TPaymentInput } from '@/api/lightning';
+import { BitcoinAddressReviewStep } from './bitcoin-address-review-step';
 import { Bolt11ReviewStep } from './bolt11-review-step';
 import { LNURLPayReviewStep } from './lnurl-pay-review-step';
 
@@ -16,6 +17,14 @@ export const ReviewStep = ({
   onSuccess,
 }: TProps) => {
   switch (paymentInput.type) {
+  case TPaymentInputType.BITCOIN_ADDRESS:
+    return (
+      <BitcoinAddressReviewStep
+        bitcoinAddress={paymentInput.bitcoinAddress}
+        backToPaymentInput={backToPaymentInput}
+        onSuccess={onSuccess}
+      />
+    );
   case TPaymentInputType.BOLT11:
     return (
       <Bolt11ReviewStep

--- a/frontends/web/src/routes/lightning/send/hooks/use-payment-review.ts
+++ b/frontends/web/src/routes/lightning/send/hooks/use-payment-review.ts
@@ -4,20 +4,23 @@ import { type TFunction } from 'i18next';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TLightningErrorCode, TSdkError, toLightningErrorMessage } from '@/api/lightning-errors';
-import { TPaymentInputType, type TLightningBolt11Invoice, type TLightningLNURLPay, type TPreparePaymentRequest, type TPreparePaymentResponse, type TSendPaymentRequest, postPreparePayment, postSendPayment } from '@/api/lightning';
+import { TPaymentInputType, type TLightningBitcoinPaymentInput, type TLightningBolt11Invoice, type TLightningLNURLPay, type TPreparePaymentRequest, type TPreparePaymentResponse, type TSendPaymentRequest, postPreparePayment, postSendPayment } from '@/api/lightning';
 import { useDebounce } from '@/hooks/debounce';
 import { useMountedRef } from '@/hooks/mount';
 
 type TPreparedPayment =
   | { status: 'preparing'; amountSat?: number }
   | { status: 'ready'; amountSat?: number; fees: TPreparePaymentResponse }
-  | { status: 'error'; amountSat?: number; error: string };
+  | { status: 'error'; amountSat?: number; error: string; fees?: TPreparePaymentResponse };
 
 const isPositiveInteger = (amount?: number): amount is number => (
   typeof amount === 'number' && Number.isFinite(amount) && Number.isInteger(amount) && amount > 0
 );
 
 export type TPaymentReviewDetails = {
+  type: TPaymentInputType.BITCOIN_ADDRESS;
+  details: TLightningBitcoinPaymentInput;
+} | {
   type: TPaymentInputType.BOLT11;
   details: TLightningBolt11Invoice;
 } | {
@@ -35,20 +38,30 @@ const isValidAmount = (paymentDetails: TPaymentReviewDetails, amount?: number): 
   if (!isPositiveInteger(amount)) {
     return false;
   }
-  if (paymentDetails.type === TPaymentInputType.BOLT11) {
-    return true;
+  if (paymentDetails.type === TPaymentInputType.LNURL_PAY) {
+    return amount >= paymentDetails.details.minAmountSat && amount <= paymentDetails.details.maxAmountSat;
   }
-  return amount >= paymentDetails.details.minAmountSat && amount <= paymentDetails.details.maxAmountSat;
+  return true;
 };
 
 const invalidAmountError = (paymentDetails: TPaymentReviewDetails, t: TFunction): string => {
-  if (paymentDetails.type === TPaymentInputType.BOLT11) {
-    return t('send.error.invalidAmount');
+  if (paymentDetails.type === TPaymentInputType.LNURL_PAY) {
+    return t('lightning.send.lnurlPay.invalidAmount', {
+      maxAmount: paymentDetails.details.maxAmountSat,
+      minAmount: paymentDetails.details.minAmountSat,
+    });
   }
-  return t('lightning.send.lnurlPay.invalidAmount', {
-    maxAmount: paymentDetails.details.maxAmountSat,
-    minAmount: paymentDetails.details.minAmountSat,
-  });
+  return t('send.error.invalidAmount');
+};
+
+const insufficientFundsFees = (error: unknown): TPreparePaymentResponse | undefined => {
+  if (!(error instanceof TSdkError)
+    || error.code !== TLightningErrorCode.INSUFFICIENT_FUNDS
+    || !error.data
+    || !('feeSat' in error.data)) {
+    return undefined;
+  }
+  return error.data;
 };
 
 export const usePaymentReview = ({
@@ -58,6 +71,7 @@ export const usePaymentReview = ({
 }: TUsePaymentReviewProps) => {
   const { t } = useTranslation();
   const fixedAmountSat = paymentDetails.type === TPaymentInputType.BOLT11
+    || paymentDetails.type === TPaymentInputType.BITCOIN_ADDRESS
     ? paymentDetails.details.amountSat
     : undefined;
   const needsCustomAmount = fixedAmountSat === undefined;
@@ -73,9 +87,20 @@ export const usePaymentReview = ({
     ? invalidAmountError(paymentDetails, t)
     : undefined;
 
-  const preparePayment = useCallback(async (amountSat?: number) => {
+  const preparePayment = useCallback(async (amountSat?: number, existingIdempotencyKey?: string) => {
     let preparePaymentRequest: TPreparePaymentRequest;
     switch (paymentDetails.type) {
+    case TPaymentInputType.BITCOIN_ADDRESS:
+      if (!isValidAmount(paymentDetails, amountSat)) {
+        return;
+      }
+      preparePaymentRequest = {
+        type: TPaymentInputType.BITCOIN_ADDRESS,
+        paymentInput: paymentDetails.details.address,
+        amountSat,
+        idempotencyKey: existingIdempotencyKey,
+      };
+      break;
     case TPaymentInputType.BOLT11:
       if (needsCustomAmount && !isValidAmount(paymentDetails, amountSat)) {
         return;
@@ -130,6 +155,7 @@ export const usePaymentReview = ({
         status: 'error',
         amountSat,
         error: toLightningErrorMessage(t, error),
+        fees: insufficientFundsFees(error),
       });
       setSendError(undefined);
     }
@@ -141,7 +167,8 @@ export const usePaymentReview = ({
     t,
   ]);
 
-  const fees = preparedPayment?.status === 'ready'
+  const fees = preparedPayment
+    && preparedPayment.status !== 'preparing'
     && (!needsCustomAmount || preparedPayment.amountSat === currentAmountSat)
     ? preparedPayment.fees
     : undefined;
@@ -156,7 +183,7 @@ export const usePaymentReview = ({
       return;
     }
 
-    if (!fees) {
+    if (preparedPayment?.status !== 'ready' || !fees) {
       return;
     }
 
@@ -166,6 +193,17 @@ export const usePaymentReview = ({
     try {
       const sendPaymentRequest: TSendPaymentRequest = (() => {
         switch (paymentDetails.type) {
+        case TPaymentInputType.BITCOIN_ADDRESS:
+          if (fees.idempotencyKey === undefined) {
+            throw new TSdkError('idempotency key missing', TLightningErrorCode.INVALID_PAYMENT_INPUT);
+          }
+          return {
+            type: TPaymentInputType.BITCOIN_ADDRESS,
+            paymentInput: paymentDetails.details.address,
+            amountSat: currentAmountSat,
+            approvedFeeSat: fees.feeSat,
+            idempotencyKey: fees.idempotencyKey,
+          };
         case TPaymentInputType.BOLT11:
           return {
             type: TPaymentInputType.BOLT11,
@@ -203,7 +241,7 @@ export const usePaymentReview = ({
         const amountSat = paymentDetails.type === TPaymentInputType.BOLT11 && paymentDetails.details.amountSat !== undefined
           ? undefined
           : currentAmountSat;
-        await preparePayment(amountSat);
+        await preparePayment(amountSat, fees.idempotencyKey);
         return;
       }
 
@@ -217,6 +255,7 @@ export const usePaymentReview = ({
     onSuccess,
     currentAmountSat,
     paymentDetails,
+    preparedPayment?.status,
     preparePayment,
     t,
   ]);
@@ -228,7 +267,9 @@ export const usePaymentReview = ({
     setSendError(undefined);
 
     if (!needsCustomAmount) {
-      preparePayment();
+      preparePayment(paymentDetails.type === TPaymentInputType.BITCOIN_ADDRESS
+        ? fixedAmountSat
+        : undefined);
     }
   }, [fixedAmountSat, needsCustomAmount, paymentDetails, preparePayment]);
 
@@ -240,7 +281,7 @@ export const usePaymentReview = ({
     customAmountRef.current = customAmount;
     setSendError(undefined);
     setPreparedPayment(undefined);
-  }, [customAmount, needsCustomAmount]);
+  }, [customAmount, needsCustomAmount, paymentDetails.type]);
 
   useEffect(() => {
     if (!needsCustomAmount || debouncedCustomAmount !== customAmount || customAmount === undefined) {
@@ -251,7 +292,7 @@ export const usePaymentReview = ({
   }, [customAmount, debouncedCustomAmount, needsCustomAmount, preparePayment]);
 
   return {
-    canSend: !!fees,
+    canSend: preparedPayment?.status === 'ready' && !!fees,
     customAmount,
     amountError,
     fees,

--- a/frontends/web/src/routes/lightning/send/hooks/use-payment-review.ts
+++ b/frontends/web/src/routes/lightning/send/hooks/use-payment-review.ts
@@ -4,7 +4,7 @@ import { type TFunction } from 'i18next';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TLightningErrorCode, TSdkError, toLightningErrorMessage } from '@/api/lightning-errors';
-import { TPaymentInputType, type TLightningBolt11Invoice, type TLightningLNURLPay, type TPreparePaymentRequest, type TPreparePaymentResponse, type TSendPaymentRequest, postPreparePayment, postSendPayment } from '@/api/lightning';
+import { TPaymentInputType, type TLightningBitcoinAddress, type TLightningBolt11Invoice, type TLightningLNURLPay, type TPreparePaymentRequest, type TPreparePaymentResponse, type TSendPaymentRequest, postPreparePayment, postSendPayment } from '@/api/lightning';
 import { useDebounce } from '@/hooks/debounce';
 import { useMountedRef } from '@/hooks/mount';
 
@@ -18,6 +18,9 @@ const isPositiveInteger = (amount?: number): amount is number => (
 );
 
 export type TPaymentReviewDetails = {
+  type: TPaymentInputType.BITCOIN_ADDRESS;
+  details: TLightningBitcoinAddress;
+} | {
   type: TPaymentInputType.BOLT11;
   details: TLightningBolt11Invoice;
 } | {
@@ -35,20 +38,20 @@ const isValidAmount = (paymentDetails: TPaymentReviewDetails, amount?: number): 
   if (!isPositiveInteger(amount)) {
     return false;
   }
-  if (paymentDetails.type === TPaymentInputType.BOLT11) {
-    return true;
+  if (paymentDetails.type === TPaymentInputType.LNURL_PAY) {
+    return amount >= paymentDetails.details.minAmountSat && amount <= paymentDetails.details.maxAmountSat;
   }
-  return amount >= paymentDetails.details.minAmountSat && amount <= paymentDetails.details.maxAmountSat;
+  return true;
 };
 
 const invalidAmountError = (paymentDetails: TPaymentReviewDetails, t: TFunction): string => {
-  if (paymentDetails.type === TPaymentInputType.BOLT11) {
-    return t('send.error.invalidAmount');
+  if (paymentDetails.type === TPaymentInputType.LNURL_PAY) {
+    return t('lightning.send.lnurlPay.invalidAmount', {
+      maxAmount: paymentDetails.details.maxAmountSat,
+      minAmount: paymentDetails.details.minAmountSat,
+    });
   }
-  return t('lightning.send.lnurlPay.invalidAmount', {
-    maxAmount: paymentDetails.details.maxAmountSat,
-    minAmount: paymentDetails.details.minAmountSat,
-  });
+  return t('send.error.invalidAmount');
 };
 
 export const usePaymentReview = ({
@@ -58,6 +61,7 @@ export const usePaymentReview = ({
 }: TUsePaymentReviewProps) => {
   const { t } = useTranslation();
   const fixedAmountSat = paymentDetails.type === TPaymentInputType.BOLT11
+    || paymentDetails.type === TPaymentInputType.BITCOIN_ADDRESS
     ? paymentDetails.details.amountSat
     : undefined;
   const needsCustomAmount = fixedAmountSat === undefined;
@@ -76,6 +80,16 @@ export const usePaymentReview = ({
   const preparePayment = useCallback(async (amountSat?: number) => {
     let preparePaymentRequest: TPreparePaymentRequest;
     switch (paymentDetails.type) {
+    case TPaymentInputType.BITCOIN_ADDRESS:
+      if (!isValidAmount(paymentDetails, amountSat)) {
+        return;
+      }
+      preparePaymentRequest = {
+        type: TPaymentInputType.BITCOIN_ADDRESS,
+        paymentInput: paymentDetails.details.address,
+        amountSat,
+      };
+      break;
     case TPaymentInputType.BOLT11:
       if (needsCustomAmount && !isValidAmount(paymentDetails, amountSat)) {
         return;
@@ -166,6 +180,17 @@ export const usePaymentReview = ({
     try {
       const sendPaymentRequest: TSendPaymentRequest = (() => {
         switch (paymentDetails.type) {
+        case TPaymentInputType.BITCOIN_ADDRESS:
+          if (fees.idempotencyKey === undefined) {
+            throw new TSdkError('idempotency key missing', TLightningErrorCode.INVALID_PAYMENT_INPUT);
+          }
+          return {
+            type: TPaymentInputType.BITCOIN_ADDRESS,
+            paymentInput: paymentDetails.details.address,
+            amountSat: currentAmountSat,
+            approvedFeeSat: fees.feeSat,
+            idempotencyKey: fees.idempotencyKey,
+          };
         case TPaymentInputType.BOLT11:
           return {
             type: TPaymentInputType.BOLT11,
@@ -228,7 +253,9 @@ export const usePaymentReview = ({
     setSendError(undefined);
 
     if (!needsCustomAmount) {
-      preparePayment();
+      preparePayment(paymentDetails.type === TPaymentInputType.BITCOIN_ADDRESS
+        ? fixedAmountSat
+        : undefined);
     }
   }, [fixedAmountSat, needsCustomAmount, paymentDetails, preparePayment]);
 
@@ -240,7 +267,7 @@ export const usePaymentReview = ({
     customAmountRef.current = customAmount;
     setSendError(undefined);
     setPreparedPayment(undefined);
-  }, [customAmount, needsCustomAmount]);
+  }, [customAmount, needsCustomAmount, paymentDetails.type]);
 
   useEffect(() => {
     if (!needsCustomAmount || debouncedCustomAmount !== customAmount || customAmount === undefined) {

--- a/frontends/web/src/routes/lightning/send/send.module.css
+++ b/frontends/web/src/routes/lightning/send/send.module.css
@@ -20,6 +20,20 @@
     margin-bottom: var(--space-eight);
 }
 
+.receiverLabel {
+    align-items: center;
+    display: flex;
+    gap: var(--space-eight);
+}
+
+.receiverBadge {
+    padding: calc(var(--space-three-quarter) / 4) calc(var(--space-three-quarter) / 2);
+}
+
+.address {
+    overflow-wrap: anywhere;
+}
+
 .amountLine {
     align-items: baseline;
     display: inline-flex;

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1
 	github.com/ethereum/go-ethereum v1.17.4
 	github.com/flynn/noise v1.1.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/karalabe/hid v1.0.1-0.20240919124526-821c38d2678e
@@ -48,7 +49,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/kkdai/bstream v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect


### PR DESCRIPTION
Recognize Bitcoin addresses in the standard Lightning send flow and use Spark fee quotes to prepare and send payments to them.

Add the on-chain review UI and turn Spark minimum-amount failures into translated errors that show the number of sats required by the address.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
