### PR TITLE
lightning: enforce minimum top-up amount

### DIFF
--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -61,6 +61,7 @@ func (lightning *Lightning) PostPrepareTopUp(r *http.Request) interface{} {
 		Success      bool          `json:"success"`
 		ErrorCode    string        `json:"errorCode,omitempty"`
 		FundingLimit *fundingLimit `json:"fundingLimit,omitempty"`
+		MinAmountSat uint64        `json:"minAmountSat,omitempty"`
 		*topUpProposal
 	}
 
@@ -76,14 +77,24 @@ func (lightning *Lightning) PostPrepareTopUp(r *http.Request) interface{} {
 		return responseDto{Success: true, Data: result{Success: true, topUpProposal: proposal}}
 	}
 
-	if limitErr, ok := err.(*topUpFundingLimitError); ok {
+	var limitErr *topUpFundingLimitError
+	if errors.As(err, &limitErr) {
 		return responseDto{Success: true, Data: result{
 			Success:      false,
 			ErrorCode:    string(errLightningBalanceLimitExceeded),
 			FundingLimit: &limitErr.fundingLimit,
 		}}
 	}
-	if validationErr, ok := errp.Cause(err).(accountErrors.TxValidationError); ok {
+	var amountBelowMinimum *lightningAmountBelowMinimumError
+	if errors.As(err, &amountBelowMinimum) {
+		return responseDto{Success: true, Data: result{
+			Success:      false,
+			ErrorCode:    string(errLightningAmountBelowMinimum),
+			MinAmountSat: amountBelowMinimum.minAmountSat,
+		}}
+	}
+	var validationErr accountErrors.TxValidationError
+	if errors.As(err, &validationErr) {
 		return responseDto{Success: true, Data: result{Success: false, ErrorCode: validationErr.Error()}}
 	}
 	return errorResponse(err)

--- a/backend/lightning/topup.go
+++ b/backend/lightning/topup.go
@@ -12,6 +12,8 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 )
 
+const minimumTopUpAmountSat = 1000
+
 const errLightningBalanceLimitExceeded errp.ErrorCode = "lightningBalanceLimitExceeded"
 
 type prepareTopUpRequest struct {
@@ -41,7 +43,15 @@ func parseTopUpAmount(accountCoin coin.Coin, amount string) (coin.Amount, error)
 	if accountCoin.GetFormatUnit(false) == string(coin.BtcUnitSats) {
 		unit = big.NewInt(1)
 	}
-	return coin.NewSendAmount(amount).Amount(unit, false)
+	return coin.NewSendAmount(amount).Amount(unit, true)
+}
+
+func validateTopUpAmount(amount coin.Amount) error {
+	minimumTopUpAmount := big.NewInt(minimumTopUpAmountSat)
+	if amount.BigInt().Cmp(minimumTopUpAmount) < 0 {
+		return &lightningAmountBelowMinimumError{minAmountSat: minimumTopUpAmountSat}
+	}
+	return nil
 }
 
 // PrepareTopUp validates the Lightning funding limit and creates the Bitcoin transaction proposal
@@ -57,6 +67,9 @@ func (lightning *Lightning) PrepareTopUp(request prepareTopUpRequest) (*topUpPro
 
 	amount, err := parseTopUpAmount(account.Coin(), request.Amount)
 	if err != nil {
+		return nil, err
+	}
+	if err := validateTopUpAmount(amount); err != nil {
 		return nil, err
 	}
 	_, limit, err := lightning.balanceWithFundingLimit()

--- a/backend/lightning/topup_test.go
+++ b/backend/lightning/topup_test.go
@@ -114,6 +114,34 @@ func TestPrepareTopUp(t *testing.T) {
 	require.Equal(t, coin.NewAmountFromInt64(125_000), parsedAmount)
 }
 
+func TestPrepareTopUpRejectsAmountBelowMinimumBeforeCreatingProposal(t *testing.T) {
+	for _, amount := range []string{"0", "0.00000999"} {
+		t.Run(amount, func(t *testing.T) {
+			sdk := &topUpTestSDK{balanceSat: 50_000, incomingSat: 25_000}
+			lightning := makeActiveLightningWithSDK(t, sdk)
+			account := testTopUpAccount(t, lightning, func(*accounts.TxProposalArgs) (
+				coin.Amount, coin.Amount, coin.Amount, error,
+			) {
+				t.Fatal("must not create a below-minimum transaction proposal")
+				return coin.Amount{}, coin.Amount{}, coin.Amount{}, nil
+			})
+
+			proposal, err := lightning.PrepareTopUp(prepareTopUpRequest{
+				SourceAccountCode: testTopUpSourceAccountCode,
+				Amount:            amount,
+				FeeTarget:         "economy",
+			})
+
+			require.Nil(t, proposal)
+			var amountBelowMinimum *lightningAmountBelowMinimumError
+			require.ErrorAs(t, err, &amountBelowMinimum)
+			require.Equal(t, uint64(minimumTopUpAmountSat), amountBelowMinimum.minAmountSat)
+			require.Empty(t, account.TxProposalCalls())
+			require.Zero(t, sdk.receiveCallCount)
+		})
+	}
+}
+
 func TestPrepareTopUpRejectsAmountAboveFundingLimitBeforeCreatingProposal(t *testing.T) {
 	sdk := &topUpTestSDK{balanceSat: 50_000, incomingSat: 25_000}
 	lightning := makeActiveLightningWithSDK(t, sdk)
@@ -136,4 +164,12 @@ func TestPrepareTopUpRejectsAmountAboveFundingLimitBeforeCreatingProposal(t *tes
 	require.Equal(t, fundingLimit{LimitSat: 200_000, MarginSat: 125_000}, limitErr.fundingLimit)
 	require.Empty(t, account.TxProposalCalls())
 	require.Zero(t, sdk.receiveCallCount)
+}
+
+func TestValidateTopUpAmount(t *testing.T) {
+	err := validateTopUpAmount(coin.NewAmountFromInt64(minimumTopUpAmountSat - 1))
+	var amountBelowMinimum *lightningAmountBelowMinimumError
+	require.ErrorAs(t, err, &amountBelowMinimum)
+	require.Equal(t, uint64(minimumTopUpAmountSat), amountBelowMinimum.minAmountSat)
+	require.NoError(t, validateTopUpAmount(coin.NewAmountFromInt64(minimumTopUpAmountSat)))
 }

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -81,6 +81,10 @@ export type TPrepareTopUpResult = {
   fundingLimit: TLightningFundingLimit;
   success: false;
 } | {
+  errorCode: TLightningErrorCode.AMOUNT_BELOW_MINIMUM;
+  minAmountSat: number;
+  success: false;
+} | {
   errorCode: TTxProposalErrorCode;
   success: false;
 };

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1884,7 +1884,6 @@
       },
       "from": "From",
       "noBitcoinAccounts": "No Bitcoin accounts active. Please activate a Bitcoin account.",
-      "noFundedBitcoinAccounts": "No Bitcoin accounts with an available balance. Receive Bitcoin before trying to top up again.",
       "note": "Lightning top-up",
       "success": {
         "message": "Top up created!",

--- a/frontends/web/src/routes/lightning/topup/topup-form.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup-form.tsx
@@ -54,6 +54,7 @@ type TProps = {
   isSubmitting: boolean;
   isUpdatingProposal: boolean;
   lightningBalance?: TBalance;
+  minimumAmountError?: string;
   note: string;
   onAmountChange: (value: string) => void;
   onBack: () => void;
@@ -82,6 +83,7 @@ export const TopUpForm = ({
   isSubmitting,
   isUpdatingProposal,
   lightningBalance,
+  minimumAmountError,
   note,
   onAmountChange,
   onBack,
@@ -144,7 +146,7 @@ export const TopUpForm = ({
                     label={sourceAmountUnit}
                     id="topUpAmount"
                     onChange={onAmountChange}
-                    error={errorHandling.amountError}
+                    error={minimumAmountError || errorHandling.amountError}
                     value={amount}
                     placeholder={t('send.amount.placeholder')}
                   />

--- a/frontends/web/src/routes/lightning/topup/topup-result.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup-result.tsx
@@ -2,7 +2,6 @@
 
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import type { TAccount } from '@/api/account';
 import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
@@ -16,10 +15,6 @@ type TTopUpAbortedProps = {
 
 type TTopUpNoBitcoinAccountsProps = {
   hasAccounts: boolean;
-};
-
-type TTopUpNoFundedBitcoinAccountsProps = {
-  btcAccounts: TAccount[];
 };
 
 export const TopUpSuccess = () => {
@@ -86,45 +81,6 @@ export const TopUpNoBitcoinAccounts = ({ hasAccounts }: TTopUpNoBitcoinAccountsP
             <ViewButtons>
               <Button primary onClick={() => navigate(primaryAction.route)}>
                 {primaryAction.label}
-              </Button>
-              <DesktopBackButton onClick={() => navigate('/lightning')}>
-                {t('button.back')}
-              </DesktopBackButton>
-            </ViewButtons>
-          </View>
-        </Main>
-      </GuidedContent>
-    </GuideWrapper>
-  );
-};
-
-export const TopUpNoFundedBitcoinAccounts = ({ btcAccounts }: TTopUpNoFundedBitcoinAccountsProps) => {
-  const { t } = useTranslation();
-  const navigate = useNavigate();
-  const receiveRoute = btcAccounts.length === 1 && btcAccounts[0]
-    ? `/account/${btcAccounts[0].code}/receive`
-    : '/accounts/select-receive/bitcoin';
-
-  return (
-    <GuideWrapper>
-      <GuidedContent>
-        <Main>
-          <Header title={
-            <>
-              <h2 className="hide-on-small">{t('lightning.topUp.title')}</h2>
-              <MobileHeader
-                onClick={() => navigate('/lightning')}
-                title={t('lightning.topUp.title')}
-              />
-            </>
-          } />
-          <View textCenter verticallyCentered>
-            <ViewContent>
-              <p>{t('lightning.topUp.noFundedBitcoinAccounts')}</p>
-            </ViewContent>
-            <ViewButtons>
-              <Button primary onClick={() => navigate(receiveRoute)}>
-                {t('generic.receive', { context: 'bitcoin' })}
               </Button>
               <DesktopBackButton onClick={() => navigate('/lightning')}>
                 {t('button.back')}

--- a/frontends/web/src/routes/lightning/topup/topup.test.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup.test.tsx
@@ -9,6 +9,7 @@ import * as accountApi from '@/api/account';
 import * as coinsApi from '@/api/coins';
 import * as keystoresApi from '@/api/keystores';
 import * as lightningApi from '@/api/lightning';
+import { TLightningErrorCode } from '@/api/lightning-errors';
 import { RatesContext } from '@/contexts/RatesContext';
 import { LightningTopUp } from './topup';
 
@@ -17,14 +18,20 @@ vi.mock('@/i18n/i18n');
 vi.mock('./topup-form', () => ({
   TopUpForm: ({
     balanceLimitError,
+    btcAccounts,
     canReview,
+    errorHandling,
+    minimumAmountError,
     onAmountChange,
     onFeeTargetChange,
     onReview,
     sendError,
   }: {
     balanceLimitError?: string;
+    btcAccounts: accountApi.TAccount[];
     canReview: boolean;
+    errorHandling: { amountError?: string };
+    minimumAmountError?: string;
     onAmountChange: (amount: string) => void;
     onFeeTargetChange: (feeTarget: accountApi.FeeTargetCode) => void;
     onReview: () => void;
@@ -34,7 +41,10 @@ vi.mock('./topup-form', () => ({
       <button onClick={() => onAmountChange('100000')}>Set amount</button>
       <button onClick={() => onFeeTargetChange('economy')}>Set fee target</button>
       <button disabled={!canReview} onClick={onReview}>Review</button>
+      <span data-testid="btc-accounts">{btcAccounts.map(account => account.code).join(',')}</span>
       <span data-testid="balance-limit-error">{balanceLimitError}</span>
+      <span data-testid="amount-error">{minimumAmountError || errorHandling.amountError}</span>
+      <span data-testid="fiat-amount-error">{errorHandling.amountError}</span>
       <span data-testid="send-error">{sendError}</span>
     </>
   ),
@@ -79,7 +89,7 @@ const lightningBalance = (marginSat = 150000): lightningApi.TLightningBalance =>
   incoming: amount('0'),
 });
 
-const renderTopUp = () => render(
+const renderTopUp = (activeAccounts = [account]) => render(
   <MemoryRouter>
     <RatesContext.Provider value={{
       defaultCurrency: 'USD',
@@ -91,7 +101,7 @@ const renderTopUp = () => render(
       updateDefaultCurrency: vi.fn(),
       removeFromActiveCurrencies: vi.fn(),
     }}>
-      <LightningTopUp activeAccounts={[account]} hasAccounts />
+      <LightningTopUp activeAccounts={activeAccounts} hasAccounts />
     </RatesContext.Provider>
   </MemoryRouter>
 );
@@ -99,8 +109,29 @@ const renderTopUp = () => render(
 describe('LightningTopUp', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    vi.spyOn(accountApi, 'getBalance').mockResolvedValue({ success: true, balance: lightningBalance() });
     vi.spyOn(lightningApi, 'subscribeLightningBalance').mockReturnValue(vi.fn());
+  });
+
+  it('shows every Bitcoin account without loading its balance', async () => {
+    const emptyAccount: accountApi.TAccount = {
+      ...account,
+      code: 'empty-btc-account',
+      name: 'Empty Bitcoin Account',
+      keystore: {
+        ...account.keystore,
+        connected: false,
+      },
+    };
+    const getBalance = vi.spyOn(accountApi, 'getBalance').mockResolvedValue({
+      success: true,
+      balance: lightningBalance(200000),
+    });
+    vi.spyOn(lightningApi, 'getLightningBalance').mockResolvedValue(lightningBalance());
+
+    renderTopUp([account, emptyAccount]);
+
+    expect(await screen.findByTestId('btc-accounts')).toHaveTextContent('btc-account,empty-btc-account');
+    expect(getBalance).not.toHaveBeenCalled();
   });
 
   it('prepares and sends a top-up through the dedicated endpoint', async () => {
@@ -152,6 +183,26 @@ describe('LightningTopUp', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Set fee target' }));
 
     await waitFor(() => expect(screen.getByTestId('balance-limit-error')).toHaveTextContent('Maximum top-up amount'));
+    expect(screen.getByRole('button', { name: 'Review' })).toBeDisabled();
+  });
+
+  it('shows the minimum-amount error returned by the prepare endpoint', async () => {
+    vi.spyOn(lightningApi, 'getLightningBalance').mockResolvedValue(lightningBalance());
+    vi.spyOn(lightningApi, 'postPrepareTopUp').mockResolvedValue({
+      success: false,
+      errorCode: TLightningErrorCode.AMOUNT_BELOW_MINIMUM,
+      minAmountSat: 1000,
+    });
+    vi.spyOn(coinsApi, 'convertToCurrency').mockResolvedValue({ success: true, fiatAmount: '0.01' });
+    renderTopUp();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Set amount' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Set fee target' }));
+
+    await waitFor(() => expect(screen.getByTestId('amount-error')).toHaveTextContent(
+      'The amount must be at least 1000 sats.'
+    ));
+    expect(screen.getByTestId('fiat-amount-error')).toBeEmptyDOMElement();
     expect(screen.getByRole('button', { name: 'Review' })).toBeDisabled();
   });
 });

--- a/frontends/web/src/routes/lightning/topup/topup.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup.tsx
@@ -12,8 +12,9 @@ import {
   subscribeLightningBalance,
   type TPrepareTopUpResult,
 } from '@/api/lightning';
+import { TLightningErrorCode } from '@/api/lightning-errors';
 import { connectKeystore } from '@/api/keystores';
-import { useLoad, useSync } from '@/hooks/api';
+import { useSync } from '@/hooks/api';
 import { useMountedRef } from '@/hooks/mount';
 import { usePrevious } from '@/hooks/previous';
 import { getDisplayedCoinUnit, isBitcoinOnly } from '@/routes/account/utils';
@@ -21,7 +22,7 @@ import { txProposalErrorHandling, type TProposalError } from '@/routes/account/s
 import { RatesContext } from '@/contexts/RatesContext';
 import { TopUpConfirm } from './topup-confirm';
 import { TopUpForm } from './topup-form';
-import { TopUpAborted, TopUpNoBitcoinAccounts, TopUpNoFundedBitcoinAccounts, TopUpSuccess } from './topup-result';
+import { TopUpAborted, TopUpNoBitcoinAccounts, TopUpSuccess } from './topup-result';
 import {
   formatLightningFundingLimit,
   formatRemainingLightningFundingLimit,
@@ -33,19 +34,6 @@ type TProps = {
 };
 
 type TStep = 'form' | 'confirming' | 'success' | 'aborted';
-
-const getTopUpAccounts = async (accounts: accountApi.TAccount[]) => {
-  const accountHasBalance = await Promise.all(accounts.map(async (account) => {
-    try {
-      const balance = await accountApi.getBalance(account.code);
-      return !balance.success || balance.balance.hasAvailable;
-    } catch {
-      return true;
-    }
-  }));
-
-  return accounts.filter((_, index) => accountHasBalance[index]);
-};
 
 export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
   const { t } = useTranslation();
@@ -62,9 +50,8 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
     () => activeAccounts.filter(account => account.active && account.coinCode === 'btc'),
     [activeAccounts]
   );
-  const topUpAccounts = useLoad(() => getTopUpAccounts(btcAccounts), [btcAccounts]);
   const [sourceAccountCode, setSourceAccountCode] = useState<accountApi.AccountCode>('');
-  const sourceAccount = topUpAccounts?.find(account => account.code === sourceAccountCode);
+  const sourceAccount = btcAccounts.find(account => account.code === sourceAccountCode);
   const lightningBalance = useSync(getLightningBalance, subscribeLightningBalance);
   const sourceAmountUnit = sourceAccount
     ? getDisplayedCoinUnit(sourceAccount.coinCode, sourceAccount.coinUnit, btcUnit)
@@ -89,27 +76,28 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
       remaining: formatRemainingLightningFundingLimit(proposal.fundingLimit),
     })
     : undefined;
+  const amountValidationError = proposal?.success === false
+    && proposal.errorCode === TLightningErrorCode.AMOUNT_BELOW_MINIMUM
+    ? t('error.lightningAmountBelowMinimum', { minAmountSat: proposal.minAmountSat })
+    : undefined;
 
   useEffect(() => {
     stepRef.current = step;
   }, [step]);
 
   useEffect(() => {
-    if (topUpAccounts === undefined) {
-      return;
-    }
-    if (!topUpAccounts.length) {
+    if (!btcAccounts.length) {
       setSourceAccountCode('');
       return;
     }
-    if (!sourceAccountCode || !topUpAccounts.some(account => account.code === sourceAccountCode)) {
+    if (!sourceAccountCode || !btcAccounts.some(account => account.code === sourceAccountCode)) {
       setSourceAccountCode(
-        topUpAccounts.find(account => account.keystore.connected)?.code
-          || topUpAccounts[0]?.code
+        btcAccounts.find(account => account.keystore.connected)?.code
+          || btcAccounts[0]?.code
           || ''
       );
     }
-  }, [sourceAccountCode, topUpAccounts]);
+  }, [btcAccounts, sourceAccountCode]);
 
   const convertToFiat = useCallback(async (value: string) => {
     const request = ++conversionRequest.current;
@@ -210,6 +198,7 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
         }
         setErrorHandling(
           result.errorCode === lightningBalanceLimitErrorCode
+            || result.errorCode === TLightningErrorCode.AMOUNT_BELOW_MINIMUM
             ? {}
             : txProposalErrorHandling(result.errorCode)
         );
@@ -374,16 +363,8 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
     );
   }
 
-  if (topUpAccounts === undefined) {
-    return null;
-  }
-
   if (!btcAccounts.length) {
     return <TopUpNoBitcoinAccounts hasAccounts={hasAccounts} />;
-  }
-
-  if (!topUpAccounts.length) {
-    return <TopUpNoFundedBitcoinAccounts btcAccounts={btcAccounts} />;
   }
 
   if (!sourceAccount) {
@@ -398,7 +379,7 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
     <TopUpForm
       amount={amount}
       balanceLimitError={fundingLimitErrorMessage}
-      btcAccounts={topUpAccounts}
+      btcAccounts={btcAccounts}
       canReview={canReview}
       customFee={customFee}
       defaultCurrency={defaultCurrency}
@@ -407,6 +388,7 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
       isSubmitting={isSubmitting}
       isUpdatingProposal={isUpdatingProposal}
       lightningBalance={lightningBalance}
+      minimumAmountError={amountValidationError}
       note={note}
       onAmountChange={handleAmountChange}
       onBack={() => navigate('/lightning')}

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -304,12 +304,6 @@ export const AppRouter = ({
 
   const ReceiveAccountsSelectorEl = <InjectParams><ReceiveAccountsSelector activeAccounts={activeAccounts}/></InjectParams>;
 
-  const BitcoinReceiveAccountsSelectorEl = (
-    <InjectParams>
-      <ReceiveAccountsSelector activeAccounts={activeAccounts.filter(account => account.coinCode === 'btc')} />
-    </InjectParams>
-  );
-
   const AllAccountsEl = <InjectParams><AllAccounts accounts={activeAccounts} /></InjectParams>;
 
   return (
@@ -382,7 +376,6 @@ export const AppRouter = ({
         </Route>
         <Route path="manage-backups/:deviceID" element={ManageBackupsEl} />
         <Route path="accounts/select-receive" element={ReceiveAccountsSelectorEl} />
-        <Route path="accounts/select-receive/bitcoin" element={BitcoinReceiveAccountsSelectorEl} />
         <Route path="accounts/all" element={AllAccountsEl} />
         <Route path="settings">
           <Route index element={MobileSettingsEl} />


### PR DESCRIPTION
Small top-ups can become impossible to claim or refund. Enforce a 1,000 sat minimum using backend-owned validation and expose the result through the existing balance and amount responses.

Hide Bitcoin accounts whose available balance does not exceed the threshold, since an exact-minimum balance cannot also cover network fees. Leave final fee sufficiency to the normal transaction proposal.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
