### PR TITLE
frontend: warn before restoring an external wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Warn about potential security risks when restoring an external wallet
 - Bitcoin: show account details for the persisted receive address type by default
 - Add external block explorer links to used addresses
 - Settings search

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -310,7 +310,8 @@
     },
     "restoreFromMnemonic": {
       "e104": "Restoring from recovery words was canceled.",
-      "failed": "Restoring from recovery words failed, please try again."
+      "failed": "Restoring from recovery words failed, please try again.",
+      "securityNotice": "Recovering a wallet not created on a BitBox? A wallet created elsewhere may not have the same security as one created on your BitBox. If you are unsure, we recommend setting up a new wallet here and moving your funds to it."
     },
     "stepBackup": {
       "beforeProceed": "Before proceeding, please read these important security considerations:",

--- a/frontends/web/src/routes/device/bitbox02/setup/wallet-restore.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/wallet-restore.tsx
@@ -5,6 +5,10 @@ import { useTranslation } from 'react-i18next';
 import * as bitbox02 from '@/api/bitbox02';
 import { alertUser } from '@/components/alert/Alert';
 import { Backup } from '@/api/backup';
+import { BackButton } from '@/components/backbutton/backbutton';
+import { Button } from '@/components/forms';
+import { Message } from '@/components/message/message';
+import { View, ViewButtons, ViewContent, ViewHeader } from '@/components/view/view';
 import { SetPasswordWithBackup } from './password';
 import { RestoreFromSDCardBackup } from './restore';
 import { WithSDCard } from './sdcard';
@@ -59,7 +63,9 @@ export const RestoreFromMnemonic = ({
   onAbort,
 }: Props) => {
   const { t } = useTranslation();
-  const [status, setStatus] = useState<'intro' | 'setName' | 'restoreMnemonic'>('intro');
+  const [status, setStatus] = useState<
+    'securityNotice' | 'intro' | 'setName' | 'restoreMnemonic'
+  >('securityNotice');
 
   const restoreMnemonic = () => {
     bitbox02.restoreFromMnemonic(deviceID)
@@ -99,6 +105,32 @@ export const RestoreFromMnemonic = ({
   };
 
   switch (status) {
+  case 'securityNotice':
+    return (
+      <View
+        fullscreen
+        textCenter
+        verticallyCentered
+        withBottomBar
+        width="700px">
+        <ViewHeader
+          small
+          title={t('bitbox02Wizard.stepUninitialized.restoreMnemonic')} />
+        <ViewContent textAlign="left">
+          <Message type="info">
+            {t('bitbox02Wizard.restoreFromMnemonic.securityNotice')}
+          </Message>
+        </ViewContent>
+        <ViewButtons>
+          <Button primary onClick={() => setStatus('intro')}>
+            {t('button.continue')}
+          </Button>
+          <BackButton onClick={onAbort}>
+            {t('button.back')}
+          </BackButton>
+        </ViewButtons>
+      </View>
+    );
   case 'intro':
     return (
       <SetDeviceName


### PR DESCRIPTION
This adds an info box to the "restore from recovery words" workflow, to inform users that an imported seed which was not created on the BitBox might not be secure.

Open points: 

- I used `Message type="info"` instead of `Message type="warning"`. I find the warning box too alerting.
- No regression test was added. IMO the state transition is simple enough.
