### PR TITLE
frontend: bind messages to vendor iframes

### DIFF
--- a/frontends/web/src/hooks/vendor-iframe-message.test.ts
+++ b/frontends/web/src/hooks/vendor-iframe-message.test.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getVendorIframeMessageTarget,
+  postMessageToVendorIframe,
+} from './vendor-iframe-message';
+
+const createIframe = () => {
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+  return iframe;
+};
+
+describe('vendor iframe messages', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it('accepts messages from the current iframe', () => {
+    const iframe = createIframe();
+    const event = new MessageEvent('message', {
+      origin: 'https://widget.example.com',
+      source: iframe.contentWindow,
+    });
+
+    expect(getVendorIframeMessageTarget(event, iframe)).toEqual({
+      origin: 'https://widget.example.com',
+      source: iframe.contentWindow,
+    });
+  });
+
+  it('rejects messages from a different window', () => {
+    const iframe = createIframe();
+    const otherIframe = createIframe();
+    const event = new MessageEvent('message', {
+      origin: 'https://widget.example.com',
+      source: otherIframe.contentWindow,
+    });
+
+    expect(getVendorIframeMessageTarget(event, iframe)).toBeUndefined();
+  });
+
+  it('replies to the validated source with its exact origin', () => {
+    const iframe = createIframe();
+    const source = iframe.contentWindow;
+    if (!source) {
+      throw new Error('Expected iframe to have a content window');
+    }
+    const postMessage = vi.spyOn(source, 'postMessage').mockImplementation(() => {});
+    const target = getVendorIframeMessageTarget(new MessageEvent('message', {
+      origin: 'https://widget.example.com',
+      source,
+    }), iframe);
+    if (!target) {
+      throw new Error('Expected message target');
+    }
+
+    postMessageToVendorIframe(target, { type: 'response' });
+
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'response' },
+      'https://widget.example.com',
+    );
+  });
+});

--- a/frontends/web/src/hooks/vendor-iframe-message.ts
+++ b/frontends/web/src/hooks/vendor-iframe-message.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type TVendorIframeMessageTarget = {
+  origin: string;
+  source: Window;
+};
+
+export const getVendorIframeMessageTarget = (
+  event: MessageEvent,
+  iframe: HTMLIFrameElement | null,
+): TVendorIframeMessageTarget | undefined => {
+  const source = iframe?.contentWindow;
+  if (!source || event.source !== source) {
+    return;
+  }
+  return {
+    origin: event.origin,
+    source,
+  };
+};
+
+export const postMessageToVendorIframe = (
+  target: TVendorIframeMessageTarget,
+  message: unknown,
+) => {
+  target.source.postMessage(message, target.origin);
+};

--- a/frontends/web/src/hooks/vendor-iframe.ts
+++ b/frontends/web/src/hooks/vendor-iframe.ts
@@ -3,3 +3,8 @@
 export { useVendorIframeResizeHeight } from '@/hooks/vendor-iframe-resize-height';
 export { useVendorTerms } from '@/hooks/vendor-iframe-terms';
 export { useMarketIframeActive, useVendorIframeActive } from '@/hooks/vendor-iframe-active';
+export {
+  getVendorIframeMessageTarget,
+  postMessageToVendorIframe,
+  type TVendorIframeMessageTarget,
+} from '@/hooks/vendor-iframe-message';

--- a/frontends/web/src/routes/bitsurance/widget.tsx
+++ b/frontends/web/src/routes/bitsurance/widget.tsx
@@ -14,7 +14,14 @@ import { UseDisableBackButton } from '@/hooks/backbutton';
 import { alertUser } from '@/components/alert/Alert';
 import { getBitsuranceURL } from '@/api/bitsurance';
 import { convertScriptType } from '@/utils/request-addess';
