### PR TITLE
gate lightning on desktop

### DIFF
--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -118,6 +118,9 @@ func NewLightning(config *config.Config,
 // Activate first creates a mnemonic from the keystore entropy, persists it, and connects to the
 // instance.
 func (lightning *Lightning) Activate() error {
+	if !lightning.environment.CanEncryptLightningMnemonic() {
+		return errp.New("Lightning is not available in this environment")
+	}
 	if lightning.Account() != nil {
 		return errp.New("Lightning accounts already configured")
 	}

--- a/backend/lightning/lightning_test.go
+++ b/backend/lightning/lightning_test.go
@@ -76,7 +76,7 @@ func newTestLightningWithConfigFilename(
 	require.NoError(t, err)
 
 	if environment == nil {
-		environment = &testEnvironment{}
+		environment = &testEnvironment{canEncrypt: true}
 	}
 
 	return NewLightning(
@@ -90,6 +90,12 @@ func newTestLightningWithConfigFilename(
 		nil,
 		false,
 	)
+}
+
+func TestActivateUnavailable(t *testing.T) {
+	lightning := newTestLightning(t, &testEnvironment{})
+
+	require.EqualError(t, lightning.Activate(), "Lightning is not available in this environment")
 }
 
 func TestAccount(t *testing.T) {

--- a/cmd/servewallet/main.go
+++ b/cmd/servewallet/main.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 
 	backendPkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/arguments"
@@ -44,6 +45,17 @@ func bindAddress() string {
 
 // webdevEnvironment implements backend.Environment.
 type webdevEnvironment struct {
+	// This is deliberately not secure storage. It exercises the encrypted mnemonic path in webdev
+	// and persists keys only so the development wallet remains usable across backend restarts.
+	lightningEncryptionKeys   *config.File
+	lightningEncryptionKeysMu *sync.Mutex
+}
+
+func newWebdevEnvironment(configDir string) webdevEnvironment {
+	return webdevEnvironment{
+		lightningEncryptionKeys:   config.NewFile(configDir, "lightning-encryption-keys.json"),
+		lightningEncryptionKeysMu: &sync.Mutex{},
+	}
 }
 
 // NotifyUser implements backend.Environment.
@@ -104,22 +116,60 @@ func (webdevEnvironment) OnAuthSettingChanged(enabled bool) {
 
 // CanEncryptLightningMnemonic implements backend.Environment.
 func (webdevEnvironment) CanEncryptLightningMnemonic() bool {
-	return false
+	return true
 }
 
 // StoreLightningEncryptionKey implements backend.Environment.
-func (webdevEnvironment) StoreLightningEncryptionKey(accountCode string, encryptionKey string) error {
-	return nil
+func (env webdevEnvironment) StoreLightningEncryptionKey(accountCode string, encryptionKey string) error {
+	env.lightningEncryptionKeysMu.Lock()
+	defer env.lightningEncryptionKeysMu.Unlock()
+
+	keys, err := env.loadLightningEncryptionKeys()
+	if err != nil {
+		return err
+	}
+	keys[accountCode] = encryptionKey
+	return env.lightningEncryptionKeys.WriteJSON(keys)
 }
 
 // LoadLightningEncryptionKey implements backend.Environment.
-func (webdevEnvironment) LoadLightningEncryptionKey(accountCode string) (string, error) {
-	return "", nil
+func (env webdevEnvironment) LoadLightningEncryptionKey(accountCode string) (string, error) {
+	env.lightningEncryptionKeysMu.Lock()
+	defer env.lightningEncryptionKeysMu.Unlock()
+
+	keys, err := env.loadLightningEncryptionKeys()
+	if err != nil {
+		return "", err
+	}
+	key, ok := keys[accountCode]
+	if !ok {
+		return "", fmt.Errorf("Lightning encryption key not found for account %q", accountCode)
+	}
+	return key, nil
 }
 
 // DeleteLightningEncryptionKey implements backend.Environment.
-func (webdevEnvironment) DeleteLightningEncryptionKey(accountCode string) error {
-	return nil
+func (env webdevEnvironment) DeleteLightningEncryptionKey(accountCode string) error {
+	env.lightningEncryptionKeysMu.Lock()
+	defer env.lightningEncryptionKeysMu.Unlock()
+
+	keys, err := env.loadLightningEncryptionKeys()
+	if err != nil {
+		return err
+	}
+	delete(keys, accountCode)
+	return env.lightningEncryptionKeys.WriteJSON(keys)
+}
+
+func (env webdevEnvironment) loadLightningEncryptionKeys() (map[string]string, error) {
+	keys := map[string]string{}
+	if !env.lightningEncryptionKeys.Exists() {
+		return keys, nil
+	}
+	if err := env.lightningEncryptionKeys.ReadJSON(&keys); err != nil {
+		return nil, err
+	}
+	return keys, nil
 }
 
 // BluetoothConnect implements backend.Environment.
@@ -262,15 +312,16 @@ func main() {
 
 	// since we are in dev-mode, we can drop the authorization token
 	connectionData := backendHandlers.NewConnectionData(-1, "")
+	appDir := config.AppDir()
 	newBackend, err := backendPkg.NewBackend(
 		arguments.NewArguments(
-			config.AppDir(),
+			appDir,
 			!*mainnet,
 			*regtest,
 			*devservers,
 			gapLimits,
 		),
-		webdevEnvironment{})
+		newWebdevEnvironment(appDir))
 	if err != nil {
 		log.WithField("error", err).Panic(err)
 	}

--- a/cmd/servewallet/main_test.go
+++ b/cmd/servewallet/main_test.go
@@ -2,7 +2,31 @@
 
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebdevLightningEncryptionKeys(t *testing.T) {
+	const (
+		accountCode   = "v0-deadbeef-ln-0"
+		encryptionKey = "test-encryption-key"
+	)
+	configDir := t.TempDir()
+	environment := newWebdevEnvironment(configDir)
+	require.True(t, environment.CanEncryptLightningMnemonic())
+	require.NoError(t, environment.StoreLightningEncryptionKey(accountCode, encryptionKey))
+
+	restartedEnvironment := newWebdevEnvironment(configDir)
+	key, err := restartedEnvironment.LoadLightningEncryptionKey(accountCode)
+	require.NoError(t, err)
+	require.Equal(t, encryptionKey, key)
+
+	require.NoError(t, restartedEnvironment.DeleteLightningEncryptionKey(accountCode))
+	_, err = environment.LoadLightningEncryptionKey(accountCode)
+	require.Error(t, err)
+}
 
 func TestNormalizeAppleSeparator(t *testing.T) {
 	for _, tc := range []struct {

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -34,6 +34,7 @@ import { Providers } from './contexts/providers';
 import { AppContext } from './contexts/AppContext';
 import { BottomNavigation } from './components/bottom-navigation/bottom-navigation';
 import { getBottomNavKey, shouldShowBottomNavigation } from './components/bottom-navigation/utils';
+import { isLightningFeatureAvailable } from './utils/env';
 import styles from './app.module.css';
 
 type TAppFrameProps = {
@@ -123,12 +124,16 @@ export const App = () => {
 
   const accounts = useDefault(useSync(getAccounts, syncAccountsList), []);
   const devices = useDefault(useSync(getDeviceList, syncDeviceList), {});
-  const lightningAccount = useSync(getLightningAccount, subscribeLightningAccount);
+  const lightningFeatureAvailable = isLightningFeatureAvailable();
+  const lightningAccount = useSync(
+    lightningFeatureAvailable ? getLightningAccount : null,
+    lightningFeatureAvailable ? subscribeLightningAccount : null,
+  );
   const prevDevices = usePrevious(devices);
 
   const deviceIDs = Object.keys(devices);
   const firstDevice = deviceIDs[0];
-  const hasLightningAccount = lightningAccount !== undefined && lightningAccount !== null;
+  const hasLightningAccount = lightningFeatureAvailable && lightningAccount !== undefined && lightningAccount !== null;
 
   useEffect(() => {
     return syncNewTxs((meta) => {
@@ -162,7 +167,8 @@ export const App = () => {
       || currentURL === '/settings/more';
     const shouldRedirectNoRegularAccount =
       !canNavigateWithLightningAccount
-      || lightningAccount === null;
+      || lightningAccount === null
+      || !lightningFeatureAvailable;
     if (accounts.length === 0 && requiresRegularAccount && shouldRedirectNoRegularAccount) {
       navigate('/');
       return;
@@ -209,7 +215,7 @@ export const App = () => {
       return;
     }
 
-  }, [accounts, deviceIDs, firstDevice, hasLightningAccount, lightningAccount, navigate]);
+  }, [accounts, deviceIDs, firstDevice, hasLightningAccount, lightningAccount, lightningFeatureAvailable, navigate]);
 
   useEffect(() => {
     const oldDeviceIDList = Object.keys(prevDevices || {});

--- a/frontends/web/src/contexts/LightningProvider.tsx
+++ b/frontends/web/src/contexts/LightningProvider.tsx
@@ -4,20 +4,28 @@ import { ReactNode } from 'react';
 import { LightningContext } from './LightningContext';
 import { getLightningAccount, getLightningReady, subscribeLightningAccount, subscribeLightningReady } from '../api/lightning';
 import { useSync } from '../hooks/api';
+import { isLightningFeatureAvailable } from '@/utils/env';
 
 type TProps = {
   children: ReactNode;
 };
 
 export const LightningProvider = ({ children }: TProps) => {
-  const lightningAccount = useSync(getLightningAccount, subscribeLightningAccount);
-  const isLightningReady = useSync(getLightningReady, subscribeLightningReady);
+  const lightningFeatureAvailable = isLightningFeatureAvailable();
+  const lightningAccount = useSync(
+    lightningFeatureAvailable ? getLightningAccount : null,
+    lightningFeatureAvailable ? subscribeLightningAccount : null,
+  );
+  const isLightningReady = useSync(
+    lightningFeatureAvailable ? getLightningReady : null,
+    lightningFeatureAvailable ? subscribeLightningReady : null,
+  );
 
   return (
     <LightningContext.Provider
       value={{
-        isLightningReady,
-        lightningAccount
+        isLightningReady: lightningFeatureAvailable ? isLightningReady : false,
+        lightningAccount: lightningFeatureAvailable ? lightningAccount : null,
       }}>
       {children}
     </LightningContext.Provider>

--- a/frontends/web/src/hooks/api.test.ts
+++ b/frontends/web/src/hooks/api.test.ts
@@ -136,6 +136,12 @@ describe('hooks for api calls', () => {
 
 
   describe('useSync', () => {
+    it('returns undefined when apiCall and subscription are null', () => {
+      const { result } = renderHook(() => useSync<string>(null, null));
+
+      expect(result.current).toBeUndefined();
+    });
+
     it('should load promise and sync to a subscription function', async () => {
       const apiValue = 'apiValue';
       const subscriptionValue = 'subscriptionValue';

--- a/frontends/web/src/hooks/api.ts
+++ b/frontends/web/src/hooks/api.ts
@@ -80,10 +80,11 @@ export const useLoad = <T>(
  * It is a combination of useLoad and useSubscribe.
  * gets fired on first render, and returns undefined while loading,
  * re-renders on every update.
+ * Passing null skips loading and subscribing.
  */
 export const useSync = <T>(
-  apiCall: () => Promise<T>,
-  subscription: ((callback: TSubscriptionCallback<T>) => TUnsubscribe),
+  apiCall: (() => Promise<T>) | null,
+  subscription: ((callback: TSubscriptionCallback<T>) => TUnsubscribe) | null,
   getRevision?: (data: T) => number,
 ): (T | undefined) => {
   const [response, setResponse] = useState<T>();
@@ -104,6 +105,10 @@ export const useSync = <T>(
   };
   useEffect(
     () => {
+      if (apiCall === null || subscription === null) {
+        setResponse(undefined);
+        return;
+      }
       apiCall().then(onData);
       return subscription(onData);
     }, // we pass no dependencies because it's only queried once

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -26,6 +26,7 @@ import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { GlobalBanners } from '@/components/banners';
 import { BackupReminder } from '@/components/banners/backup';
 import { OfflineError } from '@/components/banners/offline-error';
+import { isLightningFeatureAvailable } from '@/utils/env';
 import style from './accountssummary.module.css';
 
 type TProps = {
@@ -64,6 +65,9 @@ export const AccountsSummary = ({
   const [accountsBalanceSummary, setAccountsBalanceSummary] = useState<accountApi.TAccountsBalanceSummary>();
   const [balances, setBalances] = useState<Balances>();
   const [offlineError, setOfflineError] = useState<string | null>(null);
+  const coinsTotalBalance = accountsBalanceSummary?.coinsTotalBalance.filter(balance => (
+    balance.coinCode !== 'lightning' || isLightningFeatureAvailable()
+  ));
 
   const getChartData = useCallback(async () => {
     // replace previous timer if present
@@ -213,7 +217,7 @@ export const AccountsSummary = ({
                   hideHeader={hasOnlyLightningAccount}
                   hideLightningUnitPrice={hasActiveBitcoinAccount}
                   summaryData={chartData}
-                  coinsBalances={accountsBalanceSummary?.coinsTotalBalance}
+                  coinsBalances={coinsTotalBalance}
                 />
               )}
               {accountsByKeystore &&

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactChild } from 'react';
-import { Route, Routes, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useParams } from 'react-router-dom';
 import { TAccount } from '@/api/account';
 import { TDevices } from '@/api/devices';
 import { AddAccount } from './account/add/add-account';
@@ -54,6 +54,7 @@ import { Receive as LightningReceive } from './lightning/receive/receive';
 import { LightningTopUp } from './lightning/topup/topup';
 import { LightningClaimTopUp } from './lightning/claim-top-up/claim-top-up';
 import { LightningCloseWithdrawFunds } from './lightning/close-and-withdraw-funds/close-withdraw-funds';
+import { isLightningFeatureAvailable } from '@/utils/env';
 
 type TAppRouterProps = {
   devices: TDevices;
@@ -73,6 +74,7 @@ const InjectParams = ({ children }: TInjectParamsProps) => {
 
 export const AppRouter = ({ devices, devicesKey, accounts, activeAccounts }: TAppRouterProps) => {
   const hasAccounts = accounts.length > 0;
+  const lightningFeatureAvailable = isLightningFeatureAvailable();
   const Homepage = (<DeviceSwitch
     key={devicesKey('device-switch-default')}
     deviceID={null}
@@ -360,23 +362,27 @@ export const AppRouter = ({ devices, devicesKey, accounts, activeAccounts }: TAp
           <Route path="pocket-otc" element={<PocketOTC/>} />
           <Route path="swap" element={SwapEl} />
         </Route>
-        <Route path="lightning">
-          <Route index element={<Lightning />} />
-          <Route path="activate" element={<LightningActivate />} />
-          <Route path="disclaimer" element={<LightningDisclaimer />} />
-          <Route path="deactivate" element={<LightningDeactivate />} />
-          <Route path="set-lnurl-address" element={<LightningSetLnurlAddress />} />
-          <Route path="claim-top-up" element={<LightningClaimTopUp activeAccounts={activeAccounts} />} />
-          <Route path="close-withdraw-funds" element={(
-            <LightningCloseWithdrawFunds
-              activeAccounts={activeAccounts}
-              hasAccounts={hasAccounts}
-            />
-          )} />
-          <Route path="send" element={<LightningSend activeAccounts={activeAccounts} />} />
-          <Route path="receive" element={<LightningReceive />} />
-          <Route path="topup" element={<LightningTopUp activeAccounts={activeAccounts} hasAccounts={hasAccounts} />} />
-        </Route>
+        {lightningFeatureAvailable ? (
+          <Route path="lightning">
+            <Route index element={<Lightning />} />
+            <Route path="activate" element={<LightningActivate />} />
+            <Route path="disclaimer" element={<LightningDisclaimer />} />
+            <Route path="deactivate" element={<LightningDeactivate />} />
+            <Route path="set-lnurl-address" element={<LightningSetLnurlAddress />} />
+            <Route path="claim-top-up" element={<LightningClaimTopUp activeAccounts={activeAccounts} />} />
+            <Route path="close-withdraw-funds" element={(
+              <LightningCloseWithdrawFunds
+                activeAccounts={activeAccounts}
+                hasAccounts={hasAccounts}
+              />
+            )} />
+            <Route path="send" element={<LightningSend activeAccounts={activeAccounts} />} />
+            <Route path="receive" element={<LightningReceive />} />
+            <Route path="topup" element={<LightningTopUp activeAccounts={activeAccounts} hasAccounts={hasAccounts} />} />
+          </Route>
+        ) : (
+          <Route path="lightning/*" element={<Navigate replace to="/" />} />
+        )}
         <Route path="manage-backups/:deviceID" element={ManageBackupsEl} />
         <Route path="accounts/select-receive" element={ReceiveAccountsSelectorEl} />
         <Route path="accounts/select-receive/bitcoin" element={BitcoinReceiveAccountsSelectorEl} />
@@ -393,7 +399,12 @@ export const AppRouter = ({ devices, devicesKey, accounts, activeAccounts }: TAp
           <Route path="device-settings/recovery-words/:deviceID" element={RecoveryWordsEl} />
           <Route path="device-settings/bip85/:deviceID" element={Bip85El} />
           <Route path="advanced-settings" element={AdvancedSettingsEl} />
-          <Route path="lightning-settings" element={<LightningSettings devices={devices} hasAccounts={hasAccounts} />} />
+          <Route
+            path="lightning-settings"
+            element={lightningFeatureAvailable
+              ? <LightningSettings devices={devices} hasAccounts={hasAccounts} />
+              : <Navigate replace to="/settings/advanced-settings" />}
+          />
           <Route path="electrum" element={<ElectrumSettings />} />
           <Route path="manage-accounts" element={
             <ManageAccounts

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -24,6 +24,7 @@ import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { GlobalBanners } from '@/components/banners';
 import { SettingsContent, type TSettingsContentSection } from './components/settings-content';
 import { AppContext } from '@/contexts/AppContext';
+import { isLightningFeatureAvailable } from '@/utils/env';
 import {
   isExportLogsSettingVisible,
   isScreenLockSettingVisible,
@@ -80,7 +81,10 @@ export const AdvancedSettingsContent = ({
     {
       id: 'advanced-settings',
       items: [
-        { id: 'lightning-settings', content: <LightningSettingsSetting /> },
+        ...(isLightningFeatureAvailable() ? [{
+          id: 'lightning-settings',
+          content: <LightningSettingsSetting />,
+        }] : []),
         { id: 'custom-fees', content: <EnableCustomFeesToggleSetting /> },
         { id: 'coin-control', content: <EnableCoinControlSetting /> },
         ...(isScreenLockSettingVisible() ? [{

--- a/frontends/web/src/routes/settings/components/advanced-settings/lightning-settings-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/lightning-settings-setting.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/badge/badge';
 import { useLightning } from '@/hooks/lightning';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
+import { isLightningFeatureAvailable } from '@/utils/env';
 import styles from './lightning-settings-setting.module.css';
 
 export const LightningSettingsSetting = () => {
@@ -12,7 +13,7 @@ export const LightningSettingsSetting = () => {
   const { t } = useTranslation();
   const { lightningAccount } = useLightning();
 
-  if (lightningAccount === undefined) {
+  if (!isLightningFeatureAvailable() || lightningAccount === undefined) {
     return null;
   }
 

--- a/frontends/web/src/routes/settings/settings-availability.ts
+++ b/frontends/web/src/routes/settings/settings-availability.ts
@@ -2,7 +2,7 @@
 
 import type { DeviceInfo } from '@/api/bitbox02';
 import type { TDevices } from '@/api/devices';
-import { debug, runningInAndroid, runningInIOS } from '@/utils/env';
+import { debug, isLightningFeatureAvailable, runningInAndroid, runningInIOS } from '@/utils/env';
 
 type TTestWalletVisibilityArgs = {
   deviceIDs: string[];
@@ -26,6 +26,10 @@ export const isBluetoothToggleSettingVisible = (deviceInfo?: DeviceInfo) => (
 );
 
 export const isScreenLockSettingVisible = () => runningInAndroid() || runningInIOS();
+
+export const isLightningSettingVisible = (isLightningEnabled: boolean | undefined) => (
+  isLightningFeatureAvailable() && isLightningEnabled !== undefined
+);
 
 export const isExportLogsSettingVisible = () => !debug;
 

--- a/frontends/web/src/routes/settings/settings-search.test.ts
+++ b/frontends/web/src/routes/settings/settings-search.test.ts
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { TFunction } from 'i18next';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   filterSettingsSearchItems,
   getSettingsSearchItems,
 } from './settings-search';
 
+const isLightningFeatureAvailableMock = vi.hoisted(() => vi.fn(() => true));
+
 vi.mock('@/utils/env', () => ({
   debug: false,
+  isLightningFeatureAvailable: isLightningFeatureAvailableMock,
   runningInAndroid: () => false,
   runningInIOS: () => false,
 }));
@@ -35,6 +38,10 @@ const getItems = (
 });
 
 describe('settings search', () => {
+  beforeEach(() => {
+    isLightningFeatureAvailableMock.mockReturnValue(true);
+  });
+
   it('uses the connect title for the test wallet setting when no software wallet exists', () => {
     const results = filterSettingsSearchItems(getItems(false, true), 'test wallet');
 
@@ -78,6 +85,14 @@ describe('settings search', () => {
 
   it('hides the lightning setting while its state is loading', () => {
     const results = filterSettingsSearchItems(getItems(false, undefined), 'lightning');
+
+    expect(results).toEqual([]);
+  });
+
+  it('hides the lightning setting when the lightning feature is unavailable', () => {
+    isLightningFeatureAvailableMock.mockReturnValue(false);
+
+    const results = filterSettingsSearchItems(getItems(false, true), 'lightning');
 
     expect(results).toEqual([]);
   });

--- a/frontends/web/src/routes/settings/settings-search.ts
+++ b/frontends/web/src/routes/settings/settings-search.ts
@@ -8,6 +8,7 @@ import {
   isDeviceBluetoothSupported,
   isDeviceSettingsVisible,
   isExportLogsSettingVisible,
+  isLightningSettingVisible,
   isNotesSettingsVisible,
   isScreenLockSettingVisible,
   isTestWalletSettingVisible,
@@ -104,7 +105,7 @@ const SETTINGS_SEARCH_DESCRIPTORS: TSettingsSearchDescriptor[] = [
   },
   {
     id: 'lightning-settings',
-    isAvailable: ({ isLightningEnabled }) => isLightningEnabled !== undefined,
+    isAvailable: ({ isLightningEnabled }) => isLightningSettingVisible(isLightningEnabled),
     getTitle: ({ isLightningEnabled, t }) => t(isLightningEnabled
       ? 'lightning.settings.title'
       : 'lightning.settings.enableWallet'),

--- a/frontends/web/src/utils/env.ts
+++ b/frontends/web/src/utils/env.ts
@@ -26,3 +26,5 @@ export function runningInIOS() {
 export const runningOnMobile = () => {
   return runningInAndroid() || runningInIOS();
 };
+
+export const isLightningFeatureAvailable = () => debug || runningOnMobile();


### PR DESCRIPTION
When unavailable (not mobile / not webdev):

- Settings: hides the Lightning settings option.

- Settings search: removes Lightning results.

- Direct links are blocked: `/lightning/*` goes to home,  and `/settings/lightning-settings`
 goes back to Advanced Settings.
 
- App/Lightning context: ignores Lightning account state. 
This means sidebar, bottom nav, and account lists do not show Lightning.

- Portfolio summary: filters out the Lightning balance row.
