### PR TITLE
bitbox02: require antiklepto for signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Add a mobile-only beta Lightning hot wallet, with send, receive, Bitcoin top-up, and on-chain withdrawal flows.
+- Require antiklepto-capable firmware for transaction and message signing
 - Warn about potential security risks when restoring an external wallet
 - Bitcoin: show account details for the persisted receive address type by default
 - Add external block explorer links to used addresses

--- a/backend/aopp.go
+++ b/backend/aopp.go
@@ -100,7 +100,8 @@ const (
 type AOPP struct {
 	// State is the current state the request is in. See `aoppState*` for the possible values.
 	State aoppState `json:"state"`
-	// ErrorCode is an "aopp*" error code. Only applies if State == aoppStateError.
+	// ErrorCode describes the AOPP failure. It is usually an "aopp*" error code, but can also be a
+	// shared error code such as "firmwareUpgradeRequired". Only applies if State == aoppStateError.
 	ErrorCode errp.ErrorCode `json:"errorCode"`
 	// Accounts is the list of accounts the user can choose from. Only applies if State == aoppStateChoosingAccount.
 	Accounts []account `json:"accounts"`
@@ -165,6 +166,14 @@ func (backend *Backend) aoppSetError(err errp.ErrorCode) {
 // calling this function.
 func (backend *Backend) aoppKeystoreRegistered() {
 	if backend.aopp.State != aoppStateAwaitingKeystore {
+		return
+	}
+	if err := backend.keystore.SupportsFeature(keystore.FeatureMessageSigning); err != nil {
+		if errp.Cause(err) == keystore.ErrFirmwareUpgradeRequired {
+			backend.aoppSetError(errp.ErrorCode(keystore.ErrFirmwareUpgradeRequired.Error()))
+		} else {
+			backend.aoppSetError(errAOPPUnsupportedKeystore)
+		}
 		return
 	}
 	if !backend.keystore.CanSignMessage(backend.aopp.coinCode) {

--- a/backend/aopp_test.go
+++ b/backend/aopp_test.go
@@ -69,6 +69,9 @@ func makeKeystore(
 				return true
 			}
 		},
+		SupportsFeatureFunc: func(keystorePkg.Feature) error {
+			return nil
+		},
 		CanSignMessageFunc: func(coinpkg.Code) bool {
 			return true
 		},
@@ -498,6 +501,26 @@ func TestAOPPFailures(t *testing.T) {
 		b.AOPPChooseAccount("v0-55555555-btc-0")
 		require.Equal(t, aoppStateError, b.AOPP().State)
 		require.Equal(t, errAOPPSigningAborted, b.AOPP().ErrorCode)
+	})
+	t.Run("firmware_upgrade_required", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+		params := defaultParams()
+		b.HandleURI(uriPrefix + params.Encode())
+		b.AOPPApprove()
+		ks2 := makeKeystore(t, scriptTypeRef(signing.ScriptTypeP2WPKH), keystoreHelper)
+		ks2.SupportsFeatureFunc = func(feature keystorePkg.Feature) error {
+			require.Equal(t, keystorePkg.FeatureMessageSigning, feature)
+			return errp.WithStack(keystorePkg.ErrFirmwareUpgradeRequired)
+		}
+		b.registerKeystore(ks2)
+		require.Equal(t, aoppStateError, b.AOPP().State)
+		require.Equal(
+			t,
+			errp.ErrorCode(keystorePkg.ErrFirmwareUpgradeRequired.Error()),
+			b.AOPP().ErrorCode,
+		)
+		require.Empty(t, ks2.SignBTCMessageCalls())
 	})
 	t.Run("callback_failed", func(t *testing.T) {
 		b := newBackend(t, testnetDisabled, regtestDisabled)

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -42,6 +42,10 @@ func formatAddressForDisplay(account accounts.Interface, address string) string 
 	return backendutil.FormatAddress(account.Coin().Code(), address)
 }
 
+func isFirmwareUpgradeRequired(err error) bool {
+	return errp.Cause(err) == keystore.ErrFirmwareUpgradeRequired
+}
+
 // NewHandlers creates a new Handlers instance.
 func NewHandlers(
 	handleFunc func(string, func(*http.Request) (interface{}, error)) *mux.Route, log *logrus.Entry) *Handlers {
@@ -66,8 +70,6 @@ func NewHandlers(
 	handleFunc("/btc-sign-message-for-address", handlers.ensureAccountInitialized(handlers.postSignBTCMessageForAddress)).Methods("POST")
 	handleFunc("/eth-sign-message-for-address", handlers.ensureAccountInitialized(handlers.postSignETHMessageForAddress)).Methods("POST")
 	handleFunc("/has-secure-output", handlers.ensureAccountInitialized(handlers.getHasSecureOutput)).Methods("GET")
-	handleFunc("/has-payment-request", handlers.ensureAccountInitialized(handlers.getHasPaymentRequest)).Methods("GET")
-	handleFunc("/has-swap-payment-request", handlers.ensureAccountInitialized(handlers.getHasSwapPaymentRequest)).Methods("GET")
 	handleFunc("/notes/tx", handlers.ensureAccountInitialized(handlers.postSetTxNote)).Methods("POST")
 	handleFunc("/eth-sign-msg", handlers.ensureAccountInitialized(handlers.postEthSignMsg)).Methods("POST")
 	handleFunc("/eth-sign-typed-msg", handlers.ensureAccountInitialized(handlers.postEthSignTypedMsg)).Methods("POST")
@@ -498,6 +500,8 @@ func (handlers *Handlers) postAccountSendTx(r *http.Request) (interface{}, error
 			result.ErrorCode = validationErr.Error()
 		} else if errCode, ok := cause.(errp.ErrorCode); ok {
 			result.ErrorCode = errCode.Error()
+		} else if isFirmwareUpgradeRequired(err) {
+			result.ErrorCode = keystore.ErrFirmwareUpgradeRequired.Error()
 		} else if strings.Contains(err.Error(), etherscan.ERC20GasErr) {
 			result.ErrorCode = errors.ErrERC20InsufficientGasFunds.Error()
 		}
@@ -773,6 +777,20 @@ type signingResponse struct {
 	Signature    string `json:"signature"`
 	Aborted      bool   `json:"aborted"`
 	ErrorMessage string `json:"errorMessage"`
+	ErrorCode    string `json:"errorCode,omitempty"`
+}
+
+func newSigningErrorResponse(err error) signingResponse {
+	if errp.Cause(err) == keystore.ErrSigningAborted || errp.Cause(err) == errp.ErrUserAbort {
+		return signingResponse{Success: false, Aborted: true}
+	}
+	if isFirmwareUpgradeRequired(err) {
+		return signingResponse{
+			Success:   false,
+			ErrorCode: keystore.ErrFirmwareUpgradeRequired.Error(),
+		}
+	}
+	return signingResponse{Success: false, ErrorMessage: err.Error()}
 }
 
 func (handlers *Handlers) postEthSignMsg(r *http.Request) (interface{}, error) {
@@ -785,12 +803,11 @@ func (handlers *Handlers) postEthSignMsg(r *http.Request) (interface{}, error) {
 		return signingResponse{Success: false, ErrorMessage: "Must be an ETH based account"}, nil
 	}
 	signature, err := ethAccount.SignMsg(signInput)
-	if errp.Cause(err) == keystore.ErrSigningAborted || errp.Cause(err) == errp.ErrUserAbort {
-		return signingResponse{Success: false, Aborted: true}, nil
-	}
 	if err != nil {
-		handlers.log.WithError(err).Error("Failed to sign message")
-		result := signingResponse{Success: false, ErrorMessage: err.Error()}
+		result := newSigningErrorResponse(err)
+		if !result.Aborted {
+			handlers.log.WithError(err).Error("Failed to sign message")
+		}
 		return result, nil
 	}
 	return signingResponse{
@@ -815,12 +832,11 @@ func (handlers *Handlers) postEthSignTypedMsg(r *http.Request) (interface{}, err
 		return signingResponse{Success: false, ErrorMessage: "Must be an ETH based account"}, nil
 	}
 	signature, err := ethAccount.SignTypedMsg(*args.ChainId, args.Data)
-	if errp.Cause(err) == keystore.ErrSigningAborted || errp.Cause(err) == errp.ErrUserAbort {
-		return signingResponse{Success: false, Aborted: true}, nil
-	}
 	if err != nil {
-		handlers.log.WithError(err).Error("Failed to sign typed data")
-		result := signingResponse{Success: false, ErrorMessage: err.Error()}
+		result := newSigningErrorResponse(err)
+		if !result.Aborted {
+			handlers.log.WithError(err).Error("Failed to sign typed data")
+		}
 		return result, nil
 	}
 	return signingResponse{
@@ -854,12 +870,11 @@ func (handlers *Handlers) postEthSignWalletConnectTx(r *http.Request) (interface
 		return signingResponse{Success: false, ErrorMessage: "Must be an ETH based account"}, nil
 	}
 	txHash, rawTx, err := ethAccount.EthSignWalletConnectTx(args.Send, *args.ChainId, args.Tx)
-	if errp.Cause(err) == keystore.ErrSigningAborted || errp.Cause(err) == errp.ErrUserAbort {
-		return signingResponse{Success: false, Aborted: true}, nil
-	}
 	if err != nil {
-		handlers.log.WithError(err).Error("Failed to send transaction")
-		result := signingResponse{Success: false, ErrorMessage: err.Error()}
+		result := newSigningErrorResponse(err)
+		if !result.Aborted {
+			handlers.log.WithError(err).Error("Failed to send transaction")
+		}
 		return result, nil
 	}
 	return response{
@@ -882,6 +897,12 @@ func (handlers *Handlers) signMessageForAddressErrorResponse(err error) signMess
 	cause := errp.Cause(err)
 	if errCode, ok := cause.(errp.ErrorCode); ok {
 		return signMessageForAddressResponse{Success: false, ErrorCode: string(errCode)}
+	}
+	if isFirmwareUpgradeRequired(err) {
+		return signMessageForAddressResponse{
+			Success:   false,
+			ErrorCode: keystore.ErrFirmwareUpgradeRequired.Error(),
+		}
 	}
 	handlers.log.WithField("code", handlers.account.Config().Config.Code).WithError(err).Error("unexpected error signing message")
 	return signMessageForAddressResponse{Success: false, ErrorMessage: "An unexpected error occurred."}
@@ -971,52 +992,4 @@ func (handlers *Handlers) postSignETHMessageForAddress(r *http.Request) (interfa
 		DisplayAddress: backendutil.FormatAddress(handlers.account.Coin().Code(), address),
 		Signature:      signature,
 	}, nil
-}
-
-func (handlers *Handlers) getHasPaymentRequest(r *http.Request) (interface{}, error) {
-	type response struct {
-		Success      bool   `json:"success"`
-		ErrorMessage string `json:"errorMessage,omitempty"`
-		ErrorCode    string `json:"errorCode,omitempty"`
-	}
-
-	switch handlers.account.(type) {
-	case *btc.Account, *eth.Account:
-	default:
-		return response{
-			Success:      false,
-			ErrorMessage: "An account must be BTC or ETH based to support payment requests.",
-		}, nil
-	}
-
-	keystore, err := handlers.account.Config().ConnectKeystore()
-	if err != nil {
-		return response{Success: false, ErrorMessage: err.Error()}, nil
-	}
-	err = keystore.SupportsPaymentRequests()
-	if err != nil {
-		return response{Success: false, ErrorCode: err.Error()}, nil
-	}
-
-	return response{Success: true}, nil
-}
-
-func (handlers *Handlers) getHasSwapPaymentRequest(r *http.Request) (interface{}, error) {
-	type response struct {
-		Success      bool   `json:"success"`
-		ErrorMessage string `json:"errorMessage,omitempty"`
-		ErrorCode    string `json:"errorCode,omitempty"`
-	}
-
-	accountKeystore, err := handlers.account.Config().ConnectKeystore()
-	if err != nil {
-		return response{Success: false, ErrorMessage: err.Error()}, nil
-	}
-
-	err = accountKeystore.SupportsSwapPaymentRequests()
-	if err != nil {
-		return response{Success: false, ErrorCode: err.Error()}, nil
-	}
-
-	return response{Success: true}, nil
 }

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -35,6 +35,39 @@ type keystore struct {
 	rootFinger   []byte // cached result of RootFingerprint
 }
 
+var (
+	minBTCTransactionAntiKleptoVersion = semver.NewSemVer(9, 4, 0)
+	minAntiKleptoVersion               = semver.NewSemVer(9, 5, 0)
+	minETHTypedMessageVersion          = semver.NewSemVer(9, 12, 0)
+	minPaymentRequestVersion           = semver.NewSemVer(9, 20, 0)
+	minSwapPaymentRequestVersion       = semver.NewSemVer(9, 26, 0)
+)
+
+func (keystore *keystore) requireFirmwareVersion(minVersion *semver.SemVer) error {
+	if keystore.device.Version().AtLeast(minVersion) {
+		return nil
+	}
+	return keystorePkg.ErrFirmwareUpgradeRequired
+}
+
+// SupportsFeature implements keystore.Keystore.
+func (keystore *keystore) SupportsFeature(feature keystorePkg.Feature) error {
+	switch feature {
+	case keystorePkg.FeatureBTCTransactionSigning:
+		return keystore.requireFirmwareVersion(minBTCTransactionAntiKleptoVersion)
+	case keystorePkg.FeatureETHTransactionSigning, keystorePkg.FeatureMessageSigning:
+		return keystore.requireFirmwareVersion(minAntiKleptoVersion)
+	case keystorePkg.FeatureETHTypedMessageSigning:
+		return keystore.requireFirmwareVersion(minETHTypedMessageVersion)
+	case keystorePkg.FeaturePaymentRequests:
+		return keystore.requireFirmwareVersion(minPaymentRequestVersion)
+	case keystorePkg.FeatureSwapPaymentRequests:
+		return keystore.requireFirmwareVersion(minSwapPaymentRequestVersion)
+	default:
+		return keystorePkg.ErrUnsupportedFeature
+	}
+}
+
 func (keystore *keystore) clearRootFingerprintCache() {
 	keystore.rootFingerMu.Lock()
 	defer keystore.rootFingerMu.Unlock()
@@ -519,8 +552,14 @@ func newBTCPaymentRequest(txPaymentRequest *paymentrequest.Request) *messages.BT
 func (keystore *keystore) SignTransaction(proposedTx interface{}) error {
 	switch specificProposedTx := proposedTx.(type) {
 	case *btc.ProposedTransaction:
+		if err := keystore.SupportsFeature(keystorePkg.FeatureBTCTransactionSigning); err != nil {
+			return err
+		}
 		return keystore.signBTCTransaction(specificProposedTx)
 	case *eth.TxProposal:
+		if err := keystore.SupportsFeature(keystorePkg.FeatureETHTransactionSigning); err != nil {
+			return err
+		}
 		return keystore.signETHTransaction(specificProposedTx)
 	default:
 		panic("unknown proposal type")
@@ -538,6 +577,9 @@ func (keystore *keystore) CanSignMessage(code coinpkg.Code) bool {
 
 // SignBTCMessage implements keystore.Keystore.
 func (keystore *keystore) SignBTCMessage(message []byte, keypath signing.AbsoluteKeypath, scriptType signing.ScriptType, coin coinpkg.Code) ([]byte, error) {
+	if err := keystore.SupportsFeature(keystorePkg.FeatureMessageSigning); err != nil {
+		return nil, err
+	}
 	sc, ok := btcMsgScriptTypeMap[scriptType]
 	if !ok {
 		return nil, errp.Newf("scriptType not supported: %s", scriptType)
@@ -565,6 +607,9 @@ func (keystore *keystore) SignBTCMessage(message []byte, keypath signing.Absolut
 
 // SignETHMessage implements keystore.Keystore.
 func (keystore *keystore) SignETHMessage(chainID uint64, message []byte, keypath signing.AbsoluteKeypath) ([]byte, error) {
+	if err := keystore.SupportsFeature(keystorePkg.FeatureMessageSigning); err != nil {
+		return nil, err
+	}
 	signature, err := keystore.device.ETHSignMessage(chainID, keypath.ToUInt32(), message)
 	if firmware.IsErrorAbort(err) {
 		return nil, errp.WithStack(keystorePkg.ErrSigningAborted)
@@ -577,6 +622,9 @@ func (keystore *keystore) SignETHMessage(chainID uint64, message []byte, keypath
 
 // SignETHTypedMessage implements keystore.Keystore.
 func (keystore *keystore) SignETHTypedMessage(chainId uint64, data []byte, keypath signing.AbsoluteKeypath) ([]byte, error) {
+	if err := keystore.SupportsFeature(keystorePkg.FeatureETHTypedMessageSigning); err != nil {
+		return nil, err
+	}
 	// SignETHTypedMessage is currently only used for WalletConnect. We disable antiklepto there, as
 	// some DeFi apps require deterministic signatures.
 	// Before v9.26.0, antiklepto could not be disabled.
@@ -594,6 +642,9 @@ func (keystore *keystore) SignETHTypedMessage(chainId uint64, data []byte, keypa
 
 // SignETHWalletConnectTransaction implements keystore.Keystore.
 func (keystore *keystore) SignETHWalletConnectTransaction(chainId uint64, tx *ethTypes.Transaction, keypath signing.AbsoluteKeypath) ([]byte, error) {
+	if err := keystore.SupportsFeature(keystorePkg.FeatureETHTransactionSigning); err != nil {
+		return nil, err
+	}
 	signature, err := keystore.device.ETHSign(
 		chainId,
 		keypath.ToUInt32(),
@@ -617,23 +668,6 @@ func (keystore *keystore) SignETHWalletConnectTransaction(chainId uint64, tx *et
 // SupportsEIP1559 implements keystore.Keystore.
 func (keystore *keystore) SupportsEIP1559() bool {
 	return keystore.device.Version().AtLeast(semver.NewSemVer(9, 16, 0))
-}
-
-// SupportsPaymentRequests implements keystore.Keystore.
-func (keystore *keystore) SupportsPaymentRequests() error {
-	if keystore.device.Version().AtLeast(semver.NewSemVer(9, 20, 0)) {
-		return nil
-	}
-	return keystorePkg.ErrFirmwareUpgradeRequired
-}
-
-// SupportsSwapPaymentRequests reports whether the device supports the
-// payment-request signing flow used by swaps.
-func (keystore *keystore) SupportsSwapPaymentRequests() error {
-	if keystore.device.Version().AtLeast(semver.NewSemVer(9, 26, 0)) {
-		return nil
-	}
-	return keystorePkg.ErrFirmwareUpgradeRequired
 }
 
 // Features reports optional capabilities supported by the BitBox02 keystore.

--- a/backend/devices/bitbox02/keystore_test.go
+++ b/backend/devices/bitbox02/keystore_test.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package bitbox02
+
+import (
+	"bytes"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/maketx"
+	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth"
+	keystorePkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore/software"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/socksproxy"
+	bitbox02common "github.com/BitBoxSwiss/bitbox02-api-go/api/common"
+	"github.com/BitBoxSwiss/bitbox02-api-go/util/semver"
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+var errTestCommunication = errors.New("test communication error")
+
+type errorCommunication struct{}
+
+func (errorCommunication) Query([]byte) ([]byte, error) {
+	return nil, errTestCommunication
+}
+
+func (errorCommunication) Close() {}
+
+func newKeystoreWithVersion(version *semver.SemVer) *keystore {
+	return NewDevice(
+		"test-device",
+		version,
+		bitbox02common.ProductBitBox02Multi,
+		nil,
+		errorCommunication{},
+	).keystore
+}
+
+func TestSigningFirmwareRequirements(t *testing.T) {
+	packet, err := psbt.NewFromUnsignedTx(wire.NewMsgTx(2))
+	require.NoError(t, err)
+	btcCoin := btc.NewCoin(
+		coinpkg.CodeBTC,
+		"Bitcoin",
+		"BTC",
+		coinpkg.BtcUnitDefault,
+		&chaincfg.MainNetParams,
+		"",
+		nil,
+		"",
+		"",
+		socksproxy.NewSocksProxy(false, ""),
+	)
+	btcTransaction := &btc.ProposedTransaction{
+		TXProposal: &maketx.TxProposal{
+			Coin: btcCoin,
+			Psbt: packet,
+		},
+	}
+	contractCreation := ethTypes.NewContractCreation(
+		0,
+		big.NewInt(0),
+		21_000,
+		big.NewInt(1),
+		nil,
+	)
+	walletConnectTransaction := ethTypes.NewTransaction(
+		0,
+		ethCommon.Address{},
+		big.NewInt(0),
+		21_000,
+		big.NewInt(1),
+		nil,
+	)
+
+	tests := []struct {
+		name               string
+		feature            keystorePkg.Feature
+		unsupportedVersion *semver.SemVer
+		supportedVersion   *semver.SemVer
+		sign               func(*keystore) error
+	}{
+		{
+			name:               "BTC transaction",
+			feature:            keystorePkg.FeatureBTCTransactionSigning,
+			unsupportedVersion: semver.NewSemVer(9, 3, 0),
+			supportedVersion:   semver.NewSemVer(9, 4, 0),
+			sign: func(keystore *keystore) error {
+				return keystore.SignTransaction(btcTransaction)
+			},
+		},
+		{
+			name:               "ETH transaction",
+			feature:            keystorePkg.FeatureETHTransactionSigning,
+			unsupportedVersion: semver.NewSemVer(9, 4, 0),
+			supportedVersion:   semver.NewSemVer(9, 5, 0),
+			sign: func(keystore *keystore) error {
+				return keystore.SignTransaction(&eth.TxProposal{Tx: contractCreation})
+			},
+		},
+		{
+			name:               "BTC message",
+			feature:            keystorePkg.FeatureMessageSigning,
+			unsupportedVersion: semver.NewSemVer(9, 4, 0),
+			supportedVersion:   semver.NewSemVer(9, 5, 0),
+			sign: func(keystore *keystore) error {
+				_, err := keystore.SignBTCMessage(
+					nil,
+					nil,
+					signing.ScriptTypeP2WPKH,
+					coinpkg.CodeBTC,
+				)
+				return err
+			},
+		},
+		{
+			name:               "ETH message",
+			feature:            keystorePkg.FeatureMessageSigning,
+			unsupportedVersion: semver.NewSemVer(9, 4, 0),
+			supportedVersion:   semver.NewSemVer(9, 5, 0),
+			sign: func(keystore *keystore) error {
+				_, err := keystore.SignETHMessage(1, nil, nil)
+				return err
+			},
+		},
+		{
+			name:               "ETH typed message",
+			feature:            keystorePkg.FeatureETHTypedMessageSigning,
+			unsupportedVersion: semver.NewSemVer(9, 11, 0),
+			supportedVersion:   semver.NewSemVer(9, 12, 0),
+			sign: func(keystore *keystore) error {
+				_, err := keystore.SignETHTypedMessage(1, nil, nil)
+				return err
+			},
+		},
+		{
+			name:               "WalletConnect ETH transaction",
+			feature:            keystorePkg.FeatureETHTransactionSigning,
+			unsupportedVersion: semver.NewSemVer(9, 4, 0),
+			supportedVersion:   semver.NewSemVer(9, 5, 0),
+			sign: func(keystore *keystore) error {
+				_, err := keystore.SignETHWalletConnectTransaction(
+					1,
+					walletConnectTransaction,
+					nil,
+				)
+				return err
+			},
+		},
+		{
+			name:               "payment requests",
+			feature:            keystorePkg.FeaturePaymentRequests,
+			unsupportedVersion: semver.NewSemVer(9, 19, 0),
+			supportedVersion:   semver.NewSemVer(9, 20, 0),
+		},
+		{
+			name:               "swap payment requests",
+			feature:            keystorePkg.FeatureSwapPaymentRequests,
+			unsupportedVersion: semver.NewSemVer(9, 25, 0),
+			supportedVersion:   semver.NewSemVer(9, 26, 0),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			unsupportedKeystore := newKeystoreWithVersion(test.unsupportedVersion)
+			err := unsupportedKeystore.SupportsFeature(test.feature)
+			require.ErrorIs(t, err, keystorePkg.ErrFirmwareUpgradeRequired)
+			if test.sign != nil {
+				err = test.sign(unsupportedKeystore)
+				require.ErrorIs(t, err, keystorePkg.ErrFirmwareUpgradeRequired)
+			}
+
+			supportedKeystore := newKeystoreWithVersion(test.supportedVersion)
+			require.NoError(t, supportedKeystore.SupportsFeature(test.feature))
+			if test.sign != nil {
+				err = test.sign(supportedKeystore)
+				require.NotErrorIs(t, err, keystorePkg.ErrFirmwareUpgradeRequired)
+			}
+		})
+	}
+
+	require.ErrorIs(
+		t,
+		newKeystoreWithVersion(semver.NewSemVer(9, 26, 0)).SupportsFeature("unknown"),
+		keystorePkg.ErrUnsupportedFeature,
+	)
+}
+
+func TestSoftwareKeystoreSigningIsNotFirmwareGated(t *testing.T) {
+	masterKey, err := hdkeychain.NewMaster(
+		bytes.Repeat([]byte{0x01}, 32),
+		&chaincfg.MainNetParams,
+	)
+	require.NoError(t, err)
+	softwareKeystore := software.NewKeystore(masterKey)
+	require.NoError(t, softwareKeystore.SupportsFeature(keystorePkg.FeatureBTCTransactionSigning))
+	require.NoError(t, softwareKeystore.SupportsFeature(keystorePkg.FeatureETHTransactionSigning))
+	require.NoError(t, softwareKeystore.SupportsFeature(keystorePkg.FeatureMessageSigning))
+	require.ErrorIs(
+		t,
+		softwareKeystore.SupportsFeature(keystorePkg.FeaturePaymentRequests),
+		keystorePkg.ErrUnsupportedFeature,
+	)
+
+	_, err = softwareKeystore.SignBTCMessage(
+		[]byte("message"),
+		signing.NewAbsoluteKeypathFromUint32(),
+		signing.ScriptTypeP2WPKH,
+		coinpkg.CodeBTC,
+	)
+	require.NoError(t, err)
+}

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -1960,21 +1960,33 @@ func (handlers *Handlers) postConnectKeystore(r *http.Request) interface{} {
 	}
 
 	var request struct {
-		RootFingerprint jsonp.HexBytes `json:"rootFingerprint"`
+		RootFingerprint jsonp.HexBytes   `json:"rootFingerprint"`
+		RequiredFeature keystore.Feature `json:"requiredFeature"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return response{Success: false}
 	}
 
-	_, err := handlers.backend.ConnectKeystore([]byte(request.RootFingerprint))
+	connectedKeystore, err := handlers.backend.ConnectKeystore([]byte(request.RootFingerprint))
 	if errp.Cause(err) == errp.ErrUserAbort {
 		return response{
 			Success:   false,
 			ErrorCode: errp.ErrUserAbort.Error(),
 		}
 	}
-	return response{Success: err == nil}
+	if err != nil {
+		return response{Success: false}
+	}
+	if request.RequiredFeature != "" {
+		if err := connectedKeystore.SupportsFeature(request.RequiredFeature); err != nil {
+			if keystoreErr, ok := errp.Cause(err).(keystore.KeystoreError); ok {
+				return response{Success: false, ErrorCode: keystoreErr.Error()}
+			}
+			return response{Success: false}
+		}
+	}
+	return response{Success: true}
 }
 
 func (handlers *Handlers) postSwapSign(r *http.Request) interface{} {

--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/arguments"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/usb"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/handlers"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore/software"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/test"
 	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
 )
 
 // backendEnv is a backend environment implementation for testing.
@@ -85,6 +87,59 @@ func TestGetNativeLocale(t *testing.T) {
 	test.DecodeHandlerResponse(t, &locale, res.Body)
 	if locale != ptLocale {
 		t.Errorf("locale = %q; want %q", locale, ptLocale)
+	}
+}
+
+func TestConnectKeystoreRequiredFeature(t *testing.T) {
+	args := arguments.NewArguments(
+		test.TstTempDir("connect-keystore-feature"),
+		true,
+		false,
+		true,
+		nil,
+	)
+	back, err := backend.NewBackend(args, &backendEnv{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer back.Close()
+	h := handlers.NewHandlers(back, handlers.NewConnectionData(0, ""))
+	require.NoError(t, back.RegisterTestKeystore("0000", software.EditionMulti))
+
+	tests := []struct {
+		name              string
+		requiredFeature   string
+		expectedSuccess   bool
+		expectedErrorCode string
+	}{
+		{name: "no required feature", expectedSuccess: true},
+		{
+			name:            "supported feature",
+			requiredFeature: "messageSigning",
+			expectedSuccess: true,
+		},
+		{
+			name:              "unsupported feature",
+			requiredFeature:   "paymentRequests",
+			expectedErrorCode: "unsupportedFeature",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			body := fmt.Sprintf(`{"rootFingerprint":"","requiredFeature":%q}`, testCase.requiredFeature)
+			request := httptest.NewRequest(http.MethodPost, "/api/connect-keystore", strings.NewReader(body))
+			recorder := httptest.NewRecorder()
+			h.Router.ServeHTTP(recorder, request)
+
+			var response struct {
+				Success   bool   `json:"success"`
+				ErrorCode string `json:"errorCode"`
+			}
+			test.DecodeHandlerResponse(t, &response, recorder.Result().Body)
+			require.Equal(t, testCase.expectedSuccess, response.Success)
+			require.Equal(t, testCase.expectedErrorCode, response.ErrorCode)
+		})
 	}
 }
 

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -24,6 +24,24 @@ const (
 	TypeSoftware Type = "software"
 )
 
+// Feature identifies a keystore capability that a workflow can require before it starts.
+type Feature string
+
+const (
+	// FeatureBTCTransactionSigning requires support for signing Bitcoin-family transactions.
+	FeatureBTCTransactionSigning Feature = "btcTransactionSigning"
+	// FeatureETHTransactionSigning requires support for signing Ethereum-family transactions.
+	FeatureETHTransactionSigning Feature = "ethTransactionSigning"
+	// FeatureMessageSigning requires support for signing Bitcoin or Ethereum messages.
+	FeatureMessageSigning Feature = "messageSigning"
+	// FeatureETHTypedMessageSigning requires support for signing EIP-712 typed messages.
+	FeatureETHTypedMessageSigning Feature = "ethTypedMessageSigning"
+	// FeaturePaymentRequests requires support for payment requests.
+	FeaturePaymentRequests Feature = "paymentRequests"
+	// FeatureSwapPaymentRequests requires support for swap payment requests.
+	FeatureSwapPaymentRequests Feature = "swapPaymentRequests"
+)
+
 // KeystoreError represents errors related to the keystore.
 //
 //revive:disable-line:exported
@@ -154,12 +172,9 @@ type Keystore interface {
 	// SupportsEIP1559 returns whether the keystore supports EIP1559 type 2 transactions for Ethereum
 	SupportsEIP1559() bool
 
-	// SupportsPaymentRequests returns nil if the device supports silent payments, or an error indicating why it is not supported.
-	SupportsPaymentRequests() error
-
-	// SupportsSwapPaymentRequests reports whether the device supports swap payment requests, or an
-	// error indicating why it is not supported.
-	SupportsSwapPaymentRequests() error
+	// SupportsFeature returns nil if the keystore supports the requested feature, or an error
+	// indicating why it is not supported.
+	SupportsFeature(Feature) error
 
 	// Features reports optional capabilities supported by this keystore.
 	Features() *Features

--- a/backend/keystore/mocks/keystore.go
+++ b/backend/keystore/mocks/keystore.go
@@ -76,11 +76,8 @@ var _ keystore.Keystore = &KeystoreMock{}
 //			SupportsEIP1559Func: func() bool {
 //				panic("mock out the SupportsEIP1559 method")
 //			},
-//			SupportsPaymentRequestsFunc: func() error {
-//				panic("mock out the SupportsPaymentRequests method")
-//			},
-//			SupportsSwapPaymentRequestsFunc: func() error {
-//				panic("mock out the SupportsSwapPaymentRequests method")
+//			SupportsFeatureFunc: func(feature keystore.Feature) error {
+//				panic("mock out the SupportsFeature method")
 //			},
 //			TypeFunc: func() keystore.Type {
 //				panic("mock out the Type method")
@@ -158,11 +155,8 @@ type KeystoreMock struct {
 	// SupportsEIP1559Func mocks the SupportsEIP1559 method.
 	SupportsEIP1559Func func() bool
 
-	// SupportsPaymentRequestsFunc mocks the SupportsPaymentRequests method.
-	SupportsPaymentRequestsFunc func() error
-
-	// SupportsSwapPaymentRequestsFunc mocks the SupportsSwapPaymentRequests method.
-	SupportsSwapPaymentRequestsFunc func() error
+	// SupportsFeatureFunc mocks the SupportsFeature method.
+	SupportsFeatureFunc func(feature keystore.Feature) error
 
 	// TypeFunc mocks the Type method.
 	TypeFunc func() keystore.Type
@@ -283,11 +277,10 @@ type KeystoreMock struct {
 		// SupportsEIP1559 holds details about calls to the SupportsEIP1559 method.
 		SupportsEIP1559 []struct {
 		}
-		// SupportsPaymentRequests holds details about calls to the SupportsPaymentRequests method.
-		SupportsPaymentRequests []struct {
-		}
-		// SupportsSwapPaymentRequests holds details about calls to the SupportsSwapPaymentRequests method.
-		SupportsSwapPaymentRequests []struct {
+		// SupportsFeature holds details about calls to the SupportsFeature method.
+		SupportsFeature []struct {
+			// Feature is the feature argument value.
+			Feature keystore.Feature
 		}
 		// Type holds details about calls to the Type method.
 		Type []struct {
@@ -335,8 +328,7 @@ type KeystoreMock struct {
 	lockSupportsCoin                    sync.RWMutex
 	lockSupportsDeterministicEntropy    sync.RWMutex
 	lockSupportsEIP1559                 sync.RWMutex
-	lockSupportsPaymentRequests         sync.RWMutex
-	lockSupportsSwapPaymentRequests     sync.RWMutex
+	lockSupportsFeature                 sync.RWMutex
 	lockType                            sync.RWMutex
 	lockVerifyAddressBTC                sync.RWMutex
 	lockVerifyAddressETH                sync.RWMutex
@@ -964,57 +956,35 @@ func (mock *KeystoreMock) SupportsEIP1559Calls() []struct {
 	return calls
 }
 
-// SupportsPaymentRequests calls SupportsPaymentRequestsFunc.
-func (mock *KeystoreMock) SupportsPaymentRequests() error {
-	if mock.SupportsPaymentRequestsFunc == nil {
-		panic("KeystoreMock.SupportsPaymentRequestsFunc: method is nil but Keystore.SupportsPaymentRequests was just called")
+// SupportsFeature calls SupportsFeatureFunc.
+func (mock *KeystoreMock) SupportsFeature(feature keystore.Feature) error {
+	if mock.SupportsFeatureFunc == nil {
+		panic("KeystoreMock.SupportsFeatureFunc: method is nil but Keystore.SupportsFeature was just called")
 	}
 	callInfo := struct {
-	}{}
-	mock.lockSupportsPaymentRequests.Lock()
-	mock.calls.SupportsPaymentRequests = append(mock.calls.SupportsPaymentRequests, callInfo)
-	mock.lockSupportsPaymentRequests.Unlock()
-	return mock.SupportsPaymentRequestsFunc()
+		Feature keystore.Feature
+	}{
+		Feature: feature,
+	}
+	mock.lockSupportsFeature.Lock()
+	mock.calls.SupportsFeature = append(mock.calls.SupportsFeature, callInfo)
+	mock.lockSupportsFeature.Unlock()
+	return mock.SupportsFeatureFunc(feature)
 }
 
-// SupportsPaymentRequestsCalls gets all the calls that were made to SupportsPaymentRequests.
+// SupportsFeatureCalls gets all the calls that were made to SupportsFeature.
 // Check the length with:
 //
-//	len(mockedKeystore.SupportsPaymentRequestsCalls())
-func (mock *KeystoreMock) SupportsPaymentRequestsCalls() []struct {
+//	len(mockedKeystore.SupportsFeatureCalls())
+func (mock *KeystoreMock) SupportsFeatureCalls() []struct {
+	Feature keystore.Feature
 } {
 	var calls []struct {
+		Feature keystore.Feature
 	}
-	mock.lockSupportsPaymentRequests.RLock()
-	calls = mock.calls.SupportsPaymentRequests
-	mock.lockSupportsPaymentRequests.RUnlock()
-	return calls
-}
-
-// SupportsSwapPaymentRequests calls SupportsSwapPaymentRequestsFunc.
-func (mock *KeystoreMock) SupportsSwapPaymentRequests() error {
-	if mock.SupportsSwapPaymentRequestsFunc == nil {
-		panic("KeystoreMock.SupportsSwapPaymentRequestsFunc: method is nil but Keystore.SupportsSwapPaymentRequests was just called")
-	}
-	callInfo := struct {
-	}{}
-	mock.lockSupportsSwapPaymentRequests.Lock()
-	mock.calls.SupportsSwapPaymentRequests = append(mock.calls.SupportsSwapPaymentRequests, callInfo)
-	mock.lockSupportsSwapPaymentRequests.Unlock()
-	return mock.SupportsSwapPaymentRequestsFunc()
-}
-
-// SupportsSwapPaymentRequestsCalls gets all the calls that were made to SupportsSwapPaymentRequests.
-// Check the length with:
-//
-//	len(mockedKeystore.SupportsSwapPaymentRequestsCalls())
-func (mock *KeystoreMock) SupportsSwapPaymentRequestsCalls() []struct {
-} {
-	var calls []struct {
-	}
-	mock.lockSupportsSwapPaymentRequests.RLock()
-	calls = mock.calls.SupportsSwapPaymentRequests
-	mock.lockSupportsSwapPaymentRequests.RUnlock()
+	mock.lockSupportsFeature.RLock()
+	calls = mock.calls.SupportsFeature
+	mock.lockSupportsFeature.RUnlock()
 	return calls
 }
 

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -419,13 +419,14 @@ func (keystore *Keystore) SupportsEIP1559() bool {
 	return false
 }
 
-// SupportsPaymentRequests implements keystore.Keystore.
-func (keystore *Keystore) SupportsPaymentRequests() error {
-	return keystorePkg.ErrUnsupportedFeature
-}
-
-// SupportsSwapPaymentRequests reports whether the keystore supports the
-// payment-request signing flow used by swaps.
-func (keystore *Keystore) SupportsSwapPaymentRequests() error {
-	return keystorePkg.ErrUnsupportedFeature
+// SupportsFeature implements keystore.Keystore.
+func (keystore *Keystore) SupportsFeature(feature keystorePkg.Feature) error {
+	switch feature {
+	case keystorePkg.FeatureBTCTransactionSigning,
+		keystorePkg.FeatureETHTransactionSigning,
+		keystorePkg.FeatureMessageSigning:
+		return nil
+	default:
+		return keystorePkg.ErrUnsupportedFeature
+	}
 }

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -379,6 +379,7 @@ export const proposeTx = (
 export type TSendTxErrorCode =
   | TTxProposalErrorCode
   | 'erc20InsufficientGasFunds'
+  | 'firmwareUpgradeRequired'
   | 'syncInProgress'
   | 'wrongKeystore';
 
@@ -449,20 +450,6 @@ export const hasSecureOutput = (code: AccountCode) => {
   };
 };
 
-type THasPaymentRequest = {
-  success: boolean;
-  errorMessage?: string;
-  errorCode?: 'firmwareUpgradeRequired' | 'unsupportedFeature';
-};
-
-export const hasPaymentRequest = (code: AccountCode): Promise<THasPaymentRequest> => {
-  return apiGet(`account/${code}/has-payment-request`);
-};
-
-export const hasSwapPaymentRequest = (code: AccountCode): Promise<THasPaymentRequest> => {
-  return apiGet(`account/${code}/has-swap-payment-request`);
-};
-
 export type TAddAccount = {
   success: boolean;
   accountCode?: string;
@@ -477,12 +464,21 @@ export const addAccount = (coinCode: string, name: string): Promise<TAddAccount>
   });
 };
 
-export type TSignMessage = { success: false; aborted?: boolean; errorMessage?: string } | { success: true; signature: string };
+export type TSignMessage = {
+  success: false;
+  aborted?: boolean;
+  errorMessage?: string;
+  errorCode?: 'firmwareUpgradeRequired';
+} | {
+  success: true;
+  signature: string;
+};
 
 export type TSignWalletConnectTx = {
   success: false;
   aborted?: boolean;
   errorMessage?: string;
+  errorCode?: 'firmwareUpgradeRequired';
 } | {
   success: true;
   txHash: string;
@@ -514,7 +510,7 @@ type TAddressSignResponse = {
 } | {
   success: false;
   errorMessage?: string;
-  errorCode?: 'userAbort' | 'wrongKeystore';
+  errorCode?: 'firmwareUpgradeRequired' | 'userAbort' | 'wrongKeystore';
 };
 
 export const signBTCMessageUnusedAddress = (

--- a/frontends/web/src/api/aopp.ts
+++ b/frontends/web/src/api/aopp.ts
@@ -15,7 +15,7 @@ type Accounts = NonEmptyArray<TAccount>;
 
 export type Aopp = {
   state: 'error';
-  errorCode: 'aoppUnsupportedAsset' | 'aoppVersion' | 'aoppInvalidRequest' | 'aoppNoAccounts' | 'aoppUnsupportedKeystore' | 'aoppUnknown' | 'aoppSigningAborted' | 'aoppCallback';
+  errorCode: 'aoppUnsupportedAsset' | 'aoppVersion' | 'aoppInvalidRequest' | 'aoppNoAccounts' | 'aoppUnsupportedKeystore' | 'aoppUnknown' | 'aoppSigningAborted' | 'aoppCallback' | 'firmwareUpgradeRequired';
   callback: string;
 } | {
   state: 'inactive';

--- a/frontends/web/src/api/keystores.ts
+++ b/frontends/web/src/api/keystores.ts
@@ -47,15 +47,28 @@ export const deregisterTest = (): Promise<null> => {
 
 export type TConnectKeystoreResponse = {
   success: boolean;
-  errorCode?: string;
+  errorCode?: 'firmwareUpgradeRequired' | 'unsupportedFeature' | 'userAbort';
 };
 
-export const connectKeystore = (rootFingerprint: string): Promise<TConnectKeystoreResponse> => {
-  return apiPost('connect-keystore', { rootFingerprint });
+export type TKeystoreFeature =
+  | 'btcTransactionSigning'
+  | 'ethTransactionSigning'
+  | 'messageSigning'
+  | 'ethTypedMessageSigning'
+  | 'paymentRequests'
+  | 'swapPaymentRequests';
+
+export const connectKeystore = (
+  rootFingerprint: string,
+  requiredFeature?: TKeystoreFeature,
+): Promise<TConnectKeystoreResponse> => {
+  return apiPost('connect-keystore', { rootFingerprint, requiredFeature });
 };
 
-export const connectAnyKeystore = (): Promise<TConnectKeystoreResponse> => {
-  return apiPost('connect-keystore', { rootFingerprint: '' });
+export const connectAnyKeystore = (
+  requiredFeature?: TKeystoreFeature,
+): Promise<TConnectKeystoreResponse> => {
+  return apiPost('connect-keystore', { rootFingerprint: '', requiredFeature });
 };
 
 export const getKeystoreFeatures = (rootFingerprint: string): Promise<TKeystoreFeaturesResponse> => {

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -13,6 +13,7 @@ import { CopyableInput } from '@/components/copy/Copy';
 import { PointToBitBox02 } from '@/components/icon';
 import { VerifyAddress } from './verifyaddress';
 import { Vasp } from './vasp';
+import { FirmwareUpgradeRequiredDialog } from '@/components/dialog/firmware-upgrade-required-dialog';
 import styles from './aopp.module.css';
 
 type TProps = {
@@ -67,6 +68,14 @@ export const Aopp = () => {
   }
   switch (aopp.state) {
   case 'error':
+    if (aopp.errorCode === 'firmwareUpgradeRequired') {
+      return (
+        <FirmwareUpgradeRequiredDialog
+          open
+          onClose={aoppAPI.cancel}
+        />
+      );
+    }
     return (
       <View
         fullscreen

--- a/frontends/web/src/components/wallet-connect/incoming-signing-request.test.tsx
+++ b/frontends/web/src/components/wallet-connect/incoming-signing-request.test.tsx
@@ -24,6 +24,9 @@ const connectKeystore = vi.hoisted(() => vi.fn());
 vi.mock('@/utils/walletconnect-eth-sign-handlers', () => handlers);
 vi.mock('@/components/alert/Alert', () => ({ alertUser }));
 vi.mock('@/api/keystores', () => ({ connectKeystore }));
+vi.mock('@/components/dialog/firmware-upgrade-required-dialog', () => ({
+  FirmwareUpgradeRequiredDialog: () => <div>Firmware upgrade required</div>,
+}));
 vi.mock('i18next', () => ({ t: (key: string) => key }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('@/hooks/darkmode', () => ({ useDarkmode: () => ({ isDarkMode: false }) }));
@@ -182,6 +185,24 @@ describe('WCSigningRequest', () => {
     await act(async () => backButton.handler?.());
 
     expect(screen.getByText('confirmOnDevice')).toBeInTheDocument();
+    expect(request.onReject).not.toHaveBeenCalled();
+  });
+
+  it('prompts for a firmware upgrade after failed signing', async () => {
+    const request = makeRequest({
+      apiCaller: vi.fn().mockResolvedValue({
+        success: false,
+        errorCode: 'firmwareUpgradeRequired',
+      }),
+    });
+    const { emitRequest } = setup([request]);
+    await emitRequest();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'button.continue' }));
+
+    expect(await screen.findByText('Firmware upgrade required')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'button.continue' })).not.toBeInTheDocument();
+    expect(alertUser).not.toHaveBeenCalled();
     expect(request.onReject).not.toHaveBeenCalled();
   });
 });

--- a/frontends/web/src/components/wallet-connect/incoming-signing-request.tsx
+++ b/frontends/web/src/components/wallet-connect/incoming-signing-request.tsx
@@ -15,6 +15,7 @@ import { alertUser } from '@/components/alert/Alert';
 import type { TAccount } from '@/api/account';
 import { connectKeystore } from '@/api/keystores';
 import { TStage, WCIncomingSignRequestDialog } from './incoming-signing-request-dialog';
+import { FirmwareUpgradeRequiredDialog } from '@/components/dialog/firmware-upgrade-required-dialog';
 
 type TActiveSigningRequest = {
   accountCode: TLaunchSignDialog['accountCode'];
@@ -32,6 +33,7 @@ export const WCSigningRequest = ({ accounts }: TProps) => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogContent, setDialogContent] = useState<TRequestDialogContent>();
   const [stage, setStage] = useState<TStage>('initial');
+  const [firmwareUpgradeRequired, setFirmwareUpgradeRequired] = useState(false);
   const activeRequestRef = useRef<TActiveSigningRequest>();
   const successTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
@@ -128,22 +130,32 @@ export const WCSigningRequest = ({ accounts }: TProps) => {
 
     setStage('initial');
     setDialogOpen(false);
+    if (result.errorCode === 'firmwareUpgradeRequired') {
+      setFirmwareUpgradeRequired(true);
+      return;
+    }
     if (!result.aborted) {
       alertUser(result.errorMessage || t('pairing.error.text'));
     }
   };
 
-  if (!dialogContent || !dialogOpen) {
-    return null;
-  }
-
   return (
-    <WCIncomingSignRequestDialog
-      content={dialogContent}
-      open={dialogOpen}
-      stage={stage}
-      onAccept={handleAcceptBtn}
-      onReject={handleRejectBtn}
-    />
+    <>
+      {firmwareUpgradeRequired && (
+        <FirmwareUpgradeRequiredDialog
+          open
+          onClose={() => setFirmwareUpgradeRequired(false)}
+        />
+      )}
+      {dialogContent && dialogOpen && (
+        <WCIncomingSignRequestDialog
+          content={dialogContent}
+          open={dialogOpen}
+          stage={stage}
+          onAccept={handleAcceptBtn}
+          onReject={handleRejectBtn}
+        />
+      )}
+    </>
   );
 };

--- a/frontends/web/src/hooks/keystore.test.ts
+++ b/frontends/web/src/hooks/keystore.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { connectAnyKeystore, connectKeystore } from '@/api/keystores';
+import { alertUser } from '@/components/alert/Alert';
+import { useFeatureConnect } from './keystore';
+
+vi.mock('@/api/keystores', () => ({
+  connectAnyKeystore: vi.fn(),
+  connectKeystore: vi.fn(),
+}));
+vi.mock('@/components/alert/Alert', () => ({
+  alertUser: vi.fn(),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('useFeatureConnect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows and dismisses the firmware upgrade requirement', async () => {
+    vi.mocked(connectKeystore).mockResolvedValue({
+      success: false,
+      errorCode: 'firmwareUpgradeRequired',
+    });
+    const { result } = renderHook(() => useFeatureConnect());
+
+    let connected = true;
+    await act(async () => {
+      connected = await result.current.connect('root-fingerprint', 'messageSigning');
+    });
+
+    expect(connected).toBe(false);
+    expect(connectKeystore).toHaveBeenCalledWith('root-fingerprint', 'messageSigning');
+    expect(result.current.firmwareUpgradeRequired).toBe(true);
+
+    act(() => result.current.dismissFirmwareUpgrade());
+    expect(result.current.firmwareUpgradeRequired).toBe(false);
+  });
+
+  it('connects any supported keystore without showing an upgrade requirement', async () => {
+    vi.mocked(connectAnyKeystore).mockResolvedValue({ success: true });
+    const { result } = renderHook(() => useFeatureConnect());
+
+    let connected = false;
+    await act(async () => {
+      connected = await result.current.connectAny('swapPaymentRequests');
+    });
+
+    expect(connected).toBe(true);
+    expect(connectAnyKeystore).toHaveBeenCalledWith('swapPaymentRequests');
+    expect(result.current.firmwareUpgradeRequired).toBe(false);
+  });
+
+  it('reports unsupported features', async () => {
+    vi.mocked(connectKeystore).mockResolvedValue({
+      success: false,
+      errorCode: 'unsupportedFeature',
+    });
+    const { result } = renderHook(() => useFeatureConnect());
+
+    await act(async () => {
+      await result.current.connect('root-fingerprint', 'paymentRequests');
+    });
+
+    expect(alertUser).toHaveBeenCalledWith('device.unsupportedFeature');
+  });
+});

--- a/frontends/web/src/hooks/keystore.ts
+++ b/frontends/web/src/hooks/keystore.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  connectAnyKeystore,
+  connectKeystore,
+  TKeystoreFeature,
+} from '@/api/keystores';
+import { alertUser } from '@/components/alert/Alert';
+
+export const useFeatureConnect = () => {
+  const { t } = useTranslation();
+  const [firmwareUpgradeRequired, setFirmwareUpgradeRequired] = useState(false);
+
+  const handleResult = useCallback((result: Awaited<ReturnType<typeof connectKeystore>>) => {
+    if (result.errorCode === 'firmwareUpgradeRequired') {
+      setFirmwareUpgradeRequired(true);
+    } else if (result.errorCode === 'unsupportedFeature') {
+      alertUser(t('device.unsupportedFeature'));
+    }
+    return result.success;
+  }, [t]);
+
+  const connect = useCallback(async (
+    rootFingerprint: string,
+    requiredFeature?: TKeystoreFeature,
+  ) => {
+    return handleResult(await connectKeystore(rootFingerprint, requiredFeature));
+  }, [handleResult]);
+
+  const connectAny = useCallback(async (requiredFeature?: TKeystoreFeature) => {
+    return handleResult(await connectAnyKeystore(requiredFeature));
+  }, [handleResult]);
+
+  const dismissFirmwareUpgrade = useCallback(() => {
+    setFirmwareUpgradeRequired(false);
+  }, []);
+
+  return {
+    connect,
+    connectAny,
+    dismissFirmwareUpgrade,
+    firmwareUpgradeRequired,
+  };
+};

--- a/frontends/web/src/routes/account/actionButtons.test.tsx
+++ b/frontends/web/src/routes/account/actionButtons.test.tsx
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../__mocks__/i18n';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/api/keystores', () => ({
+  connectAnyKeystore: vi.fn(),
+  connectKeystore: vi.fn(),
+}));
+vi.mock('@/components/dialog/firmware-upgrade-required-dialog', () => ({
+  FirmwareUpgradeRequiredDialog: () => <div>firmware upgrade required</div>,
+}));
+vi.mock('@/hooks/mediaquery', () => ({
+  useMediaQuery: () => false,
+}));
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import type { CoinCode, TAccount } from '@/api/account';
+import { connectKeystore } from '@/api/keystores';
+import { ActionButtons } from './actionButtons';
+
+const account: TAccount = {
+  active: true,
+  blockExplorerTxPrefix: '',
+  code: 'btc-account',
+  coinCode: 'btc',
+  coinName: 'Bitcoin',
+  coinUnit: 'BTC',
+  isToken: false,
+  keystore: {
+    connected: false,
+    lastConnected: '',
+    name: 'BitBox02',
+    rootFingerprint: 'f23ab988',
+    watchonly: false,
+  },
+  name: 'Bitcoin Account',
+};
+
+const Location = () => {
+  const location = useLocation();
+  return <div>{location.pathname}</div>;
+};
+
+const renderActionButtons = (coinCode: CoinCode = 'btc') => {
+  const currentAccount = { ...account, coinCode };
+  render(
+    <MemoryRouter initialEntries={['/account/btc-account']}>
+      <ActionButtons
+        account={currentAccount}
+        accountDataLoaded
+        canSend
+        code={currentAccount.code}
+        coinCode={coinCode}
+      />
+      <Location />
+    </MemoryRouter>
+  );
+};
+
+describe('routes/account/actionButtons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prompts for an upgrade before entering the send screen', async () => {
+    vi.mocked(connectKeystore).mockResolvedValue({
+      success: false,
+      errorCode: 'firmwareUpgradeRequired',
+    });
+    renderActionButtons();
+
+    fireEvent.click(screen.getByRole('link', { name: 'generic.send' }));
+
+    await waitFor(() => {
+      expect(connectKeystore).toHaveBeenCalledWith(
+        account.keystore.rootFingerprint,
+        'btcTransactionSigning',
+      );
+    });
+    expect(await screen.findByText('firmware upgrade required')).toBeInTheDocument();
+    expect(screen.getByText('/account/btc-account')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['btc', 'btcTransactionSigning'],
+    ['eth', 'ethTransactionSigning'],
+  ] as const)('checks %s signing support before navigating', async (coinCode, requiredFeature) => {
+    vi.mocked(connectKeystore).mockResolvedValue({ success: true });
+    renderActionButtons(coinCode);
+
+    fireEvent.click(screen.getByRole('link', { name: 'generic.send' }));
+
+    await waitFor(() => {
+      expect(connectKeystore).toHaveBeenCalledWith(
+        account.keystore.rootFingerprint,
+        requiredFeature,
+      );
+    });
+    expect(screen.getByText('/account/btc-account/send')).toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/routes/account/actionButtons.tsx
+++ b/frontends/web/src/routes/account/actionButtons.tsx
@@ -7,9 +7,10 @@ import { ArrowFloorDownWhite, ArrowFloorUpWhite, Coins, WalletConnectLight } fro
 import { useMediaQuery } from '@/hooks/mediaquery';
 import { AccountCode, TAccount, CoinCode } from '@/api/account';
 import { isEthereumBased } from './utils';
-import { connectKeystore } from '@/api/keystores';
 import { AccountActionButtonLink } from './components/account-action-button-link';
 import { AccountActionButtons } from './components/account-action-buttons';
+import { FirmwareUpgradeRequiredDialog } from '@/components/dialog/firmware-upgrade-required-dialog';
+import { useFeatureConnect } from '@/hooks/keystore';
 import style from './account.module.css';
 
 type TProps = {
@@ -24,18 +25,25 @@ type TProps = {
 export const ActionButtons = ({ canSend, code, coinCode, exchangeSupported, account, accountDataLoaded }: TProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const {
+    connect,
+    dismissFirmwareUpgrade,
+    firmwareUpgradeRequired,
+  } = useFeatureConnect();
   const walletConnectEnabled = isEthereumBased(account.coinCode) && !account.isToken;
   const isLargeTablet = useMediaQuery('(max-width: 830px)');
   const isMobile = useMediaQuery('(max-width: 768px)');
 
-  // When clicking 'Send', for Ethereum based accounts we first prompt to connect the keystore
-  // before proceeding. The reason is that in ETH, we need to know what keystore (which BitBox02
-  // version) is connected to decide which ETH transaction proposals to construct (legacy vs EIP1559).
+  // When clicking 'Send', first prompt to connect the keystore and check that it supports signing.
+  // For Ethereum based accounts, we also need to know which keystore (which BitBox02 version) is
+  // connected to decide which ETH transaction proposals to construct (legacy vs EIP1559).
   const sendLink = `/account/${code}/send`;
-  const maybeRouteSend = async (e: MouseEvent<HTMLAnchorElement>) => {
+  const routeSend = async (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    const connectResult = await connectKeystore(account.keystore.rootFingerprint);
-    if (connectResult.success) {
+    const requiredFeature = isEthereumBased(coinCode)
+      ? 'ethTransactionSigning'
+      : 'btcTransactionSigning';
+    if (await connect(account.keystore.rootFingerprint, requiredFeature)) {
       // Proceed to the send screen if the keystore was connected.
       navigate(sendLink);
     }
@@ -48,7 +56,7 @@ export const ActionButtons = ({ canSend, code, coinCode, exchangeSupported, acco
       <AccountActionButtonLink
         disabled={!canClickSend}
         to={sendLink}
-        onClick={isEthereumBased(coinCode) ? maybeRouteSend : undefined}
+        onClick={routeSend}
       >
         <ArrowFloorUpWhite width={16} height={16} />
         <span>{t('generic.send')}</span>
@@ -83,6 +91,12 @@ export const ActionButtons = ({ canSend, code, coinCode, exchangeSupported, acco
             <span>Wallet Connect</span>
           )}
         </AccountActionButtonLink>
+      )}
+      {firmwareUpgradeRequired && (
+        <FirmwareUpgradeRequiredDialog
+          open
+          onClose={dismissFirmwareUpgrade}
+        />
       )}
     </AccountActionButtons>
   );

--- a/frontends/web/src/routes/account/sign-message/sign-message.test.tsx
+++ b/frontends/web/src/routes/account/sign-message/sign-message.test.tsx
@@ -130,7 +130,10 @@ describe('routes/account/sign-message', () => {
     await user.click(screen.getByRole('button', { name: 'Sign on device' }));
 
     await waitFor(() => {
-      expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(mockAccount.keystore.rootFingerprint);
+      expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(
+        mockAccount.keystore.rootFingerprint,
+        'messageSigning',
+      );
       expect(signMessageSpy).toHaveBeenCalledWith(
         mockAccount.code,
         'native-address-id',
@@ -222,7 +225,10 @@ describe('routes/account/sign-message', () => {
     await user.click(screen.getByRole('button', { name: 'Sign on device' }));
 
     await waitFor(() => {
-      expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(mockAccount.keystore.rootFingerprint);
+      expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(
+        mockAccount.keystore.rootFingerprint,
+        'messageSigning',
+      );
       expect(signMessageSpy).toHaveBeenCalledWith(
         mockAccount.code,
         'native-address-id',
@@ -276,7 +282,10 @@ describe('routes/account/sign-message', () => {
     await user.click(screen.getByRole('button', { name: 'Sign on device' }));
 
     await waitFor(() => {
-      expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(mockAccount.keystore.rootFingerprint);
+      expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(
+        mockAccount.keystore.rootFingerprint,
+        'messageSigning',
+      );
       expect(signMessageSpy).toHaveBeenCalledWith(
         mockAccount.code,
         usedAddress.addressID,
@@ -356,7 +365,10 @@ describe('routes/account/sign-message', () => {
     await user.click(screen.getByRole('button', { name: 'Sign on device' }));
 
     await waitFor(() => {
-      expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(ethAccount.keystore.rootFingerprint);
+      expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(
+        ethAccount.keystore.rootFingerprint,
+        'messageSigning',
+      );
       expect(ethSignSpy).toHaveBeenCalledWith(
         ethAccount.code,
         'eth sign test',
@@ -404,7 +416,10 @@ describe('routes/account/sign-message', () => {
     await user.click(screen.getByRole('button', { name: 'Sign on device' }));
 
     await waitFor(() => {
-      expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(mockAccount.keystore.rootFingerprint);
+      expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(
+        mockAccount.keystore.rootFingerprint,
+        'messageSigning',
+      );
     });
     expect(signMessageSpy).not.toHaveBeenCalled();
     expect(screen.getByRole('button', { name: 'Sign on device' })).toBeInTheDocument();

--- a/frontends/web/src/routes/account/sign-message/sign-message.tsx
+++ b/frontends/web/src/routes/account/sign-message/sign-message.tsx
@@ -14,6 +14,7 @@ import {
 import { useSignMessageController } from './use-sign-message-controller';
 import { isBitcoinBased } from '../utils';
 import { AddressesContent } from '../addresses/addresses';
+import { FirmwareUpgradeRequiredDialog } from '@/components/dialog/firmware-upgrade-required-dialog';
 import styles from './sign-message.module.css';
 
 type TProps = {
@@ -42,6 +43,12 @@ export const SignMessage = ({
 
   return (
     <Main>
+      {controller.firmwareUpgradeRequired && (
+        <FirmwareUpgradeRequiredDialog
+          open
+          onClose={controller.dismissFirmwareUpgrade}
+        />
+      )}
       <Header
         hideSidebarToggler
         title={

--- a/frontends/web/src/routes/account/sign-message/use-sign-message-controller.ts
+++ b/frontends/web/src/routes/account/sign-message/use-sign-message-controller.ts
@@ -36,6 +36,8 @@ export type TSignMessageController = {
   error: string | null;
   result: TSignatureResult | null;
   isTaprootAddress: boolean;
+  firmwareUpgradeRequired: boolean;
+  dismissFirmwareUpgrade: () => void;
   handleSign: () => Promise<void>;
   previous: (event: SyntheticEvent) => void;
   next: (event: SyntheticEvent) => void;
@@ -72,6 +74,8 @@ export const useSignMessageController = ({
     error,
     result,
     isTaprootAddress,
+    firmwareUpgradeRequired,
+    dismissFirmwareUpgrade,
     handleSign,
     reset,
   } = useSignMessage({
@@ -124,6 +128,8 @@ export const useSignMessageController = ({
     error,
     result,
     isTaprootAddress,
+    firmwareUpgradeRequired,
+    dismissFirmwareUpgrade,
     handleSign,
     previous,
     next,

--- a/frontends/web/src/routes/account/sign-message/use-sign-message.test.ts
+++ b/frontends/web/src/routes/account/sign-message/use-sign-message.test.ts
@@ -90,7 +90,7 @@ describe('routes/account/sign-message/use-sign-message', () => {
       'test-addr-id',
       'test message',
     );
-    expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(rootFingerprint);
+    expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(rootFingerprint, 'messageSigning');
   });
 
   it('signs ETH message for ethereum-based coin', async () => {
@@ -131,7 +131,7 @@ describe('routes/account/sign-message/use-sign-message', () => {
       'eth test message',
     );
     expect(accountApi.signBTCMessageForAddress).not.toHaveBeenCalled();
-    expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(rootFingerprint);
+    expect(keystoresApi.connectKeystore).toHaveBeenCalledWith(rootFingerprint, 'messageSigning');
   });
 
   it('handles connect-keystore userAbort by returning to input', async () => {
@@ -178,6 +178,30 @@ describe('routes/account/sign-message/use-sign-message', () => {
 
     expect(result.current.state).toBe('input');
     expect(result.current.error).toBeNull();
+    expect(accountApi.signBTCMessageForAddress).not.toHaveBeenCalled();
+  });
+
+  it('requires a firmware upgrade before signing', async () => {
+    vi.mocked(keystoresApi.connectKeystore).mockResolvedValue({
+      success: false,
+      errorCode: 'firmwareUpgradeRequired',
+    });
+
+    const { result } = renderHook(() => useSignMessage({
+      accountCode: 'btc-acc' as accountApi.AccountCode,
+      address: mockAddress,
+      rootFingerprint,
+    }));
+
+    act(() => {
+      result.current.setMessage('some message');
+    });
+
+    await act(async () => {
+      await result.current.handleSign();
+    });
+
+    expect(result.current.firmwareUpgradeRequired).toBe(true);
     expect(accountApi.signBTCMessageForAddress).not.toHaveBeenCalled();
   });
 

--- a/frontends/web/src/routes/account/sign-message/use-sign-message.ts
+++ b/frontends/web/src/routes/account/sign-message/use-sign-message.ts
@@ -3,8 +3,8 @@
 import { useCallback, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as accountApi from '@/api/account';
-import { connectKeystore } from '@/api/keystores';
 import { AccountCode, ScriptType, TReceiveAddress } from '@/api/account';
+import { useFeatureConnect } from '@/hooks/keystore';
 import { isEthereumBased } from '../utils';
 
 export type TSigningState = 'input' | 'signing' | 'result';
@@ -31,6 +31,8 @@ type UseSignMessageReturn = {
   error: string | null;
   result: TSignatureResult | null;
   isTaprootAddress: boolean;
+  firmwareUpgradeRequired: boolean;
+  dismissFirmwareUpgrade: () => void;
   handleSign: () => Promise<void>;
   reset: () => void;
 };
@@ -47,6 +49,11 @@ export const useSignMessage = ({
   const [state, setState] = useState<TSigningState>('input');
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<TSignatureResult | null>(null);
+  const {
+    connect,
+    dismissFirmwareUpgrade,
+    firmwareUpgradeRequired,
+  } = useFeatureConnect();
 
   const isTaproot = scriptType === 'p2tr';
 
@@ -66,8 +73,7 @@ export const useSignMessage = ({
 
     signingRef.current = true;
     try {
-      const connectResult = await connectKeystore(rootFingerprint);
-      if (!connectResult.success) {
+      if (!await connect(rootFingerprint, 'messageSigning')) {
         return;
       }
 
@@ -102,7 +108,7 @@ export const useSignMessage = ({
     } finally {
       signingRef.current = false;
     }
-  }, [accountCode, address, coinCode, message, rootFingerprint, t]);
+  }, [accountCode, address, coinCode, connect, message, rootFingerprint, t]);
 
   const reset = useCallback(() => {
     setMessage('');
@@ -118,6 +124,8 @@ export const useSignMessage = ({
     error,
     result,
     isTaprootAddress: isTaproot,
+    firmwareUpgradeRequired,
+    dismissFirmwareUpgrade,
     handleSign,
     reset,
   };

--- a/frontends/web/src/routes/bitsurance/account.test.tsx
+++ b/frontends/web/src/routes/bitsurance/account.test.tsx
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../__mocks__/i18n';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/api/bitsurance', () => ({
+  bitsuranceLookup: vi.fn(),
+}));
+vi.mock('@/api/keystores', () => ({
+  connectAnyKeystore: vi.fn(),
+  connectKeystore: vi.fn(),
+}));
+vi.mock('@/components/dialog/firmware-upgrade-required-dialog', () => ({
+  FirmwareUpgradeRequiredDialog: () => <div>firmware upgrade required</div>,
+}));
+vi.mock('@/components/groupedaccountselector/groupedaccountselector', () => ({
+  GroupedAccountSelector: () => null,
+}));
+vi.mock('@/components/layout', () => ({
+  GuideWrapper: ({ children }: { children: ReactNode }) => <>{children}</>,
+  GuidedContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Header: () => null,
+  Main: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/spinner/Spinner', () => ({
+  Spinner: () => null,
+}));
+vi.mock('@/components/view/view', () => ({
+  View: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ViewContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/routes/market/components/markettab', () => ({
+  MarketTab: () => null,
+}));
+vi.mock('./guide', () => ({
+  BitsuranceGuide: () => null,
+}));
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import type { TAccount } from '@/api/account';
+import { bitsuranceLookup } from '@/api/bitsurance';
+import { connectKeystore } from '@/api/keystores';
+import { BitsuranceAccount } from './account';
+
+const account: TAccount = {
+  active: true,
+  blockExplorerTxPrefix: '',
+  code: 'btc-account',
+  coinCode: 'btc',
+  coinName: 'Bitcoin',
+  coinUnit: 'BTC',
+  isToken: false,
+  keystore: {
+    connected: false,
+    lastConnected: '',
+    name: 'BitBox02',
+    rootFingerprint: 'f23ab988',
+    watchonly: false,
+  },
+  name: 'Bitcoin Account',
+};
+
+const Location = () => {
+  const location = useLocation();
+  return <div>{location.pathname}</div>;
+};
+
+describe('routes/bitsurance/account', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prompts for an upgrade before opening the widget', async () => {
+    vi.mocked(bitsuranceLookup).mockResolvedValue({
+      success: true,
+      errorMessage: '',
+      bitsuranceAccounts: [],
+    });
+    vi.mocked(connectKeystore).mockResolvedValue({
+      success: false,
+      errorCode: 'firmwareUpgradeRequired',
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/market/bitsurance/account/btc-account']}>
+        <BitsuranceAccount accounts={[account]} code={account.code} />
+        <Location />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(connectKeystore).toHaveBeenCalledWith(
+        account.keystore.rootFingerprint,
+        'messageSigning',
+      );
+    });
+    expect(await screen.findByText('firmware upgrade required')).toBeInTheDocument();
+    expect(screen.getByText('/market/bitsurance/account/btc-account')).toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/routes/bitsurance/account.tsx
+++ b/frontends/web/src/routes/bitsurance/account.tsx
@@ -11,8 +11,9 @@ import { Spinner } from '@/components/spinner/Spinner';
 import { View, ViewContent } from '@/components/view/view';
 import { bitsuranceLookup } from '@/api/bitsurance';
 import { alertUser } from '@/components/alert/Alert';
-import { connectKeystore } from '@/api/keystores';
 import { BitsuranceGuide } from './guide';
+import { useFeatureConnect } from '@/hooks/keystore';
+import { FirmwareUpgradeRequiredDialog } from '@/components/dialog/firmware-upgrade-required-dialog';
 
 type TProps = {
   accounts: TAccount[];
@@ -23,6 +24,11 @@ export const BitsuranceAccount = ({ code, accounts }: TProps) => {
   const navigate = useNavigate();
   const [disabled, setDisabled] = useState<boolean>(false);
   const [btcAccounts, setBtcAccounts] = useState<TAccount[]>();
+  const {
+    connect,
+    dismissFirmwareUpgrade,
+    firmwareUpgradeRequired,
+  } = useFeatureConnect();
 
   const { t } = useTranslation();
 
@@ -58,15 +64,15 @@ export const BitsuranceAccount = ({ code, accounts }: TProps) => {
   useEffect(() => {
     if (btcAccounts !== undefined && btcAccounts.length === 1) {
       const account = btcAccounts[0] as TAccount;
-      connectKeystore(account.keystore.rootFingerprint).then(connectResult => {
-        if (!connectResult.success) {
+      connect(account.keystore.rootFingerprint, 'messageSigning').then(success => {
+        if (!success) {
           return;
         }
         // replace current history item when redirecting so that the user can go back
         navigate(`/market/bitsurance/widget/${account.code}`, { replace: true });
       });
     }
-  }, [btcAccounts, navigate]);
+  }, [btcAccounts, connect, navigate]);
 
   const handleProceed = async () => {
     setDisabled(true);
@@ -75,8 +81,7 @@ export const BitsuranceAccount = ({ code, accounts }: TProps) => {
       if (account === undefined) {
         return;
       }
-      const connectResult = await connectKeystore(account.keystore.rootFingerprint);
-      if (!connectResult.success) {
+      if (!await connect(account.keystore.rootFingerprint, 'messageSigning')) {
         return;
       }
     } finally {
@@ -91,6 +96,12 @@ export const BitsuranceAccount = ({ code, accounts }: TProps) => {
 
   return (
     <GuideWrapper>
+      {firmwareUpgradeRequired && (
+        <FirmwareUpgradeRequiredDialog
+          open
+          onClose={dismissFirmwareUpgrade}
+        />
+      )}
       <GuidedContent>
         <Main>
           <Header title={<h2>{t('generic.buySell')}</h2>} />

--- a/frontends/web/src/routes/bitsurance/widget.tsx
+++ b/frontends/web/src/routes/bitsurance/widget.tsx
@@ -34,7 +34,6 @@ export const BitsuranceWidget = ({ code }: TProps) => {
   const { agreedTerms, setAgreedTerms } = useVendorTerms(config?.frontend.skipBitsuranceDisclaimer ?? false);
   useVendorIframeActive(agreedTerms && !!iframeURL);
   const signingRef = useRef(false);
-
   useEffect(() => {
     window.addEventListener('message', onMessage);
     return () => {

--- a/frontends/web/src/routes/market/bitrefill.tsx
+++ b/frontends/web/src/routes/market/bitrefill.tsx
@@ -57,7 +57,6 @@ export const Bitrefill = ({
 
   const [pendingPayment, setPendingPayment] = useState<boolean>(false);
   const [verifyPaymentRequest, setVerifyPaymentRequest] = useState<TTxProposalResult & { address: string } | false>(false);
-
   const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
 
   const handleConfiguration = useCallback(async (event: MessageEvent) => {

--- a/frontends/web/src/routes/market/btcdirect.tsx
+++ b/frontends/web/src/routes/market/btcdirect.tsx
@@ -53,7 +53,6 @@ export const BTCDirect = ({
   const btcdirectInfo = useAccountSynced(code, fetchBTCDirectInfo);
 
   const [blocking, setBlocking] = useState(false);
-
   const account = findAccount(accounts, code);
   const { containerRef, height, iframeLoaded, iframeRef, onIframeLoad } = useVendorIframeResizeHeight();
   const { agreedTerms, setAgreedTerms } = useVendorTerms(config?.frontend.skipBTCDirectWidgetDisclaimer ?? false);

--- a/frontends/web/src/routes/market/market.test.tsx
+++ b/frontends/web/src/routes/market/market.test.tsx
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../__mocks__/i18n';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/api/keystores', () => ({
+  connectAnyKeystore: vi.fn(),
+  connectKeystore: vi.fn(),
+}));
+vi.mock('@/components/dialog/dialog', () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/dialog/firmware-upgrade-required-dialog', () => ({
+  FirmwareUpgradeRequiredDialog: () => <div>firmware upgrade required</div>,
+}));
+vi.mock('@/components/forms', () => ({
+  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+}));
+vi.mock('@/components/groupedaccountselector/groupedaccountselector', () => ({
+  GroupedAccountSelector: () => null,
+}));
+vi.mock('@/components/infobutton/infobutton', () => ({
+  InfoButton: () => null,
+}));
+vi.mock('@/components/layout', () => ({
+  GuideWrapper: ({ children }: { children: ReactNode }) => <>{children}</>,
+  GuidedContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Header: () => null,
+  Main: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/spinner/Spinner', () => ({
+  Spinner: () => null,
+}));
+vi.mock('@/components/view/view', () => ({
+  View: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ViewContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/contexts/ConfigProvider', () => ({
+  useConfig: () => ({ config: { frontend: {} }, setConfig: vi.fn() }),
+}));
+vi.mock('@/hooks/api', () => ({
+  useLoad: () => undefined,
+}));
+vi.mock('@/hooks/vendor-iframe-terms', () => ({
+  useVendorTerms: () => ({ agreedTerms: true }),
+}));
+vi.mock('./components/countryselect', () => ({
+  CountrySelect: () => null,
+}));
+vi.mock('./components/deals', () => ({
+  Deals: ({ goToVendor }: { goToVendor: (vendor: 'bitrefill') => void }) => (
+    <button onClick={() => goToVendor('bitrefill')}>enter Bitrefill</button>
+  ),
+}));
+vi.mock('./components/infocontent', () => ({
+  getBTCDirectOTCLink: vi.fn(),
+  getPocketOTCLink: vi.fn(),
+  InfoContent: () => null,
+}));
+vi.mock('./components/markettab', () => ({
+  MarketTab: () => null,
+}));
+vi.mock('./guide', () => ({
+  MarketGuide: () => null,
+}));
+vi.mock('./market-context', () => ({
+  useMarketContext: () => ({
+    regions: [{ code: 'CH', name: 'Switzerland' }],
+    selectedRegion: 'CH',
+    setSelectedRegion: vi.fn(),
+  }),
+}));
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import type { TAccount } from '@/api/account';
+import { connectKeystore } from '@/api/keystores';
+import { Market } from './market';
+
+const account: TAccount = {
+  active: true,
+  blockExplorerTxPrefix: '',
+  code: 'btc-account',
+  coinCode: 'btc',
+  coinName: 'Bitcoin',
+  coinUnit: 'BTC',
+  isToken: false,
+  keystore: {
+    connected: false,
+    lastConnected: '',
+    name: 'BitBox02',
+    rootFingerprint: 'f23ab988',
+    watchonly: false,
+  },
+  name: 'Bitcoin Account',
+};
+
+const Location = () => {
+  const location = useLocation();
+  return <div>{location.pathname}{location.search}</div>;
+};
+
+describe('routes/market/market', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prompts for an upgrade before entering a signing workflow', async () => {
+    vi.mocked(connectKeystore).mockResolvedValue({
+      success: false,
+      errorCode: 'firmwareUpgradeRequired',
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/market/select/btc-account?tab=spend']}>
+        <Market accounts={[account]} code={account.code} />
+        <Location />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'enter Bitrefill' }));
+
+    await waitFor(() => {
+      expect(connectKeystore).toHaveBeenCalledWith(
+        account.keystore.rootFingerprint,
+        'btcTransactionSigning',
+      );
+    });
+    expect(await screen.findByText('firmware upgrade required')).toBeInTheDocument();
+    expect(screen.getByText('/market/select/btc-account?tab=spend')).toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/routes/market/market.tsx
+++ b/frontends/web/src/routes/market/market.tsx
@@ -13,7 +13,7 @@ import { useLoad } from '@/hooks/api';
 import { useVendorTerms } from '@/hooks/vendor-iframe-terms';
 import { Header, GuidedContent, GuideWrapper, Main } from '@/components/layout';
 import { MarketTab } from './components/markettab';
-import { getFallbackMarketAccountCode, getVendorFormattedName } from './utils';
+import { getFallbackMarketAccountCode, getRequiredKeystoreFeature, getVendorFormattedName } from './utils';
 import { Spinner } from '@/components/spinner/Spinner';
 import { Dialog } from '@/components/dialog/dialog';
 import { alertUser } from '@/components/alert/Alert';
@@ -23,11 +23,13 @@ import { useConfig } from '@/contexts/ConfigProvider';
 import { CountrySelect, TOption } from './components/countryselect';
 import { getBTCDirectOTCLink, getPocketOTCLink, InfoContent, TInfoContentProps } from './components/infocontent';
 import { GroupedAccountSelector } from '@/components/groupedaccountselector/groupedaccountselector';
-import { connectAnyKeystore, connectKeystore } from '@/api/keystores';
 import { open } from '@/api/system';
 import { useMarketContext } from './market-context';
 import { MarketGuide } from './guide';
 import { isBitcoinOnly } from '../account/utils';
+import { useFeatureConnect } from '@/hooks/keystore';
+import { FirmwareUpgradeRequiredDialog } from '@/components/dialog/firmware-upgrade-required-dialog';
+import type { TKeystoreFeature } from '@/api/keystores';
 import style from './market.module.css';
 
 type TProps = {
@@ -56,6 +58,12 @@ export const Market = ({
 
   const [info, setInfo] = useState<TInfoContentProps>();
   const selectedAccount = code || getFallbackMarketAccountCode(accounts);
+  const {
+    connect,
+    connectAny,
+    dismissFirmwareUpgrade,
+    firmwareUpgradeRequired,
+  } = useFeatureConnect();
 
   const {
     agreedTerms: agreedBTCDirectOTCTerms,
@@ -79,13 +87,15 @@ export const Market = ({
   const swapDealsResponse = useLoad(selectedAccount ? () => marketAPI.getMarketDeals('swap', selectedAccount, selectedRegion) : null, [selectedAccount, selectedRegion]);
   const otcDealsResponse = useLoad(selectedAccount ? () => marketAPI.getMarketDeals('otc', selectedAccount, selectedRegion) : null, [selectedAccount, selectedRegion]);
 
-  const promptConnectKeystore = async (accountCode: string): Promise<boolean> => {
+  const promptConnectKeystore = async (
+    accountCode: string,
+    requiredFeature?: TKeystoreFeature,
+  ): Promise<boolean> => {
     const account = accounts.find(acc => acc.code === accountCode);
     if (!account) {
       return false;
     }
-    const connectResult = await connectKeystore(account.keystore.rootFingerprint);
-    return connectResult.success;
+    return connect(account.keystore.rootFingerprint, requiredFeature);
   };
 
   const handleAccountChange = async (accountCode: string) => {
@@ -95,8 +105,8 @@ export const Market = ({
   };
 
   const handleGoToSwap = async () => {
-    const connectResult = await connectAnyKeystore();
-    if (!connectResult.success) {
+    const requiredFeature = getRequiredKeystoreFeature('swapkit', 'swap');
+    if (!await connectAny(requiredFeature)) {
       return;
     }
 
@@ -166,7 +176,12 @@ export const Market = ({
         return;
       }
     }
-    if (!selectedAccount || !await promptConnectKeystore(selectedAccount)) {
+    const account = accounts.find(({ code }) => code === selectedAccount);
+    if (!account) {
+      return;
+    }
+    const requiredFeature = getRequiredKeystoreFeature(vendor, activeTab, account.coinCode);
+    if (!await promptConnectKeystore(selectedAccount, requiredFeature)) {
       return;
     }
     navigate(`/market/${vendor}/${activeTab}/${selectedAccount}/${selectedRegion}`);
@@ -182,6 +197,12 @@ export const Market = ({
 
   return (
     <GuideWrapper>
+      {firmwareUpgradeRequired && (
+        <FirmwareUpgradeRequiredDialog
+          open
+          onClose={dismissFirmwareUpgrade}
+        />
+      )}
       <GuidedContent>
         <Main>
           <Header title={<h2>{t('generic.buySell')}</h2>} />

--- a/frontends/web/src/routes/market/pocket.tsx
+++ b/frontends/web/src/routes/market/pocket.tsx
@@ -8,7 +8,7 @@ import { useConfig } from '@/contexts/ConfigProvider';
 import { Dialog } from '@/components/dialog/dialog';
 import { confirmation } from '@/components/confirm/Confirm';
 import { verifyAddress, getPocketURL, TMarketAction } from '@/api/market';
-import { AccountCode, getInfo, getTransactionList, hasPaymentRequest, signBTCMessageUnusedAddress, proposeTx, sendTx, TTxInput } from '@/api/account';
+import { AccountCode, getInfo, getTransactionList, signBTCMessageUnusedAddress, proposeTx, sendTx, TTxInput } from '@/api/account';
 import { Header } from '@/components/layout';
 import { MobileHeader } from '../settings/components/mobile-header';
 import { Spinner } from '@/components/spinner/Spinner';
@@ -20,7 +20,6 @@ import { alertUser } from '@/components/alert/Alert';
 import { MarketGuide } from './guide';
 import { convertScriptType } from '@/utils/request-addess';
 import { parseExternalBtcAmount } from '@/api/coins';
-import { FirmwareUpgradeRequiredDialog } from '@/components/dialog/firmware-upgrade-required-dialog';
 import { useMarketIframeActive, useVendorIframeResizeHeight, useVendorTerms } from '@/hooks/vendor-iframe';
 import { useAccountSynced } from '@/hooks/account';
 import { Message } from '@/components/message/message';
@@ -39,10 +38,6 @@ export const Pocket = ({
   const { config } = useConfig();
   const navigate = useNavigate();
 
-  // Pocket sell only works if the FW supports payment requests
-  const hasPaymentRequestResponse = useLoad(() => hasPaymentRequest(code));
-  const [fwRequiredDialog, setFwRequiredDialog] = useState(false);
-
   const [blocking, setBlocking] = useState(false);
   const [verifying, setVerifying] = useState(false);
 
@@ -54,19 +49,6 @@ export const Pocket = ({
 
   const pocketInfo = useAccountSynced(code, useCallback(() => getPocketURL(action), [action]));
   useMarketIframeActive(!!config && agreedTerms && pocketInfo?.success === true);
-
-  useEffect(() => {
-    // enable paymentRequestError only when the action is sell.
-    if (action === 'sell' && hasPaymentRequestResponse?.success === false) {
-      if (hasPaymentRequestResponse?.errorCode === 'firmwareUpgradeRequired') {
-        setFwRequiredDialog(true);
-      } else if (hasPaymentRequestResponse?.errorCode) {
-        alertUser(t('device.' + hasPaymentRequestResponse.errorCode));
-      } else if (hasPaymentRequestResponse?.errorMessage) {
-        alertUser(hasPaymentRequestResponse?.errorMessage);
-      }
-    }
-  }, [action, hasPaymentRequestResponse, t]);
 
   useEffect(() => {
     window.addEventListener('message', onMessage);
@@ -355,13 +337,6 @@ export const Pocket = ({
             {t('buy.pocket.verifyBitBox02')}
             <PointToBitBox02 />
           </Dialog>
-          <FirmwareUpgradeRequiredDialog
-            open={fwRequiredDialog}
-            onClose={() => {
-              setFwRequiredDialog(false);
-              navigate(-1);
-            }}
-          />
         </div>
       </div>
       <MarketGuide vendor="pocket" translationContext="bitcoin" />

--- a/frontends/web/src/routes/market/swap/swap.test.tsx
+++ b/frontends/web/src/routes/market/swap/swap.test.tsx
@@ -76,7 +76,6 @@ vi.mock('@/api/account', async (importOriginal) => {
   return {
     ...actual,
     getBalance: vi.fn(),
-    hasSwapPaymentRequest: vi.fn(),
     proposeTx: vi.fn(),
     sendTx: vi.fn(),
   };

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -5,7 +5,6 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   getBalance,
-  hasSwapPaymentRequest,
   proposeTx,
   sendTx,
   TBalance,
@@ -25,7 +24,6 @@ import {
   type TSwapQuoteErrorCode,
   type TSwapQuoteRoute,
 } from '@/api/swap';
-import { FirmwareUpgradeRequiredDialog } from '@/components/dialog/firmware-upgrade-required-dialog';
 import { GuideWrapper, GuidedContent, Main, Header } from '@/components/layout';
 import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
@@ -123,8 +121,6 @@ export const Swap = ({
   }>();
   const [result, setResult] = useState<TSendTx | undefined>();
   const [canFlip, setCanFlip] = useState<boolean>(false);
-  const [fwRequiredDialog, setFwRequiredDialog] = useState(false);
-
   const [routes, setRoutes] = useState<TSwapQuoteRoute[]>([]);
   const [selectedRouteId, setSelectedRouteId] = useState<string | undefined>();
   const [isFetchingRoutes, setIsFetchingRoutes] = useState<boolean>(false);
@@ -410,18 +406,6 @@ export const Swap = ({
         return;
       }
 
-      const paymentRequestSupport = await hasSwapPaymentRequest(sellAccountCode);
-      if (!paymentRequestSupport.success) {
-        if (paymentRequestSupport.errorCode === 'firmwareUpgradeRequired') {
-          setFwRequiredDialog(true);
-        } else if (paymentRequestSupport.errorCode) {
-          alertUser(t(`device.${paymentRequestSupport.errorCode}`));
-        } else {
-          alertUser(paymentRequestSupport.errorMessage || t('genericError'));
-        }
-        return;
-      }
-
       setResult(undefined);
       setConfirmDetails(undefined);
 
@@ -562,10 +546,6 @@ export const Swap = ({
   return (
     <GuideWrapper>
       <GuidedContent>
-        <FirmwareUpgradeRequiredDialog
-          open={fwRequiredDialog}
-          onClose={() => setFwRequiredDialog(false)}
-        />
         <Main>
           <Header
             hideSidebarToggler

--- a/frontends/web/src/routes/market/utils.test.ts
+++ b/frontends/web/src/routes/market/utils.test.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { getRequiredKeystoreFeature } from './utils';
+
+describe('getRequiredKeystoreFeature', () => {
+  it.each([
+    ['pocket', 'buy', 'btc', 'messageSigning'],
+    ['pocket', 'sell', 'btc', 'paymentRequests'],
+    ['btcdirect', 'sell', 'btc', 'btcTransactionSigning'],
+    ['btcdirect', 'sell', 'eth', 'ethTransactionSigning'],
+    ['btcdirect', 'sell', 'eth-erc20-usdt', 'ethTransactionSigning'],
+    ['bitrefill', 'spend', 'ltc', 'btcTransactionSigning'],
+    ['bitrefill', 'spend', 'eth', 'ethTransactionSigning'],
+    ['swapkit', 'swap', 'btc', 'swapPaymentRequests'],
+  ] as const)('maps %s %s with %s', (vendor, action, coinCode, expected) => {
+    expect(getRequiredKeystoreFeature(vendor, action, coinCode)).toBe(expected);
+  });
+
+  it('does not require signing support for non-signing workflows', () => {
+    expect(getRequiredKeystoreFeature('btcdirect', 'buy', 'btc')).toBeUndefined();
+    expect(getRequiredKeystoreFeature('moonpay', 'buy', 'btc')).toBeUndefined();
+  });
+});

--- a/frontends/web/src/routes/market/utils.ts
+++ b/frontends/web/src/routes/market/utils.ts
@@ -1,12 +1,41 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { TVendorName } from '@/api/market';
-import type { TAccount } from '@/api/account';
+import type { TMarketAction, TVendorName } from '@/api/market';
+import type { CoinCode, TAccount } from '@/api/account';
+import type { TKeystoreFeature } from '@/api/keystores';
+import { isEthereumBased } from '@/routes/account/utils';
 
 export const getFallbackMarketAccountCode = (accounts: TAccount[]) => {
   return accounts.find(account => account.keystore.connected)?.code
     || accounts[0]?.code
     || '';
+};
+
+const transactionSigningFeature = (coinCode: CoinCode): TKeystoreFeature => {
+  return isEthereumBased(coinCode) ? 'ethTransactionSigning' : 'btcTransactionSigning';
+};
+
+export const getRequiredKeystoreFeature = (
+  vendor: TVendorName,
+  action: TMarketAction,
+  coinCode?: CoinCode,
+): TKeystoreFeature | undefined => {
+  if (action === 'swap') {
+    return 'swapPaymentRequests';
+  }
+  if (vendor === 'pocket' && action === 'buy') {
+    return 'messageSigning';
+  }
+  if (vendor === 'pocket' && action === 'sell') {
+    return 'paymentRequests';
+  }
+  if (vendor === 'btcdirect' && action === 'sell' && coinCode) {
+    return transactionSigningFeature(coinCode);
+  }
+  if (vendor === 'bitrefill' && action === 'spend' && coinCode) {
+    return transactionSigningFeature(coinCode);
+  }
+  return undefined;
 };
 
 /**

--- a/frontends/web/src/utils/walletconnect-eth-sign-handlers.ts
+++ b/frontends/web/src/utils/walletconnect-eth-sign-handlers.ts
@@ -60,6 +60,7 @@ export type TSignDialogResult = {
 } | {
   success: false;
   aborted?: boolean;
+  errorCode?: 'firmwareUpgradeRequired';
   errorMessage?: string;
 };
 
@@ -84,6 +85,7 @@ type TAccountDetails = {
 type TFailedSigningApiResult = {
   success: false;
   aborted?: boolean;
+  errorCode?: 'firmwareUpgradeRequired';
   errorMessage?: string;
 };
 


### PR DESCRIPTION
Reject transaction and message signing on firmware versions that predate
the relevant antiklepto support.

Check required signing features at each workflow's existing keystore connection,
so firmware upgrades are prompted immediately after connecting.

  - [ ] Normal BTC/LTC transaction send
  - [ ] Normal ETH/ERC20 transaction send
  - [ ] Bitrefill checkout payment
  - [ ] BTC Direct sell/payment
  - [ ] Pocket sell payment
  - [ ] Swap sell transaction
  - [ ] Account message signing, BTC or ETH
  - [ ] AOPP ownership proof, BTC or ETH
  - [ ] Pocket address ownership proof
  - [ ] Bitsurance address ownership proof
  - [ ] WalletConnect plain message signing, eth_sign or personal_sign
  - [ ] WalletConnect transaction signing, eth_signTransaction or eth_sendTransaction
  - [ ] WalletConnect typed-data signing, using any one typed-data variant