### PR TITLE
backend: restrict export file permissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,8 @@ component state — no form library is used.
 
 ### Go
 - Must pass `gofmt` and `goimports`. Linting via `golangci-lint run` (config in `.golangci.yml`).
+- Create files containing sensitive data with owner-only (`0600`) permissions, and tighten the
+  permissions of existing destination files when overwriting them.
 
 ### TypeScript / React
 - ESLint config in `eslint.config.js`.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1299,7 +1299,7 @@ func (backend *Backend) ExportLogs() error {
 
 	exportFile, err := os.OpenFile(
 		path,
-		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+		os.O_WRONLY|os.O_CREATE,
 		utilConfig.PrivateFileMode,
 	)
 	if err != nil {
@@ -1309,6 +1309,11 @@ func (backend *Backend) ExportLogs() error {
 	if err := utilConfig.EnsurePrivateFile(path); err != nil {
 		_ = exportFile.Close()
 		backend.log.WithError(err).Error("error restricting log file permissions")
+		return err
+	}
+	if err := exportFile.Truncate(0); err != nil {
+		_ = exportFile.Close()
+		backend.log.WithError(err).Error("error truncating log file")
 		return err
 	}
 	logFilePath := filepath.Join(utilConfig.AppDir(), "log.txt")

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1297,9 +1297,18 @@ func (backend *Backend) ExportLogs() error {
 	}
 	backend.log.Infof("Export logs to %s.", path)
 
-	exportFile, err := os.Create(path)
+	exportFile, err := os.OpenFile(
+		path,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+		utilConfig.PrivateFileMode,
+	)
 	if err != nil {
 		backend.log.WithError(err).Error("error creating new log file")
+		return err
+	}
+	if err := utilConfig.EnsurePrivateFile(path); err != nil {
+		_ = exportFile.Close()
+		backend.log.WithError(err).Error("error restricting log file permissions")
 		return err
 	}
 	logFilePath := filepath.Join(utilConfig.AppDir(), "log.txt")

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -244,7 +244,7 @@ func (handlers *Handlers) postExportTransactions(*http.Request) (interface{}, er
 
 	file, err := os.OpenFile(
 		path,
-		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+		os.O_WRONLY|os.O_CREATE,
 		config.PrivateFileMode,
 	)
 	if err != nil {
@@ -254,6 +254,11 @@ func (handlers *Handlers) postExportTransactions(*http.Request) (interface{}, er
 	if err := config.EnsurePrivateFile(path); err != nil {
 		_ = file.Close()
 		handlers.log.WithError(err).Error("error restricting file permissions")
+		return result{Success: false, ErrorMessage: err.Error()}, nil
+	}
+	if err := file.Truncate(0); err != nil {
+		_ = file.Close()
+		handlers.log.WithError(err).Error("error truncating file")
 		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
 	if err := handlers.account.ExportCSV(file, transactions); err != nil {

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -242,9 +242,18 @@ func (handlers *Handlers) postExportTransactions(*http.Request) (interface{}, er
 		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
 
-	file, err := os.Create(path)
+	file, err := os.OpenFile(
+		path,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+		config.PrivateFileMode,
+	)
 	if err != nil {
 		handlers.log.WithError(err).Error("error creating file")
+		return result{Success: false, ErrorMessage: err.Error()}, nil
+	}
+	if err := config.EnsurePrivateFile(path); err != nil {
+		_ = file.Close()
+		handlers.log.WithError(err).Error("error restricting file permissions")
 		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
 	if err := handlers.account.ExportCSV(file, transactions); err != nil {

--- a/backend/export_test.go
+++ b/backend/export_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	utilconfig "github.com/BitBoxSwiss/bitbox-wallet-app/util/config"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+type fileExportEnvironment struct {
+	environment
+	filename string
+}
+
+func (e fileExportEnvironment) GetSaveFilename(string) string {
+	return e.filename
+}
+
+func TestExportNotesRestrictsFilePermissions(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "notes.jsonl")
+	require.NoError(t, os.WriteFile(filename, nil, 0644))
+	require.NoError(t, os.Chmod(filename, 0644))
+
+	backend := &Backend{
+		environment: fileExportEnvironment{filename: filename},
+		log:         logrus.NewEntry(logrus.New()),
+	}
+	require.NoError(t, backend.ExportNotes())
+
+	info, err := os.Stat(filename)
+	require.NoError(t, err)
+	require.Equal(t, utilconfig.PrivateFileMode, info.Mode().Perm())
+}
+
+func TestExportLogsRestrictsFilePermissions(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "log.txt")
+	require.NoError(t, os.WriteFile(filename, nil, 0644))
+	require.NoError(t, os.Chmod(filename, 0644))
+
+	backend := &Backend{
+		environment: fileExportEnvironment{filename: filename},
+		log:         logrus.NewEntry(logrus.New()),
+	}
+	// The source log may not exist in a unit test, but the export file is opened and restricted
+	// before it is read.
+	_ = backend.ExportLogs()
+
+	info, err := os.Stat(filename)
+	require.NoError(t, err)
+	require.Equal(t, utilconfig.PrivateFileMode, info.Mode().Perm())
+}

--- a/backend/export_test.go
+++ b/backend/export_test.go
@@ -23,7 +23,7 @@ func (e fileExportEnvironment) GetSaveFilename(string) string {
 
 func TestExportNotesRestrictsFilePermissions(t *testing.T) {
 	filename := filepath.Join(t.TempDir(), "notes.jsonl")
-	require.NoError(t, os.WriteFile(filename, nil, 0644))
+	require.NoError(t, os.WriteFile(filename, []byte("stale contents"), 0644))
 	require.NoError(t, os.Chmod(filename, 0644))
 
 	backend := &Backend{
@@ -35,6 +35,9 @@ func TestExportNotesRestrictsFilePermissions(t *testing.T) {
 	info, err := os.Stat(filename)
 	require.NoError(t, err)
 	require.Equal(t, utilconfig.PrivateFileMode, info.Mode().Perm())
+	contents, err := os.ReadFile(filename)
+	require.NoError(t, err)
+	require.Empty(t, contents)
 }
 
 func TestExportLogsRestrictsFilePermissions(t *testing.T) {

--- a/backend/notes.go
+++ b/backend/notes.go
@@ -153,11 +153,18 @@ func (backend *Backend) ExportNotes() error {
 		return errp.ErrUserAbort
 	}
 	err = func() error {
-		file, err := os.Create(path)
+		file, err := os.OpenFile(
+			path,
+			os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+			utilcfg.PrivateFileMode,
+		)
 		if err != nil {
 			return err
 		}
 		defer func() { _ = file.Close() }()
+		if err := utilcfg.EnsurePrivateFile(path); err != nil {
+			return err
+		}
 
 		writer := bufio.NewWriter(file)
 		if err := backend.exportNotes(writer); err != nil {

--- a/backend/notes.go
+++ b/backend/notes.go
@@ -155,7 +155,7 @@ func (backend *Backend) ExportNotes() error {
 	err = func() error {
 		file, err := os.OpenFile(
 			path,
-			os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+			os.O_WRONLY|os.O_CREATE,
 			utilcfg.PrivateFileMode,
 		)
 		if err != nil {
@@ -163,6 +163,9 @@ func (backend *Backend) ExportNotes() error {
 		}
 		defer func() { _ = file.Close() }()
 		if err := utilcfg.EnsurePrivateFile(path); err != nil {
+			return err
+		}
+		if err := file.Truncate(0); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Create notes, transaction, and log exports with private file permissions. Tighten existing destinations before writing and document the policy.