### PR TITLE
swap: support large EVM payment request amounts

### DIFF
--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -340,6 +340,9 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 	paymentRequest := btcProposedTx.TXProposal.PaymentRequest
 	var paymentRequestIndex *uint32
 	if paymentRequest != nil {
+		if paymentRequest.TotalAmount == nil || !paymentRequest.TotalAmount.IsUint64() {
+			return errp.New("BTC payment request amount overflows uint64")
+		}
 		btcPaymentRequests = []*messages.BTCPaymentRequestRequest{
 			newBTCPaymentRequest(paymentRequest),
 		}
@@ -506,10 +509,17 @@ func newBTCPaymentRequest(txPaymentRequest *paymentrequest.Request) *messages.BT
 		memos = append(memos, &memo)
 	}
 
+	// total_amount is a legacy BTC-only protobuf field. EVM payment requests are
+	// displayed and validated against the arbitrary-precision amount parsed from the tx.
+	totalAmount := uint64(0)
+	if amount := txPaymentRequest.TotalAmount; amount != nil && amount.IsUint64() {
+		totalAmount = amount.Uint64()
+	}
+
 	return &messages.BTCPaymentRequestRequest{
 		RecipientName: txPaymentRequest.RecipientName,
 		Nonce:         txPaymentRequest.Nonce,
-		TotalAmount:   txPaymentRequest.TotalAmount,
+		TotalAmount:   totalAmount,
 		Signature:     txPaymentRequest.Signature,
 		Memos:         memos,
 	}

