### PR TITLE
lightning: clarify top-up confirmations

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1820,7 +1820,8 @@
       "noBitcoinAccounts": "No Bitcoin accounts active. Please activate a Bitcoin account.",
       "noFundedBitcoinAccounts": "No Bitcoin accounts with an available balance. Receive Bitcoin before trying to top up again.",
       "success": {
-        "message": "Top up created!"
+        "message": "Top up created!",
+        "note": "The top-up transaction will appear after one confirmation and complete after three confirmations. This usually takes 30+ minutes."
       },
       "title": "Top up lightning wallet",
       "to": "To"

--- a/frontends/web/src/routes/lightning/topup/topup-result.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup-result.tsx
@@ -32,6 +32,7 @@ export const TopUpSuccess = () => {
           <View textCenter verticallyCentered>
             <ViewContent withIcon="success">
               <p>{t('lightning.topUp.success.message')}</p>
+              <p>{t('lightning.topUp.success.note')}</p>
             </ViewContent>
             <ViewButtons>
               <Button primary onClick={() => navigate('/lightning')}>


### PR DESCRIPTION
Top-ups do not show immediately in the Lightning wallet after sending the on-chain transaction. Show the expected confirmation milestones on the top-up success page so users know when the deposit should appear and complete.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
