### PR TITLE
lightning: add default top-up transaction note

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1819,6 +1819,7 @@
       "from": "From",
       "noBitcoinAccounts": "No Bitcoin accounts active. Please activate a Bitcoin account.",
       "noFundedBitcoinAccounts": "No Bitcoin accounts with an available balance. Receive Bitcoin before trying to top up again.",
+      "note": "Lightning top-up",
       "success": {
         "message": "Top up created!"
       },

--- a/frontends/web/src/routes/lightning/topup/topup.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup.tsx
@@ -93,7 +93,7 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
   const [fiatAmount, setFiatAmount] = useState('');
   const [feeTarget, setFeeTarget] = useState<accountApi.FeeTargetCode>();
   const [customFee, setCustomFee] = useState('');
-  const [note, setNote] = useState('');
+  const [note, setNote] = useState(() => t('lightning.topUp.note'));
   const [proposal, setProposal] = useState<accountApi.TTxProposalResult>();
   const [errorHandling, setErrorHandling] = useState<TProposalError>({});
   const [isUpdatingProposal, setIsUpdatingProposal] = useState(false);


### PR DESCRIPTION
Pre-fill the top-up transaction note with "Lightning top-up" so the outgoing Bitcoin transaction is labeled before it is sent.

The note remains editable in the existing send note field, and the top-up flow continues to send it through the normal Bitcoin account send path.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
