### PR TITLE
build: verify vendored Go dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ WEBROOT  := frontends/web
 
 include version.mk.inc
 
+.PHONY: check-go-vendor
+
 GO_LDFLAGS := $(GO_VERSION_LDFLAGS)
 GO_RUN := go run -mod=vendor -ldflags "$(GO_LDFLAGS)"
 
@@ -52,17 +54,17 @@ webserve:
 	cd ${WEBROOT} && $(MAKE) serve
 webe2etest:
 	cd ${WEBROOT} && $(MAKE) test-e2e
-qt-linux-bin: # build only the executable, skip deb/rpm/AppImage packaging
+qt-linux-bin: check-go-vendor # build only the executable, skip deb/rpm/AppImage packaging
 	$(MAKE) buildweb
 	cd frontends/qt && $(MAKE) linux-bin
-qt-linux: # run inside dockerdev
+qt-linux: check-go-vendor # run inside dockerdev
 	$(MAKE) buildweb
 	cd frontends/qt && $(MAKE) linux
-qt-osx: # run on OSX.
+qt-osx: check-go-vendor # run on OSX.
 	$(MAKE) buildweb
 	cd frontends/qt && $(MAKE) osx
 	$(MAKE) osx-sec-check
-qt-windows:
+qt-windows: check-go-vendor
 	$(MAKE) buildweb
 	cd frontends/qt && $(MAKE) windows
 android:
@@ -94,6 +96,8 @@ dockerdev:
 	./scripts/dockerdev.sh
 go-vendor:
 	go mod vendor
+check-go-vendor:
+	bash ./scripts/check-go-vendor.sh
 update-bitbox02-api-go:
 	./scripts/update-bitbox02-api-go.sh
 update-btc-checkpoints:

--- a/frontends/android/Makefile
+++ b/frontends/android/Makefile
@@ -11,6 +11,7 @@ deploy-debug:
 clean:
 	cd BitBoxApp && ./gradlew clean
 prepare-android:
+	cd ../.. && ${MAKE} check-go-vendor
 	cd ../../ && ${MAKE} buildweb
 	rm -rf BitBoxApp/app/src/main/assets/web
 	mkdir -p BitBoxApp/app/src/main/assets/web

--- a/frontends/ios/Makefile
+++ b/frontends/ios/Makefile
@@ -1,4 +1,5 @@
 prepare:
+	cd ../.. && ${MAKE} check-go-vendor
 	cd ../../ && ${MAKE} buildweb
 	rm -rf BitBoxApp/BitBoxApp/assets/web/
 	mkdir -p BitBoxApp/BitBoxApp/assets/web/

--- a/scripts/check-go-vendor.sh
+++ b/scripts/check-go-vendor.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+check_dir="$(mktemp -d)"
+vendor_dir="${check_dir}/vendor"
+
+cleanup() {
+    chmod -R u+w "${check_dir}" 2>/dev/null || true
+    rm -rf "${check_dir}"
+}
+trap cleanup EXIT
+
+mkdir -p "${check_dir}/modcache"
+(
+    cd "${repo_root}"
+    # Regenerate from go.sum-authenticated downloads rather than trusting vendor/ or a reused cache.
+    GOMODCACHE="${check_dir}/modcache" GOFLAGS="-mod=readonly -modcacherw" \
+        go mod vendor -o "${vendor_dir}"
+)
+
+if ! git diff --no-index --exit-code --ignore-cr-at-eol -- \
+    "${repo_root}/vendor" "${vendor_dir}"; then
+    echo "vendor/ does not match the dependencies authenticated by go.sum." >&2
+    echo "Run 'make go-vendor' and commit the result." >&2
+    exit 1
+fi


### PR DESCRIPTION
Release builds compile vendor/ directly, but go.sum authenticates downloaded
module archives, not the copied vendor tree. A source-only vendor change can
therefore bypass go mod verify.

Regenerate vendor/ from a fresh, read-only module cache and compare it before
platform builds in CI and release workflows. This prevents Qt, Android, and iOS
artifacts from using vendored sources that do not match the checksummed modules.

Verified with a clean vendor tree and a temporary source-only modification,
which the check rejected.