### PR TITLE
lightning: warn about lightning not using tor.

### DIFF
--- a/frontends/web/src/api/config.ts
+++ b/frontends/web/src/api/config.ts
@@ -46,7 +46,8 @@ type TConfigFrontendDismissibleKnownKey =
   | 'walletConnectDisclaimerDismissed'
   | 'skipTestingWarning'
   | 'mobile-data-warning'
-  | 'lightning-beta-warning';
+  | 'lightning-beta-warning'
+  | 'lightning-tor-proxy-warning';
 
 export type TConfigFrontendDismissibleKey =
   | TConfigFrontendDismissibleKnownKey
@@ -80,6 +81,7 @@ export type TConfigFrontend = Readonly<{
   skipTestingWarning?: boolean;
   'mobile-data-warning'?: boolean;
   'lightning-beta-warning'?: boolean;
+  'lightning-tor-proxy-warning'?: boolean;
 }> & Readonly<{
   [key in TConfigFrontendDismissibleDynamicKey]?: boolean;
 }>;

--- a/frontends/web/src/components/banners/lightning-tor-proxy-warning.tsx
+++ b/frontends/web/src/components/banners/lightning-tor-proxy-warning.tsx
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from 'react-i18next';
+import { useConfig } from '@/contexts/ConfigProvider';
+import { Status } from '@/components/status/status';
+
+type TProps = {
+  className?: string;
+  dismissible?: boolean;
+  hidden?: boolean;
+};
+
+export const LightningTorProxyWarning = ({
+  className,
+  dismissible = false,
+  hidden = false,
+}: TProps) => {
+  const { t } = useTranslation();
+  const { config } = useConfig();
+
+  return (
+    <Status
+      className={className}
+      dismissibleKey={dismissible ? 'lightning-tor-proxy-warning' : ''}
+      hidden={hidden || !config?.backend.proxy.useProxy}
+      type="warning">
+      {t('lightning.torProxyWarning')}
+    </Status>
+  );
+};

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1888,7 +1888,8 @@
       },
       "title": "Top up lightning wallet",
       "to": "To"
-    }
+    },
+    "torProxyWarning": "Lightning does not use the Tor proxy. Lightning will continue to work over your regular internet connection."
   },
   "loading": "loading…",
   "logo": {

--- a/frontends/web/src/routes/lightning/activate.tsx
+++ b/frontends/web/src/routes/lightning/activate.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Logo } from '@/components/icon/logo';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { UseDisableBackButton } from '@/hooks/backbutton';
 import { useLightning } from '@/hooks/lightning';
 import { Header, Main } from '../../components/layout';
@@ -16,6 +17,7 @@ import { unsubscribe } from '../../utils/subscriptions';
 import { postActivate } from '../../api/lightning';
 import { Status } from '../../components/status/status';
 import { LightningDisclaimerContent } from './disclaimer';
+import { LightningTorProxyWarning } from '@/components/banners/lightning-tor-proxy-warning';
 import styles from './activate.module.css';
 
 const CONTENT_MIN_HEIGHT = '38em';
@@ -221,9 +223,12 @@ export const LightningActivate = () => {
 
   return (
     <Main>
-      <Status dismissibleKey="" type="warning" hidden={!setupError}>
-        {setupError}
-      </Status>
+      <ContentWrapper>
+        <LightningTorProxyWarning />
+        <Status dismissibleKey="" type="warning" hidden={!setupError}>
+          {setupError}
+        </Status>
+      </ContentWrapper>
       <Header title={t('lightning.activate.title')} />
       {renderSteps()}
     </Main>

--- a/frontends/web/src/routes/lightning/lightning.tsx
+++ b/frontends/web/src/routes/lightning/lightning.tsx
@@ -22,6 +22,7 @@ import { Spinner } from '../../components/spinner/Spinner';
 import { ActionButtons } from './components/action-buttons';
 import { LightningGuide } from './guide';
 import { GlobalBanners } from '@/components/banners';
+import { LightningTorProxyWarning } from '@/components/banners/lightning-tor-proxy-warning';
 import { Status } from '../../components/status/status';
 import { HideAmountsButton } from '../../components/hideamountsbutton/hideamountsbutton';
 import { PaymentDetails } from './components/payment-details';
@@ -368,6 +369,7 @@ export const Lightning = () => {
 
   const statusBanners = (
     <>
+      <LightningTorProxyWarning dismissible />
       <Status
         dismissibleKey="lightning-beta-warning"
         type="warning">

--- a/frontends/web/src/routes/settings/components/advanced-settings/tor-proxy-dialog.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/tor-proxy-dialog.tsx
@@ -10,6 +10,8 @@ import { Button, Input } from '@/components/forms';
 import { useConfig } from '@/contexts/ConfigProvider';
 import { socksProxyCheck } from '@/api/backend';
 import { alertUser } from '@/components/alert/Alert';
+import { useLightning } from '@/hooks/lightning';
+import { LightningTorProxyWarning } from '@/components/banners/lightning-tor-proxy-warning';
 
 type TProps = {
   open: boolean;
@@ -19,6 +21,7 @@ type TProps = {
 
 export const TorProxyDialog = ({ open, onCloseDialog, handleShowRestartMessage }: TProps) => {
   const { config, setConfig } = useConfig();
+  const { lightningAccount } = useLightning();
   const proxyConfig = config?.backend.proxy;
   const [proxyAddress, setProxyAddress] = useState<string>();
   const { t } = useTranslation();
@@ -82,6 +85,7 @@ export const TorProxyDialog = ({ open, onCloseDialog, handleShowRestartMessage }
           checked={proxyConfig.useProxy}
           onChange={handleToggleProxy} />
       </div>
+      <LightningTorProxyWarning className="m-top-half" hidden={!lightningAccount} />
       <div className="m-top-half">
         <Input
           name="proxyAddress"


### PR DESCRIPTION
Lightning's connections are handled by the breeze sdk and can not be configured to use a specific proxy. Warn the user that lightning will still work but it will not be using Tor.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
