### PR TITLE
frontend: refine total assets loading

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -80,11 +80,13 @@ export const parseEthereumPaymentRequest = (
   return apiPost(`account/${code}/parse-ethereum-payment-request`, { uri });
 };
 
-export type CoinFormattedAmount = {
+export type CoinFormattedOptionalAmount = {
   coinCode: CoinCode;
   coinName: string;
-  formattedAmount: TAmountWithConversions;
+  formattedAmount?: TAmountWithConversions;
 };
+
+export type CoinFormattedAmount = Required<CoinFormattedOptionalAmount>;
 
 export type TAmountsByCoin = {
   [key in CoinCode]?: TAmountWithConversions;

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -61,9 +61,27 @@ export const AccountsSummary = ({
   const [accountsBalanceSummary, setAccountsBalanceSummary] = useState<accountApi.TAccountsBalanceSummary>();
   const [balances, setBalances] = useState<Balances>();
   const [offlineError, setOfflineError] = useState<string | null>(null);
-  const coinsTotalBalance = accountsBalanceSummary?.coinsTotalBalance.filter(balance => (
-    balance.coinCode !== 'lightning' || isLightningFeatureAvailable()
-  ));
+  const coinBalancePlaceholders = Object.values(accountsPerCoin).flatMap(coinAccounts => {
+    const account = coinAccounts?.[0];
+    return account ? [{
+      coinCode: account.coinCode,
+      coinName: account.coinName,
+      coinUnit: account.coinUnit,
+    }] : [];
+  });
+  if (lightningAccount && isLightningFeatureAvailable()) {
+    const bitcoinIndex = coinBalancePlaceholders.findIndex(balance => balance.coinCode === 'btc');
+    coinBalancePlaceholders.splice(bitcoinIndex + 1, 0, {
+      coinCode: 'lightning',
+      coinName: 'Lightning',
+      coinUnit: 'BTC',
+    });
+  }
+  const coinsTotalBalance = accountsBalanceSummary
+    ? accountsBalanceSummary.coinsTotalBalance.filter(balance => (
+      balance.coinCode !== 'lightning' || isLightningFeatureAvailable()
+    ))
+    : coinBalancePlaceholders.length > 0 ? coinBalancePlaceholders : undefined;
 
   const getChartData = useCallback(async () => {
     // replace previous timer if present

--- a/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.tsx
+++ b/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ReactNode, useContext } from 'react';
-import { CoinCode, TAmountWithConversions } from '@/api/account';
+import { CoinCode, CoinUnit, TAmountWithConversions } from '@/api/account';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import { Logo } from '@/components/icon/logo';
 import { Skeleton } from '@/components/skeleton/skeleton';
@@ -14,6 +14,7 @@ type TProps = {
   amount?: TAmountWithConversions;
   coinCode: CoinCode;
   coinName: ReactNode;
+  coinUnit?: CoinUnit;
   dataTestId?: string;
   showUnitPrice?: boolean;
 };
@@ -22,11 +23,12 @@ export const AssetBalanceWithUnitPrice = ({
   amount,
   coinCode,
   coinName,
+  coinUnit,
   dataTestId,
   showUnitPrice = true,
 }: TProps) => {
   const { defaultCurrency } = useContext(RatesContext);
-  const unitPrice = useCoinUnitPrice(coinCode, amount?.unit);
+  const unitPrice = useCoinUnitPrice(coinCode, amount?.unit ?? coinUnit);
   const shouldShowUnitPrice = showUnitPrice
     && (!isBitcoinOnly(coinCode) || (defaultCurrency !== 'BTC' && defaultCurrency !== 'sat'));
 

--- a/frontends/web/src/routes/account/summary/total-balance-for-all-keystores.tsx
+++ b/frontends/web/src/routes/account/summary/total-balance-for-all-keystores.tsx
@@ -9,11 +9,15 @@ import { BalanceSection } from './balance-section';
 import { AssetBalanceWithUnitPrice } from './asset-balance-with-unit-price';
 import style from './accountssummary.module.css';
 
+type TCoinBalance = accountApi.CoinFormattedOptionalAmount & {
+  coinUnit?: accountApi.CoinUnit;
+};
+
 type TProps = {
   hideHeader?: boolean;
   hideLightningUnitPrice?: boolean;
   summaryData?: accountApi.TChartData;
-  coinsBalances?: accountApi.CoinFormattedAmount[];
+  coinsBalances?: TCoinBalance[];
 };
 
 export const TotalBalanceForAllKeystores = ({
@@ -60,6 +64,7 @@ export const TotalBalanceForAllKeystores = ({
               amount={balance.formattedAmount}
               coinCode={balance.coinCode}
               coinName={balance.coinName}
+              coinUnit={balance.coinUnit}
               showUnitPrice={!isLightning || !hideLightningUnitPrice}
             />
           </div>


### PR DESCRIPTION
- Show coin names/icons while Total assets balances load.
- Let unit prices load from coin metadata before balances arrive.

Before:

<img width="872" height="846" alt="image" src="https://github.com/user-attachments/assets/79458371-2b3e-4e8f-b7e8-5681deaa1e9d" />


After:
<img width="888" height="583" alt="Screenshot 2026-08-12 at 12 31 55" src="https://github.com/user-attachments/assets/9dc2d2c9-a014-41b1-b7e6-723881d321b8" />
