### PR TITLE
docs: clarify local development setup order

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ full node.
 
 Run `make envinit` to fetch golangci-lint and some other devtools.
 
-Run `make servewallet` and `make webdev` in separate terminals.
+Before the first use of `make webdev`, and after any change to the frontend dependencies, run
+`make buildweb` to install the web dev dependencies.
 
-Before the first use of `make webdev`, you also need to run `make buildweb`, to install the dev
-dependencies.
+Then run `make servewallet` (backend) and `make webdev` (frontend dev server) in separate
+terminals.
 
 #### Local development with BB02 simulator
 


### PR DESCRIPTION
## Problem

The **Local development** section of the README lists the commands out of order:

> Run `make servewallet` and `make webdev` in separate terminals.
>
> Before the first use of `make webdev`, you also need to run `make buildweb`, to install the dev dependencies.

The prerequisite (`make buildweb`) is mentioned *after* the command that depends on it, so a first-time contributor following the instructions top-to-bottom will run `make webdev` before the web dependencies are installed.

## Change

Reorders the section into two numbered terminal steps, putting `make buildweb` ahead of `make webdev` where it's actually needed, and clarifies that `make buildweb` is a one-time (or after-dependency-change) step rather than something to run on every session.