### PR TITLE
Use gap limit 20 for change address discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Bitcoin: display zero amounts without decimal places
 - Add option to navigate to "Used addresses" in sign-message workflow
 - Floating mobile bottom navigation bar
+- Increase default change gap limit to 20
 
 ## v4.51.3
 - Bundle BitBox02 and BitBox02 Nova firmware version v9.26.4

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -174,7 +174,7 @@ func (account *Account) defaultGapLimits(signingConfiguration *signing.Configura
 		// Usually 20, but BWS used to not have any limit. We put it fairly high to cover most
 		// outliers.
 		limits.Receive = 60
-		account.log.Warning("increased change gap limit to 20 and gap limit to 60 for BWS compatibility")
+		account.log.Warning("increased change gap limit to 25 and gap limit to 60 for BWS compatibility")
 	}
 
 	return limits

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -163,11 +163,10 @@ func (account *Account) String() string {
 func (account *Account) defaultGapLimits(signingConfiguration *signing.Configuration) types.GapLimits {
 	limits := types.GapLimits{
 		Receive: 20,
-		Change:  6,
+		Change:  20,
 	}
 
 	if signingConfiguration.ScriptType() == signing.ScriptTypeP2PKH {
-		// Usually 6, but BWS uses 20, so for legacy accounts, we have to do that too.
 		// We increase it a bit more as some users still had change buried a bit deeper.
 		limits.Change = 25
 

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -261,6 +261,7 @@ func NewConfig(appConfigFilename string, accountsConfigFilename string) (*Config
 	migrateFiatList(&appconf)
 	migrateFiatCode(&appconf)
 	migrateElectrumX(&appconf)
+	migrateGapLimitChange(&appconf)
 	migrateUserLanguage(&appconf)
 	if err := config.SetAppConfig(appconf); err != nil {
 		return nil, errp.WithStack(err)
@@ -499,5 +500,14 @@ func migrateUserLanguage(appconf *AppConfig) {
 	if lang, ok := frontconf["userLanguage"].(string); ok {
 		appconf.Backend.UserLanguage = lang
 		delete(frontconf, "userLanguage")
+	}
+}
+
+// migrateGapLimitChange raises a configured change gap limit to the new minimum. Zero is kept as
+// the sentinel value for using the account default.
+func migrateGapLimitChange(appconf *AppConfig) {
+	const minimumGapLimitChange = 20
+	if appconf.Backend.GapLimitChange > 0 && appconf.Backend.GapLimitChange < minimumGapLimitChange {
+		appconf.Backend.GapLimitChange = minimumGapLimitChange
 	}
 }

--- a/backend/config/config_test.go
+++ b/backend/config/config_test.go
@@ -109,6 +109,7 @@ func TestMigrationsAtLoad(t *testing.T) {
 	cfg, err := NewConfig(appConfigFilename, accountsConfigFilename)
 	require.NoError(t, err)
 	appCfg := cfg.AppConfig()
+	appCfg.Backend.GapLimitChange = 6
 	appCfg.Frontend = map[string]interface{}{
 		"userLanguage": "de",
 	}
@@ -122,6 +123,7 @@ func TestMigrationsAtLoad(t *testing.T) {
 	// Loading the conf applies the migrations.
 	cfg2, err := NewConfig(appConfigFilename, accountsConfigFilename)
 	require.NoError(t, err)
+	require.Equal(t, 20, cfg2.AppConfig().Backend.GapLimitChange)
 	require.Equal(t, "de", cfg2.AppConfig().Backend.UserLanguage)
 	require.Equal(t,
 		[]*Account{{CoinCode: coin.CodeETH, ActiveTokens: nil}},
@@ -131,6 +133,31 @@ func TestMigrationsAtLoad(t *testing.T) {
 	cfg3, err := NewConfig(appConfigFilename, accountsConfigFilename)
 	require.NoError(t, err)
 	require.Equal(t, cfg2, cfg3)
+}
+
+func TestMigrateGapLimitChange(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    int
+		expected int
+	}{
+		{name: "default", value: 0, expected: 0},
+		{name: "below old minimum", value: 5, expected: 20},
+		{name: "old minimum", value: 6, expected: 20},
+		{name: "below new minimum", value: 19, expected: 20},
+		{name: "new minimum", value: 20, expected: 20},
+		{name: "above new minimum", value: 21, expected: 21},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			appConfig := AppConfig{Backend: Backend{GapLimitChange: test.value}}
+
+			migrateGapLimitChange(&appConfig)
+
+			require.Equal(t, test.expected, appConfig.Backend.GapLimitChange)
+		})
+	}
 }
 
 func requirePrivateFileMode(t *testing.T, filename string) {

--- a/frontends/web/src/routes/settings/components/advanced-settings/custom-gap-limit-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/custom-gap-limit-setting.tsx
@@ -10,7 +10,7 @@ import { Message } from '@/components/message/message';
 import { useMediaQuery } from '@/hooks/mediaquery';
 
 const DEFAULT_GAP_LIMIT_RECEIVE = 20;
-const DEFAULT_GAP_LIMIT_CHANGE = 6;
+const DEFAULT_GAP_LIMIT_CHANGE = 20;
 const MAX_LIMIT = 2000;
 
 export const CustomGapLimitSettings = () => {

--- a/frontends/web/tests/gapSettings.test.ts
+++ b/frontends/web/tests/gapSettings.test.ts
@@ -43,9 +43,9 @@ test('Gap limits are correctly saved', async ({ page, host, frontendPort, servew
     const changeInput = page.locator('#gapLimitChange');
     await changeInput.clear();
     await changeInput.click();
-    await page.keyboard.press('1');
+    await page.keyboard.press('3');
     await expect(page.locator('label[for="gapLimitChange"]')).toHaveText(
-      'Gap limit for change addresses: The gap limit must be at least 6.'
+      'Gap limit for change addresses: The gap limit must be at least 20.'
     );
     await page.waitForTimeout(1000);
     await expect(changeInput).toBeFocused();
@@ -60,7 +60,7 @@ test('Gap limits are correctly saved', async ({ page, host, frontendPort, servew
     const recvInput = page.locator('#gapLimitReceive');
     await expect(recvInput).toHaveValue('50');
     const changeInput = page.locator('#gapLimitChange');
-    await expect(changeInput).toHaveValue('10');
+    await expect(changeInput).toHaveValue('30');
   });
 });
 


### PR DESCRIPTION
Use the commonly adopted gap limit of 20 when discovering UTXOs on change addresses generated by other wallets.

Hardware wallets used with other apps commonly use a gap limit of 20. As a result, those apps may generate change addresses beyond the BitBoxApp's previous gap limit of 6, preventing the BitBoxApp from discovering the corresponding addresses and UTXOs.

Since not all users will recognize this issue or know how to adjust the gap limit manually, use the more common value of 20 by default.

Reviewed with AI.

Tested on Linux and Android.