-import { useVendorIframeActive, useVendorIframeResizeHeight, useVendorTerms } from '@/hooks/vendor-iframe';
+import {
+  getVendorIframeMessageTarget,
+  postMessageToVendorIframe,
+  useVendorIframeActive,
+  useVendorIframeResizeHeight,
+  useVendorTerms,
+  type TVendorIframeMessageTarget,
+} from '@/hooks/vendor-iframe';
 import { BitsuranceGuide } from './guide';
 import style from './widget.module.css';
 
@@ -42,13 +49,12 @@ export const BitsuranceWidget = ({ code }: TProps) => {
     };
   });
 
-  const sendAddressWithXPub = (address: string, sig: string, xpub: string) => {
-    const { current } = iframeRef;
-
-    if (!current) {
-      return;
-    }
-
+  const sendAddressWithXPub = (
+    target: TVendorIframeMessageTarget,
+    address: string,
+    sig: string,
+    xpub: string,
+  ) => {
     const message = serializeMessage({
       version: MessageVersion.V0,
       type: V0MessageType.Address,
@@ -57,7 +63,7 @@ export const BitsuranceWidget = ({ code }: TProps) => {
       signature: sig,
     });
 
-    current.contentWindow?.postMessage(message, '*');
+    postMessageToVendorIframe(target, message);
   };
 
   const getXPub = (wantedScriptType: ScriptType) => {
@@ -67,7 +73,10 @@ export const BitsuranceWidget = ({ code }: TProps) => {
     return xpubConfig?.bitcoinSimple?.keyInfo.xpub;
   };
 
-  const handleRequestAddress = (message: RequestAddressV0Message) => {
+  const handleRequestAddress = (
+    target: TVendorIframeMessageTarget,
+    message: RequestAddressV0Message,
+  ) => {
     signingRef.current = true;
     const addressType = message.withScriptType ? convertScriptType(message.withScriptType) : '';
     const withMessageSignature = message.withMessageSignature ? message.withMessageSignature : '';
@@ -82,12 +91,12 @@ export const BitsuranceWidget = ({ code }: TProps) => {
           if (withExtendedPublicKey) {
             const xpub = getXPub(addressType as ScriptType);
             if (xpub) {
-              sendAddressWithXPub(response.address, response.signature, xpub);
+              sendAddressWithXPub(target, response.address, response.signature, xpub);
             } else {
               alertUser(t('bitsuranceAccount.errorNoXpub'));
             }
           } else {
-            sendAddressWithXPub(response.address, response.signature, '');
+            sendAddressWithXPub(target, response.address, response.signature, '');
           }
         } else {
           if (!['userAbort', 'wrongKeystore'].includes(response.errorCode || '')) {
@@ -104,8 +113,9 @@ export const BitsuranceWidget = ({ code }: TProps) => {
       return;
     }
 
-    // verify the origin of the received message
-    if (m.origin !== new URL(iframeURL).origin) {
+    const target = getVendorIframeMessageTarget(m, iframeRef.current);
+    // Verify that the message came from the current Bitsurance iframe and its expected origin.
+    if (!target || target.origin !== new URL(iframeURL).origin) {
       return;
     }
 
@@ -123,7 +133,7 @@ export const BitsuranceWidget = ({ code }: TProps) => {
         // we ignore further signing requests
         // while there is an ongoing one
         if (!signingRef.current) {
-          handleRequestAddress(message);
+          handleRequestAddress(target, message);
         }
         break;
       }

--- a/frontends/web/src/routes/market/bitrefill.tsx
+++ b/frontends/web/src/routes/market/bitrefill.tsx
@@ -18,7 +18,14 @@ import { getBitrefillInfo } from '@/api/market';
 import { getURLOrigin } from '@/utils/url';
 import { ConfirmBitrefill } from './bitrefill-confirm';
 import { AppContext } from '@/contexts/AppContext';
-import { useMarketIframeActive, useVendorIframeResizeHeight, useVendorTerms } from '@/hooks/vendor-iframe';
+import {
+  getVendorIframeMessageTarget,
+  postMessageToVendorIframe,
+  useMarketIframeActive,
+  useVendorIframeResizeHeight,
+  useVendorTerms,
+  type TVendorIframeMessageTarget,
+} from '@/hooks/vendor-iframe';
 import { useAccountSynced } from '@/hooks/account';
 import style from './iframe.module.css';
 
@@ -60,14 +67,14 @@ export const Bitrefill = ({
 
   const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
 
-  const handleConfiguration = useCallback(async (event: MessageEvent) => {
+  const handleConfiguration = useCallback(async (target: TVendorIframeMessageTarget) => {
     if (
       !account
       || !bitrefillInfo?.success
     ) {
       return;
     }
-    event.source?.postMessage({
+    postMessageToVendorIframe(target, {
       event: 'configuration',
       ref: bitrefillInfo.ref,
       utm_source: 'BITBOX',
@@ -80,8 +87,6 @@ export const Bitrefill = ({
       region, // can be an empty string if user didnt select a region in market
       // Option to show payment information in the widget, defaults to 'true'
       showPaymentInfo: 'true'
-    }, {
-      targetOrigin: event.origin
     });
   }, [account, bitrefillInfo, isDarkMode, region]);
 
@@ -157,11 +162,13 @@ export const Bitrefill = ({
   }, [account, code, pendingPayment, t]);
 
   const handleMessage = useCallback(async (event: MessageEvent) => {
+    const target = getVendorIframeMessageTarget(event, iframeRef.current);
     if (
-      !bitrefillInfo?.success
+      !target
+      || !bitrefillInfo?.success
       || (
         !isDevServers // if prod check that event is from same origin as bitrefillInfo.url
-        && ![getURLOrigin(bitrefillInfo.url), 'https://embed.bitrefill.com'].includes(event.origin))
+        && ![getURLOrigin(bitrefillInfo.url), 'https://embed.bitrefill.com'].includes(target.origin))
     ) {
       return;
     }
@@ -170,7 +177,7 @@ export const Bitrefill = ({
 
     switch (data.event) {
     case 'request-configuration': {
-      handleConfiguration(event);
+      handleConfiguration(target);
       break;
     }
     case 'payment_intent': {
@@ -181,7 +188,7 @@ export const Bitrefill = ({
       break;
     }
     }
-  }, [bitrefillInfo, handleConfiguration, handlePaymentRequest, isDevServers]);
+  }, [bitrefillInfo, handleConfiguration, handlePaymentRequest, iframeRef, isDevServers]);
 
   useEffect(() => {
     window.addEventListener('message', handleMessage);

--- a/frontends/web/src/routes/market/btcdirect.tsx
+++ b/frontends/web/src/routes/market/btcdirect.tsx
@@ -19,7 +19,14 @@ import { findAccount, isBitcoinOnly } from '@/routes/account/utils';
 import { BTCDirectTerms } from '@/components/terms/btcdirect-terms';
 import { MarketGuide } from './guide';
 import { alertUser } from '@/components/alert/Alert';
-import { useMarketIframeActive, useVendorIframeResizeHeight, useVendorTerms } from '@/hooks/vendor-iframe';
+import {
+  getVendorIframeMessageTarget,
+  postMessageToVendorIframe,
+  useMarketIframeActive,
+  useVendorIframeResizeHeight,
+  useVendorTerms,
+  type TVendorIframeMessageTarget,
+} from '@/hooks/vendor-iframe';
 import { Message } from '@/components/message/message';
 import style from './iframe.module.css';
 
@@ -59,7 +66,10 @@ export const BTCDirect = ({
   const { agreedTerms, setAgreedTerms } = useVendorTerms(config?.frontend.skipBTCDirectWidgetDisclaimer ?? false);
   useMarketIframeActive(!!account && !!config && agreedTerms && btcdirectInfo?.success === true);
 
-  const handlePaymentRequest = useCallback(async (event: MessageEvent) => {
+  const handlePaymentRequest = useCallback(async (
+    event: MessageEvent,
+    target: TVendorIframeMessageTarget,
+  ) => {
     const {
       amount,
       currency,
@@ -110,11 +120,9 @@ export const BTCDirect = ({
       setBlocking(false);
       if (sendResult.success) {
         const { txId } = sendResult;
-        event.source?.postMessage({
+        postMessageToVendorIframe(target, {
           action: 'confirm-transaction-id',
           transactionId: txId
-        }, {
-          targetOrigin: event.origin
         });
         // stop here and continue in the widget
         return;
@@ -137,21 +145,19 @@ export const BTCDirect = ({
     }
 
     // cancel the sell order here if txProposal or sendTx was unsuccessful
-    event.source?.postMessage({
+    postMessageToVendorIframe(target, {
       action: 'cancel-order',
-    }, {
-      targetOrigin: event.origin
     });
 
   }, [code, t, btcdirectInfo]);
 
   const locale = i18n.resolvedLanguage ? localeMapping[i18n.resolvedLanguage] : 'en-GB';
 
-  const handleConfiguration = useCallback((event: MessageEvent) => {
+  const handleConfiguration = useCallback((target: TVendorIframeMessageTarget) => {
     if (!account || !btcdirectInfo?.success) {
       return;
     }
-    event.source?.postMessage({
+    postMessageToVendorIframe(target, {
       action: 'configuration',
       ...(action === 'buy' && {
         address: btcdirectInfo.address
@@ -162,35 +168,35 @@ export const BTCDirect = ({
       quoteCurrency: 'EUR', // BTC Direct currently only accepts EURO
       mode: isDevServers ? 'debug' : 'production',
       apiKey: btcdirectInfo.apiKey,
-    }, {
-      targetOrigin: event.origin
     });
   }, [account, action, btcdirectInfo, isDarkMode, isDevServers, locale]);
 
   const onMessage = useCallback((event: MessageEvent) => {
+    const target = getVendorIframeMessageTarget(event, iframeRef.current);
     if (
-      !account
+      !target
+      || !account
       || !btcdirectInfo?.success
       || (
         !isDevServers // if prod check that event is from same origin as btcdirectInfo.url
-        && event.origin !== getURLOrigin(btcdirectInfo.url)
+        && target.origin !== getURLOrigin(btcdirectInfo.url)
       )
     ) {
       return;
     }
     switch (event.data.action) {
     case 'request-configuration':
-      handleConfiguration(event);
+      handleConfiguration(target);
       break;
     case 'request-payment':
-      handlePaymentRequest(event);
+      handlePaymentRequest(event, target);
       break;
     case 'back-to-app':
       navigate(`/account/${code}`);
       break;
     }
 
-  }, [account, btcdirectInfo, code, isDevServers, navigate, handleConfiguration, handlePaymentRequest]);
+  }, [account, btcdirectInfo, code, iframeRef, isDevServers, navigate, handleConfiguration, handlePaymentRequest]);
 
   useEffect(() => {
     window.addEventListener('message', onMessage);

--- a/frontends/web/src/routes/market/pocket.tsx
+++ b/frontends/web/src/routes/market/pocket.tsx
@@ -21,7 +21,14 @@ import { MarketGuide } from './guide';
 import { convertScriptType } from '@/utils/request-addess';
 import { parseExternalBtcAmount } from '@/api/coins';
 import { FirmwareUpgradeRequiredDialog } from '@/components/dialog/firmware-upgrade-required-dialog';
-import { useMarketIframeActive, useVendorIframeResizeHeight, useVendorTerms } from '@/hooks/vendor-iframe';
+import {
+  getVendorIframeMessageTarget,
+  postMessageToVendorIframe,
+  useMarketIframeActive,
+  useVendorIframeResizeHeight,
+  useVendorTerms,
+  type TVendorIframeMessageTarget,
+} from '@/hooks/vendor-iframe';
 import { useAccountSynced } from '@/hooks/account';
 import { Message } from '@/components/message/message';
 import style from './iframe.module.css';
@@ -75,13 +82,12 @@ export const Pocket = ({
     };
   });
 
-  const sendAddress = (address: string, sig: string, correlationId?: string) => {
-    const { current } = iframeRef;
-
-    if (!current) {
-      return;
-    }
-
+  const sendAddress = (
+    target: TVendorIframeMessageTarget,
+    address: string,
+    sig: string,
+    correlationId?: string,
+  ) => {
     const message = serializeMessage({
       version: MessageVersion.V0,
       type: V0MessageType.Address,
@@ -90,14 +96,14 @@ export const Pocket = ({
       signature: sig,
     });
 
-    current.contentWindow?.postMessage(message, '*');
+    postMessageToVendorIframe(target, message);
   };
 
-  const sendPaymentTxId = (txid: string, correlationId?: string) => {
-    if (!iframeRef.current) {
-      return;
-    }
-
+  const sendPaymentTxId = (
+    target: TVendorIframeMessageTarget,
+    txid: string,
+    correlationId?: string,
+  ) => {
     const message = serializeMessage({
       version: MessageVersion.V0,
       type: V0MessageType.Payment,
@@ -105,14 +111,14 @@ export const Pocket = ({
       txid,
     });
 
-    iframeRef.current.contentWindow?.postMessage(message, '*');
+    postMessageToVendorIframe(target, message);
   };
 
-  const sendCanceledMessage = (reason: string, correlationId?: string) => {
-    if (!iframeRef.current) {
-      return;
-    }
-
+  const sendCanceledMessage = (
+    target: TVendorIframeMessageTarget,
+    reason: string,
+    correlationId?: string,
+  ) => {
     const message = serializeMessage({
       version: MessageVersion.V0,
       type: V0MessageType.Cancel,
@@ -120,10 +126,13 @@ export const Pocket = ({
       reason,
     });
 
-    iframeRef.current.contentWindow?.postMessage(message, '*');
+    postMessageToVendorIframe(target, message);
   };
 
-  const handleRequestAddress = (message: RequestAddressV0Message) => {
+  const handleRequestAddress = (
+    target: TVendorIframeMessageTarget,
+    message: RequestAddressV0Message,
+  ) => {
     signingRef.current = true;
     const addressType = message.withScriptType ? convertScriptType(message.withScriptType) : '';
     const withMessageSignature = message.withMessageSignature ? message.withMessageSignature : '';
@@ -134,7 +143,7 @@ export const Pocket = ({
       .then(response => {
         signingRef.current = false;
         if (response.success) {
-          sendAddress(response.address, response.signature, message.correlationId);
+          sendAddress(target, response.address, response.signature, message.correlationId);
         } else {
           if (response.errorCode !== 'userAbort') {
             alertUser(t('unknownError', { errorMessage: response.errorMessage }));
@@ -163,27 +172,23 @@ export const Pocket = ({
       });
   };
 
-  const sendXpub = (correlationId?: string) => {
+  const sendXpub = (target: TVendorIframeMessageTarget, correlationId?: string) => {
     if (accountInfo) {
       const bitcoinSimple = accountInfo.signingConfigurations[0]?.bitcoinSimple;
       if (bitcoinSimple) {
         const xpub = bitcoinSimple.keyInfo.xpub;
-        const { current } = iframeRef;
-        if (!current) {
-          return;
-        }
         const message = serializeMessage({
           version: MessageVersion.V0,
           type: V0MessageType.ExtendedPublicKey,
           extendedPublicKey: xpub,
           correlationId,
         });
-        current.contentWindow?.postMessage(message, '*');
+        postMessageToVendorIframe(target, message);
       }
     }
   };
 
-  const handleRequestXpub = (correlationId?: string) => {
+  const handleRequestXpub = (target: TVendorIframeMessageTarget, correlationId?: string) => {
     getTransactionList(code).then(txs => {
       if (!txs.success) {
         alertUser(t('transactions.errorLoadTransactions'));
@@ -192,16 +197,19 @@ export const Pocket = ({
       if (txs.list.length > 0) {
         confirmation(t('buy.pocket.previousTransactions'), result => {
           if (result) {
-            sendXpub(correlationId);
+            sendXpub(target, correlationId);
           }
         });
       } else {
-        sendXpub(correlationId);
+        sendXpub(target, correlationId);
       }
     });
   };
 
-  const handlePaymentRequest = async (message: PaymentRequestV0Message) => {
+  const handlePaymentRequest = async (
+    target: TVendorIframeMessageTarget,
+    message: PaymentRequestV0Message,
+  ) => {
     if (!message.slip24) {
       alertUser(t('unknownError', { errorMessage: 'Missing payment request data' }));
       return;
@@ -210,7 +218,7 @@ export const Pocket = ({
     // this allows to correctly handle sats mode
     const parsedAmount = await parseExternalBtcAmount(message.amount.toString());
     if (!parsedAmount.success) {
-      sendCanceledMessage('invalid_amount', message.correlationId);
+      sendCanceledMessage(target, 'invalid_amount', message.correlationId);
       alertUser(t('unknownError', { errorMessage: 'Invalid amount' }));
       return;
     }
@@ -232,12 +240,12 @@ export const Pocket = ({
       const sendResult = await sendTx(code, txNote);
       setBlocking(false);
       if (sendResult.success) {
-        sendPaymentTxId(sendResult.txId, message.correlationId);
+        sendPaymentTxId(target, sendResult.txId, message.correlationId);
       } else {
         if ('aborted' in sendResult) {
-          sendCanceledMessage('rejected_by_customer', message.correlationId);
+          sendCanceledMessage(target, 'rejected_by_customer', message.correlationId);
         } else {
-          sendCanceledMessage('unknown_error', message.correlationId);
+          sendCanceledMessage(target, 'unknown_error', message.correlationId);
           if (sendResult.errorMessage) {
             alertUser(t('unknownError', { errorMessage: sendResult.errorMessage }));
           } else {
@@ -260,8 +268,9 @@ export const Pocket = ({
     if (!pocketInfo?.success || !code) {
       return;
     }
-    // verify the origin of the received message
-    if (m.origin !== new URL(pocketInfo.url).origin) {
+    const target = getVendorIframeMessageTarget(m, iframeRef.current);
+    // Verify that the message came from the current Pocket iframe and its expected origin.
+    if (!target || target.origin !== new URL(pocketInfo.url).origin) {
       return;
     }
 
@@ -271,7 +280,7 @@ export const Pocket = ({
       switch (message.type) {
       case V0MessageType.RequestAddress:
         if (!signingRef.current) {
-          handleRequestAddress(message);
+          handleRequestAddress(target, message);
         }
         break;
       case V0MessageType.VerifyAddress:
@@ -280,10 +289,10 @@ export const Pocket = ({
         }
         break;
       case V0MessageType.RequestExtendedPublicKey:
-        handleRequestXpub(message.correlationId);
+        handleRequestXpub(target, message.correlationId);
         break;
       case V0MessageType.PaymentRequest:
-        handlePaymentRequest(message);
+        handlePaymentRequest(target, message);
         break;
       case V0MessageType.Close:
         navigate(`/account/${code}`, { replace: true });


### PR DESCRIPTION
Validate postMessage sources against the active iframe and retain the
validated source and origin for asynchronous replies.

Apply the same protection to Pocket, Bitsurance, BTC Direct, and Bitrefill,
and add regression tests for source binding and exact reply origins.