### PR TITLE
frontend: add buy btn on empty account (both desktop & mobile)

### DIFF
--- a/frontends/web/src/routes/account/info/buy-receive-cta.module.css
+++ b/frontends/web/src/routes/account/info/buy-receive-cta.module.css
@@ -8,20 +8,55 @@
     display: flex;
     align-items: center;
     gap: var(--space-quarter);
+    justify-content: center;
+    white-space: nowrap;
 }
 
 .buttons {
+    align-items: stretch;
     display: flex;
     gap: var(--space-half);
     justify-content: center;
 }
 
 .walletConnect span {
-    margin-left: var(--space-eight);
+    margin-left: 0;
+}
+
+@media (max-width: 768px) {
+    .buttons {
+        gap: var(--space-quarter);
+        width: 100%;
+    }
+
+    .buttons button,
+    .buttons a {
+        flex: 1 1 0;
+        min-width: 0;
+        padding-left: var(--space-half);
+        padding-right: var(--space-half);
+    }
+
+    .buttons .walletConnect {
+        flex: 0 0 auto;
+        min-width: 0;
+    }
 }
 
 @media (max-width: 425px) {
-    .buttons button {
+    .buttons {
+        gap: var(--space-eight);
+    }
+
+    .buttons button,
+    .buttons a {
         font-size: var(--size-small);
+        padding-left: var(--space-quarter);
+        padding-right: var(--space-quarter);
+    }
+
+    .buttons .walletConnect {
+        padding-left: var(--space-quarter);
+        padding-right: var(--space-quarter);
     }
 }

--- a/frontends/web/src/routes/account/info/buy-receive-cta.tsx
+++ b/frontends/web/src/routes/account/info/buy-receive-cta.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import type { AccountCode, CoinUnit, TAccount, TBalance } from '@/api/account';
 import { useMediaQuery } from '@/hooks/mediaquery';
-import { Button } from '@/components/forms';
+import { Button, ButtonLink } from '@/components/forms';
 import { Balances } from '@/routes/account/summary/accountssummary';
 import { isBitcoinCoin, isEthereumBased } from '@/routes/account/utils';
 import { ArrowFloorDownWhite, Coins, WalletConnectLight } from '@/components/icon';
@@ -16,6 +16,7 @@ type TBuyReceiveCTAProps = {
   code?: AccountCode;
   unit?: CoinUnit;
   account?: TAccount;
+  showBuyButton?: boolean;
 };
 
 type TAddBuyReceiveOnEmpyBalancesProps = {
@@ -28,13 +29,18 @@ export const BuyReceiveCTA = ({
   code,
   unit,
   account,
+  showBuyButton = false,
 }: TBuyReceiveCTAProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const isBitcoin = isBitcoinCoin(unit);
   const isMobile = useMediaQuery('(max-width: 768px)');
+  const receiveLabel = isMobile ? t('generic.receiveWithoutCoinCode') : t('generic.receive', {
+    context: isBitcoin ? 'bitcoin' : (unit ? '' : 'crypto'),
+    coinCode: unit
+  });
 
-  const onMarketCTA = () => navigate(code ? `/market/select/${code}` : '/market/select');
+  const marketPath = code ? `/market/select/${code}?tab=buy` : '/market/select?tab=buy';
   const onWalletConnect = () => code && navigate(`/account/${code}/wallet-connect/dashboard`);
   const onReceiveCTA = () => {
     if (balanceList) {
@@ -60,21 +66,18 @@ export const BuyReceiveCTA = ({
         {balanceList && (
           <Button className={styles.button} primary onClick={onReceiveCTA}>
             <ArrowFloorDownWhite width={18} height={18} />
-            {/* "Receive Bitcoin", "Receive crypto" or "Receive LTC" (via placeholder "Receive {{coinCode}}") */}
-            {t('generic.receive', {
-              context: isBitcoin ? 'bitcoin' : (unit ? '' : 'crypto'),
-              coinCode: unit
-            })}
+            {/* Desktop includes the coin unit; mobile keeps the CTA compact. */}
+            {receiveLabel}
           </Button>
         )}
-        {!isMobile && (
-          <Button className={styles.button} primary onClick={onMarketCTA}>
+        {(!isMobile || code || showBuyButton) && (
+          <ButtonLink className={styles.button} primary to={marketPath}>
             <Coins width={18} height={18} />
-            {t('generic.buySell')}
-          </Button>
+            {t('buy.exchange.buy')}
+          </ButtonLink>
         )}
         {account && isEthereumBased(account.coinCode) && !account.isToken && (
-          <Button primary onClick={onWalletConnect} className={styles.walletConnect}>
+          <Button primary onClick={onWalletConnect} className={`${styles.button || ''} ${styles.walletConnect || ''}`}>
             {isMobile ? (
               <WalletConnectLight width={28} height={28} />
             ) : (
@@ -101,8 +104,12 @@ export const AddBuyReceiveOnEmptyBalances = ({ balances, accounts }: TAddBuyRece
       .filter(balance => !!balance)
   );
 
+  if (balanceList.length !== accounts.length) {
+    return null;
+  }
+
   // at least 1 active account has balance
-  if (balanceList.some(entry => entry.hasAvailable)) {
+  if (balanceList.some(entry => entry.hasAvailable || entry.hasIncoming)) {
     return null;
   }
 
@@ -112,6 +119,7 @@ export const AddBuyReceiveOnEmptyBalances = ({ balances, accounts }: TAddBuyRece
       <BuyReceiveCTA
         balanceList={balanceList}
         code={onlyHasOneActiveAccount ? accounts[0]?.code : undefined}
+        showBuyButton
         unit="BTC"
       />
     );
@@ -120,6 +128,7 @@ export const AddBuyReceiveOnEmptyBalances = ({ balances, accounts }: TAddBuyRece
   return (
     <BuyReceiveCTA
       balanceList={balanceList}
+      showBuyButton
     />
   );
 };


### PR DESCRIPTION

Added "Buy" button on Desktop & Mobile for empty accounts:
<img width="420" height="469" alt="Screenshot 2026-08-10 at 11 36 46" src="https://github.com/user-attachments/assets/7360bdd3-d029-4836-a4fd-9b1f390acb15" />


Also on account summary:

<img width="354" height="490" alt="Screenshot 2026-08-10 at 11 36 25" src="https://github.com/user-attachments/assets/7d3eedd9-362e-4f1a-807d-0a717cf49796" />