--- a/backend/devices/bitbox02/keystore_simulator_test.go
+++ b/backend/devices/bitbox02/keystore_simulator_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
@@ -790,13 +791,30 @@ func TestSimulatorSignBTCPaymentRequest(t *testing.T) {
 		proposedTransaction := makeTx(t, device, maketx.NewOutputInfo(pkScript))
 
 		txProposal := proposedTransaction.TXProposal
+		for _, testCase := range []struct {
+			name        string
+			totalAmount *big.Int
+		}{
+			{name: "nil total amount", totalAmount: nil},
+			{name: "amount exceeding uint64", totalAmount: new(big.Int).Lsh(big.NewInt(1), 64)},
+		} {
+			t.Run(testCase.name, func(t *testing.T) {
+				txProposal.PaymentRequest = &paymentrequest.Request{TotalAmount: testCase.totalAmount}
+				require.EqualError(
+					t,
+					device.Keystore().SignTransaction(proposedTransaction),
+					"BTC payment request amount overflows uint64",
+				)
+			})
+		}
+
 		recipientOutput := txProposal.Psbt.UnsignedTx.TxOut[txProposal.OutIndex]
 		value := uint64(recipientOutput.Value)
 
 		paymentRequest := &paymentrequest.Request{
 			RecipientName: "Test Merchant", // Hard-coded test merchant in simulator
 			Nonce:         nil,
-			TotalAmount:   value,
+			TotalAmount:   new(big.Int).SetUint64(value),
 			Memos: []paymentrequest.Memo{
 				{
 					Text: &paymentrequest.TextMemo{

--- a/backend/market/swapkit/helpers_test.go
+++ b/backend/market/swapkit/helpers_test.go
@@ -261,7 +261,7 @@ func TestNewSwapUsesInjectedHTTPClient(t *testing.T) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body: io.NopCloser(strings.NewReader(
-					`{"routeId":"route-id","sourceAddress":"source-address","destinationAddress":"destination-address","expectedBuyAmount":"9.87","swapId":"swap-id"}`,
+					`{"routeId":"route-id","sourceAddress":"source-address","destinationAddress":"destination-address","expectedBuyAmount":"9.87","swapId":"swap-id","meta":{"slip24":{"recipientName":"SWAPKIT (NEAR)","nonce":null,"memos":[],"outputs":[{"amount":55000000000000000000,"address":"0x986f66F28C6a2BBE939dF3161D1D2b238933895c"}],"signature":""}}}`,
 				)),
 				Header: make(http.Header),
 			}, nil
@@ -281,6 +281,7 @@ func TestNewSwapUsesInjectedHTTPClient(t *testing.T) {
 	require.Nil(t, apiError)
 	require.Equal(t, "swap-id", response.SwapID)
 	require.Equal(t, "9.87", response.ExpectedBuyAmount)
+	require.Equal(t, "55000000000000000000", response.PaymentRequest().Outputs[0].Amount)
 }
 
 func TestNewQuoteFromCoinCodePreservesRoutesWithAnyProviderCount(t *testing.T) {

--- a/backend/market/swapkit/live_test.go
+++ b/backend/market/swapkit/live_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"math/big"
 	"net/http"
 	"os"
 	"strings"
@@ -92,6 +93,15 @@ func TestSwapKitLiveSlip24(t *testing.T) {
 			sellCoin:           newQuoteCoin(coinpkg.Code("eth-erc20-usdc"), "USDC"),
 			buyCoin:            newQuoteCoin(coinpkg.CodeETH, "ETH"),
 			sellAmount:         "1000",
+			sourceAddress:      "0x171A32C3Dcbc92fD74026cBA6e3f9cB2c2bb938e",
+			destinationAddress: "0x171A32C3Dcbc92fD74026cBA6e3f9cB2c2bb938e",
+			slip44:             60,
+		},
+		{
+			name:               "dai-to-eth",
+			sellCoin:           newQuoteCoin(coinpkg.Code("eth-erc20-dai0x6b17"), "DAI"),
+			buyCoin:            newQuoteCoin(coinpkg.CodeETH, "ETH"),
+			sellAmount:         "55",
 			sourceAddress:      "0x171A32C3Dcbc92fD74026cBA6e3f9cB2c2bb938e",
 			destinationAddress: "0x171A32C3Dcbc92fD74026cBA6e3f9cB2c2bb938e",
 			slip44:             60,
@@ -209,8 +219,13 @@ func verifySwapKitSlip24(t *testing.T, slip24 *paymentrequest.Slip24, trustedPub
 	require.NotNil(t, paymentRequest, "payment request")
 	signature := swapKitECDSASignature(t, paymentRequest.Signature)
 	output := slip24.Outputs[0]
+	protoTotalAmount := uint64(0)
+	if !swapKitEVMAsset(testCase.sellCoin) {
+		require.True(t, paymentRequest.TotalAmount.IsUint64(), "BTC-family payment request amount")
+		protoTotalAmount = paymentRequest.TotalAmount.Uint64()
+	}
 	sighash, err := firmware.ComputePaymentRequestSighashBytes(
-		btcPaymentRequest(t, paymentRequest),
+		btcPaymentRequest(t, paymentRequest, protoTotalAmount),
 		testCase.slip44,
 		slip24OutputValueBytes(t, testCase.sellCoin, paymentRequest.TotalAmount),
 		output.Address,
@@ -219,7 +234,11 @@ func verifySwapKitSlip24(t *testing.T, slip24 *paymentrequest.Slip24, trustedPub
 	require.True(t, signature.Verify(sighash, trustedPubKey), "signature did not match trusted key")
 }
 
-func btcPaymentRequest(t *testing.T, paymentRequest *paymentrequest.Request) *messages.BTCPaymentRequestRequest {
+func btcPaymentRequest(
+	t *testing.T,
+	paymentRequest *paymentrequest.Request,
+	totalAmount uint64,
+) *messages.BTCPaymentRequestRequest {
 	t.Helper()
 
 	memos := make([]*messages.BTCPaymentRequestRequest_Memo, 0, len(paymentRequest.Memos))
@@ -252,21 +271,31 @@ func btcPaymentRequest(t *testing.T, paymentRequest *paymentrequest.Request) *me
 		RecipientName: paymentRequest.RecipientName,
 		Memos:         memos,
 		Nonce:         paymentRequest.Nonce,
-		TotalAmount:   paymentRequest.TotalAmount,
+		TotalAmount:   totalAmount,
 		Signature:     paymentRequest.Signature,
 	}
 }
 
-func slip24OutputValueBytes(t *testing.T, sellCoin coinpkg.Coin, amount uint64) []byte {
+func swapKitEVMAsset(sellCoin coinpkg.Coin) bool {
+	return sellCoin.Code() == coinpkg.CodeETH || strings.HasPrefix(string(sellCoin.Code()), "eth-erc20-")
+}
+
+func slip24OutputValueBytes(t *testing.T, sellCoin coinpkg.Coin, amount *big.Int) []byte {
 	t.Helper()
 
-	sellCoinCode := string(sellCoin.Code())
-	if sellCoin.Code() == coinpkg.CodeETH || strings.HasPrefix(sellCoinCode, "eth-erc20-") {
+	require.NotNil(t, amount)
+	require.NotEqual(t, -1, amount.Sign())
+	if swapKitEVMAsset(sellCoin) {
+		require.LessOrEqual(t, amount.BitLen(), 256)
 		result := make([]byte, 32)
-		binary.LittleEndian.PutUint64(result, amount)
+		bigEndian := amount.Bytes()
+		for index := range bigEndian {
+			result[index] = bigEndian[len(bigEndian)-index-1]
+		}
 		return result
 	}
-	return binary.LittleEndian.AppendUint64(nil, amount)
+	require.True(t, amount.IsUint64())
+	return binary.LittleEndian.AppendUint64(nil, amount.Uint64())
 }
 
 func swapKitECDSASignature(t *testing.T, sig []byte) *ecdsa.Signature {

--- a/backend/paymentrequest/convert.go
+++ b/backend/paymentrequest/convert.go
@@ -22,6 +22,10 @@ func (slip24 *Slip24) ToRequest() (*Request, error) {
 	if slip24.Nonce != nil && len(*slip24.Nonce) > 0 {
 		return nil, errp.New("Nonce value unsupported")
 	}
+	totalAmount, err := slip24.Outputs[0].AmountBigInt()
+	if err != nil {
+		return nil, err
+	}
 
 	sigBytes, err := base64.StdEncoding.DecodeString(slip24.Signature)
 	if err != nil {
@@ -67,7 +71,7 @@ func (slip24 *Slip24) ToRequest() (*Request, error) {
 		RecipientName: slip24.RecipientName,
 		Nonce:         nil,
 		Signature:     sigBytes,
-		TotalAmount:   slip24.Outputs[0].Amount,
+		TotalAmount:   totalAmount,
 		Memos:         memos,
 	}, nil
 }

--- a/backend/paymentrequest/request.go
+++ b/backend/paymentrequest/request.go
@@ -2,7 +2,11 @@
 
 package paymentrequest
 
-import "github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
+import (
+	"math/big"
+
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
+)
 
 // TextMemo represents a slip-0024 text memo.
 type TextMemo struct {
@@ -41,6 +45,6 @@ type Request struct {
 	RecipientName string
 	Memos         []Memo
 	Nonce         []byte
-	TotalAmount   uint64
+	TotalAmount   *big.Int
 	Signature     []byte
 }

--- a/backend/paymentrequest/types.go
+++ b/backend/paymentrequest/types.go
@@ -2,6 +2,13 @@
 
 package paymentrequest
 
+import (
+	"encoding/json"
+	"math/big"
+
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+)
+
 // Slip24 models a payment request payload.
 type Slip24 struct {
 	RecipientName string       `json:"recipientName"`
@@ -45,6 +52,45 @@ type Slip24BtcAddressDerivation struct {
 
 // Slip24Out models a single signed payment-request output.
 type Slip24Out struct {
-	Amount  uint64 `json:"amount"`
+	Amount  string `json:"amount"`
 	Address string `json:"address"`
+}
+
+// UnmarshalJSON accepts the numeric amount returned by payment-request providers as well as the
+// string amount sent back by the frontend. Amount is stored as a string so values larger than
+// uint64 or JavaScript's safe integer range remain exact.
+func (output *Slip24Out) UnmarshalJSON(jsonBytes []byte) error {
+	decoded := struct {
+		Amount  json.RawMessage `json:"amount"`
+		Address string          `json:"address"`
+	}{}
+	if err := json.Unmarshal(jsonBytes, &decoded); err != nil {
+		return errp.WithStack(err)
+	}
+
+	var amount string
+	if len(decoded.Amount) > 0 && decoded.Amount[0] == '"' {
+		if err := json.Unmarshal(decoded.Amount, &amount); err != nil {
+			return errp.WithStack(err)
+		}
+	} else {
+		amount = string(decoded.Amount)
+	}
+	parsedAmount, ok := new(big.Int).SetString(amount, 10)
+	if !ok || parsedAmount.Sign() < 0 {
+		return errp.Newf("invalid payment request output amount %q", amount)
+	}
+
+	output.Amount = amount
+	output.Address = decoded.Address
+	return nil
+}
+
+// AmountBigInt returns the output amount as an arbitrary-precision integer.
+func (output Slip24Out) AmountBigInt() (*big.Int, error) {
+	amount, ok := new(big.Int).SetString(output.Amount, 10)
+	if !ok || amount.Sign() < 0 {
+		return nil, errp.Newf("invalid payment request output amount %q", output.Amount)
+	}
+	return amount, nil
 }

--- a/backend/paymentrequest/types_test.go
+++ b/backend/paymentrequest/types_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package paymentrequest
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlip24OutLargeAmountJSONRoundTrip(t *testing.T) {
+	var output Slip24Out
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"amount":55000000000000000000,"address":"0x1234"}`),
+		&output,
+	))
+	require.Equal(t, "55000000000000000000", output.Amount)
+
+	encoded, err := json.Marshal(output)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"amount":"55000000000000000000","address":"0x1234"}`, string(encoded))
+
+	var decoded Slip24Out
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	require.Equal(t, output, decoded)
+}
+
+func TestSlip24OutRejectsInvalidAmounts(t *testing.T) {
+	for _, testCase := range []struct {
+		amount string
+		error  string
+	}{
+		{amount: "null", error: `invalid payment request output amount "null"`},
+		{amount: `""`, error: `invalid payment request output amount ""`},
+		{amount: `"-1"`, error: `invalid payment request output amount "-1"`},
+		{amount: "1.5", error: `invalid payment request output amount "1.5"`},
+		{amount: "1e18", error: `invalid payment request output amount "1e18"`},
+	} {
+		t.Run(testCase.amount, func(t *testing.T) {
+			var output Slip24Out
+			err := json.Unmarshal([]byte(`{"amount":`+testCase.amount+`,"address":"0x1234"}`), &output)
+			require.EqualError(t, err, testCase.error)
+		})
+	}
+}
+
+func TestSlip24ToRequestPreservesLargeAmount(t *testing.T) {
+	slip24 := &Slip24{
+		Outputs: []Slip24Out{{
+			Amount:  "55000000000000000000",
+			Address: "0x1234",
+		}},
+	}
+
+	request, err := slip24.ToRequest()
+	require.NoError(t, err)
+	expected, ok := new(big.Int).SetString("55000000000000000000", 10)
+	require.True(t, ok)
+	require.Equal(t, expected, request.TotalAmount)
+}

--- a/backend/swap.go
+++ b/backend/swap.go
@@ -4,7 +4,6 @@ package backend
 
 import (
 	"context"
-	"math/big"
 	"slices"
 	"sort"
 	"strings"
@@ -540,7 +539,11 @@ func swapSignTxInput(
 	if strings.TrimSpace(output.Address) == "" {
 		return SwapSignTxInput{}, errp.New("Missing target address")
 	}
-	amount := sellCoin.FormatAmount(coinpkg.NewAmount(new(big.Int).SetUint64(output.Amount)), false)
+	outputAmount, err := output.AmountBigInt()
+	if err != nil {
+		return SwapSignTxInput{}, err
+	}
+	amount := sellCoin.FormatAmount(coinpkg.NewAmount(outputAmount), false)
 	return SwapSignTxInput{
 		Address:        output.Address,
 		Amount:         amount,

--- a/backend/swap_test.go
+++ b/backend/swap_test.go
@@ -12,9 +12,12 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc"
 	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	coinMocks "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin/mocks"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth/erc20"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/paymentrequest"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/socksproxy"
 	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -349,7 +352,7 @@ func TestSwapSignTxInputUsesSignedOutput(t *testing.T) {
 		},
 		Outputs: []paymentrequest.Slip24Out{
 			{
-				Amount:  100000000,
+				Amount:  "100000000",
 				Address: "1GqULdYGDRfF3w85yGmEq8LTWecpKn8JMJ",
 			},
 		},
@@ -401,7 +404,7 @@ func TestSwapSignTxInputUsesBTCDestinationDerivation(t *testing.T) {
 		},
 		Outputs: []paymentrequest.Slip24Out{
 			{
-				Amount:  100000000,
+				Amount:  "100000000",
 				Address: "1GqULdYGDRfF3w85yGmEq8LTWecpKn8JMJ",
 			},
 		},
@@ -428,6 +431,33 @@ func TestSwapSignTxInputUsesBTCDestinationDerivation(t *testing.T) {
 		"p2wpkh",
 		txInput.PaymentRequest.Memos[0].CoinPurchase.AddressDerivation.Btc.ScriptType,
 	)
+}
+
+func TestSwapSignTxInputSupportsLargeERC20Amount(t *testing.T) {
+	daiCoin := eth.NewCoin(
+		nil,
+		coinpkg.Code("eth-erc20-dai0x6b17"),
+		"Dai",
+		"DAI",
+		"ETH",
+		params.MainnetChainConfig,
+		"",
+		nil,
+		erc20.NewToken("0x6b175474e89094c44da98b954eedeac495271d0f", 18),
+	)
+	paymentRequest := &paymentrequest.Slip24{
+		Outputs: []paymentrequest.Slip24Out{
+			{
+				Amount:  "55000000000000000000",
+				Address: "0x986f66F28C6a2BBE939dF3161D1D2b238933895c",
+			},
+		},
+	}
+
+	txInput, err := swapSignTxInput(paymentRequest, daiCoin, nil)
+	require.NoError(t, err)
+	require.Equal(t, "55", txInput.Amount)
+	require.Equal(t, "55000000000000000000", txInput.PaymentRequest.Outputs[0].Amount)
 }
 
 func setAccountBalance(t *testing.T, b *Backend, accountCode accountsTypes.Code, amount int64) {

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -322,7 +322,8 @@ export type Slip24 = {
     };
   }>;
   outputs: Array<{
-    amount: number;
+    // Pocket's request-address library uses numbers; backend amounts use strings.
+    amount: number | string;
     address: string;
   }>;
   signature: string;


### PR DESCRIPTION
SwapKit returns token amounts in the asset's smallest unit. Values for 18-decimal tokens can exceed uint64 and previously failed while decoding the signed payment request.

Preserve output amounts as decimal strings across JSON and frontend round trips. Parse them as arbitrary-precision integers for swap formatting and payment-request verification. Keep the legacy uint64 protobuf amount for BTC-family signing and reject values that do not fit.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
