### PR TITLE
lightning: warn about incoming funds before shutdown

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1685,6 +1685,9 @@
         "tryAgain": "Please try again."
       },
       "fee": "Fee",
+      "incomingFunds": "Incoming funds",
+      "incomingWarning": "Incoming funds cannot be withdrawn when closing your lightning wallet. Please try again later to withdraw all funds.",
+      "incomingWarningConfirm": "I understand that incoming funds will not be withdrawn.",
       "lightningBalanceToBeSent": "Lightning balance to be sent",
       "partialFailure": {
         "action": "Shut down wallet",

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.module.css
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.module.css
@@ -58,6 +58,11 @@
     margin-top: var(--space-default);
 }
 
+.incomingConfirm {
+    display: block;
+    margin-top: var(--space-half);
+}
+
 .failureContent,
 .successContent {
     align-items: center;

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
@@ -38,6 +38,9 @@ export const LightningCloseWithdrawFunds = ({
   const [confirmed, setConfirmed] = useState(false);
   const [step, setStep] = useState<TStep>('confirm');
   const [balance, setBalance] = useState<TAmountWithConversions>();
+  const [hasIncoming, setHasIncoming] = useState(false);
+  const [incoming, setIncoming] = useState<TAmountWithConversions>();
+  const [incomingConfirmed, setIncomingConfirmed] = useState(false);
   const [quote, setQuote] = useState<TPreparedQuote>();
   const [isClosing, setIsClosing] = useState(false);
   const [txID, setTxID] = useState<string>();
@@ -46,7 +49,11 @@ export const LightningCloseWithdrawFunds = ({
   const quoteRequest = useRef(0);
   const destinationAccount = btcAccounts.find(account => account.code === destinationAccountCode);
   const quoteMatchesDestination = quote?.destinationAccountCode === destinationAccountCode;
-  const canClose = confirmed && !!quote && quoteMatchesDestination && !isClosing;
+  const canClose = confirmed
+    && (!hasIncoming || incomingConfirmed)
+    && !!quote
+    && quoteMatchesDestination
+    && !isClosing;
 
   useEffect(() => {
     if (!btcAccounts.length) {
@@ -69,6 +76,8 @@ export const LightningCloseWithdrawFunds = ({
         return;
       }
       setBalance(lightningBalance.available);
+      setHasIncoming(lightningBalance.hasIncoming);
+      setIncoming(lightningBalance.incoming);
       if (!lightningBalance.hasAvailable) {
         return;
       }
@@ -169,10 +178,14 @@ export const LightningCloseWithdrawFunds = ({
           confirmed={confirmed}
           destinationAccountCode={destinationAccountCode}
           fee={quote?.fee}
+          hasIncoming={hasIncoming}
+          incoming={incoming}
+          incomingConfirmed={incomingConfirmed}
           isClosing={isClosing}
           onCancel={() => navigate(-1)}
           onClose={closeWithdraw}
           onConfirmChange={() => setConfirmed(current => !current)}
+          onIncomingConfirmChange={() => setIncomingConfirmed(current => !current)}
           onDestinationAccountChange={(code) => {
             setConfirmed(false);
             setDestinationAccountCode(code);

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
@@ -5,6 +5,7 @@ import type { AccountCode, TAccount, TAmountWithConversions } from '@/api/accoun
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import { Button, Checkbox } from '@/components/forms';
 import { GroupedAccountSelector } from '@/components/groupedaccountselector/groupedaccountselector';
+import { Message } from '@/components/message/message';
 import { Skeleton } from '@/components/skeleton/skeleton';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
 import { CONTENT_MIN_HEIGHT } from './constants';
@@ -17,10 +18,14 @@ type TProps = {
   confirmed: boolean;
   destinationAccountCode: AccountCode;
   fee?: TAmountWithConversions;
+  hasIncoming: boolean;
+  incoming?: TAmountWithConversions;
+  incomingConfirmed: boolean;
   isClosing: boolean;
   onCancel: () => void;
   onClose: () => void;
   onConfirmChange: () => void;
+  onIncomingConfirmChange: () => void;
   onDestinationAccountChange: (code: AccountCode) => void;
 };
 
@@ -51,10 +56,14 @@ export const CloseWithdrawConfirm = ({
   confirmed,
   destinationAccountCode,
   fee,
+  hasIncoming,
+  incoming,
+  incomingConfirmed,
   isClosing,
   onCancel,
   onClose,
   onConfirmChange,
+  onIncomingConfirmChange,
   onDestinationAccountChange,
 }: TProps) => {
   const { t } = useTranslation();
@@ -85,6 +94,30 @@ export const CloseWithdrawConfirm = ({
             <h2 className={styles.sectionTitle}>{t('lightning.closeWithdrawFunds.fee')}</h2>
             <AmountRow amount={fee} />
           </section>
+
+          {hasIncoming && (
+            <Message type="warning">
+              {t('lightning.closeWithdrawFunds.incomingWarning')}
+              {incoming && (
+                <>
+                  <br />
+                  {t('lightning.closeWithdrawFunds.incomingFunds')}:&nbsp;
+                  <AmountWithUnit amount={incoming} maxDecimals={9} />
+                  {' / '}
+                  <AmountWithUnit amount={incoming} convertToFiat />
+                </>
+              )}
+              <Checkbox
+                className={styles.incomingConfirm}
+                id="confirmIncomingFunds"
+                checked={incomingConfirmed}
+                disabled={isClosing}
+                onChange={onIncomingConfirmChange}
+              >
+                {t('lightning.closeWithdrawFunds.incomingWarningConfirm')}
+              </Checkbox>
+            </Message>
+          )}
 
           <Checkbox
             className={styles.confirm}


### PR DESCRIPTION
Incoming and unclaimed funds cannot be included in a close-and-withdraw transaction. Show a warning in the confirmation step and link back to the Lightning account, where users can claim or refund those funds.

Keep shutdown available for users who choose to continue without withdrawing every fund.

<img width="466" height="848" alt="screenshot_11-Aug-2026_16-01-48" src="https://github.com/user-attachments/assets/553aa563-fdbe-4401-b2fa-49338fe4d371" />


Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
