### PR TITLE
feat: adjust unit price

### DIFF
--- a/backend/rates/history.go
+++ b/backend/rates/history.go
@@ -315,10 +315,7 @@ func (updater *RateUpdater) fetchGeckoMarketRange(ctx context.Context, coin, fia
 	// Transform the response into a usable result.
 	rates := make([]exchangeRate, len(jsonBody.Prices))
 	for i, v := range jsonBody.Prices {
-		value := v[1]
-		if fiat == SAT.String() {
-			value *= unitSatoshi
-		}
+		value := normalizeHistoricalRate(gcoin, fiat, v[1])
 		rates[i] = exchangeRate{
 			value:     value,
 			timestamp: time.Unix(int64(v[0])/1000, 0), // local timezone

--- a/backend/rates/history_test.go
+++ b/backend/rates/history_test.go
@@ -113,6 +113,52 @@ func TestUpdateHistory(t *testing.T) {
 	assert.Equal(t, wantHistory, updater.history, "updater2.history")
 }
 
+func TestFetchGeckoMarketRangeNormalizesBitcoinUnitRates(t *testing.T) {
+	tt := []struct {
+		coin      string
+		fiat      string
+		wantValue float64
+	}{
+		{coin: "btc", fiat: BTC.String(), wantValue: 1},
+		{coin: "btc", fiat: SAT.String(), wantValue: unitSatoshi},
+		{coin: "tbtc", fiat: BTC.String(), wantValue: 1},
+		{coin: "eth-erc20-wbtc", fiat: BTC.String(), wantValue: 0.99904149},
+	}
+	for _, test := range tt {
+		t.Run(test.coin+"/"+test.fiat, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "GET", r.Method, "request method")
+				assert.Equal(t, "/coins/"+geckoCoin[test.coin]+"/market_chart/range", r.URL.Path, "URL path")
+				assert.Equal(t, "btc", r.URL.Query().Get("vs_currency"), "vs_currency query arg")
+
+				fmt.Fprintln(w, `{
+					"prices": [
+					  [
+					    1598918700000,
+					    0.99904149
+					  ]
+					]
+				}`)
+			}))
+			defer ts.Close()
+
+			updater := NewRateUpdater(http.DefaultClient, t.TempDir())
+			defer updater.Stop()
+			updater.SetCoingeckoURL(ts.URL)
+
+			rates, err := updater.fetchGeckoMarketRange(
+				t.Context(),
+				test.coin,
+				test.fiat,
+				fixedTimeRange(time.Unix(1598918462, 0), time.Unix(1599004862, 0)),
+			)
+			require.NoError(t, err)
+			require.Len(t, rates, 1)
+			assert.Equal(t, test.wantValue, rates[0].value)
+		})
+	}
+}
+
 func TestFetchGeckoMarketRangeInvalidCoinFiat(t *testing.T) {
 	tt := []struct{ coin, fiat string }{
 		{"BTC", "invalid"},

--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -40,6 +40,31 @@ const interval = time.Minute
 // unitSatoshi is 1 BTC (default unit) in Satoshi.
 const unitSatoshi = 1e8
 
+func normalizeBitcoinUnitRates(rates map[string]map[string]float64) {
+	btcRates := rates[BTC.String()]
+	if btcRates == nil {
+		return
+	}
+	// BTC/sat conversions are unit identities, not market prices.
+	btcRates[BTC.String()] = 1
+	btcRates[SAT.String()] = unitSatoshi
+}
+
+func normalizeHistoricalRate(geckoCoinID, fiat string, value float64) float64 {
+	isBitcoin := geckoCoinID == geckoCoin["btc"]
+
+	switch {
+	case isBitcoin && fiat == BTC.String():
+		return 1
+	case isBitcoin && fiat == SAT.String():
+		return unitSatoshi
+	case fiat == SAT.String():
+		return value * unitSatoshi
+	default:
+		return value
+	}
+}
+
 type exchangeRate struct {
 	value     float64
 	timestamp time.Time
@@ -322,6 +347,8 @@ func (updater *RateUpdater) updateLast(ctx context.Context) {
 		}
 		rates[coinUnit] = newVal
 	}
+
+	normalizeBitcoinUnitRates(rates)
 
 	// Create sat rates from BTC
 	sat := make(map[string]float64)

--- a/backend/rates/rates_test.go
+++ b/backend/rates/rates_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rates
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateLastNormalizesBitcoinUnitRates(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "request method")
+		assert.Equal(t, "/simple/price", r.URL.Path, "URL path")
+		assert.Contains(t, r.URL.Query().Get("ids"), "bitcoin", "ids query arg")
+		assert.Contains(t, r.URL.Query().Get("vs_currencies"), "btc", "vs_currencies query arg")
+
+		fmt.Fprintln(w, `{
+			"bitcoin": {
+				"usd": 123.45,
+				"btc": 0.99904149
+			},
+			"wrapped-bitcoin": {
+				"usd": 123.40,
+				"btc": 0.998
+			}
+		}`)
+	}))
+	defer ts.Close()
+
+	updater := NewRateUpdater(http.DefaultClient, t.TempDir())
+	defer updater.Stop()
+	updater.SetCoingeckoURL(ts.URL)
+
+	updater.updateLast(t.Context())
+
+	last := updater.LatestPrice()
+	require.NotNil(t, last)
+	require.Contains(t, last, BTC.String())
+	require.Contains(t, last, SAT.String())
+	require.Contains(t, last, "WBTC")
+
+	assert.Equal(t, 1.0, last[BTC.String()][BTC.String()])
+	assert.Equal(t, float64(unitSatoshi), last[BTC.String()][SAT.String()])
+	assert.Equal(t, 1.0/unitSatoshi, last[SAT.String()][BTC.String()])
+	assert.Equal(t, 1.0, last[SAT.String()][SAT.String()])
+	assert.Equal(t, 1.0, last["TBTC"][BTC.String()])
+	assert.Equal(t, 1.0, last["RBTC"][BTC.String()])
+
+	assert.InDelta(t, 0.998, last["WBTC"][BTC.String()], 1e-12)
+}

--- a/frontends/web/src/routes/account/summary/accountssummary.module.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.module.css
@@ -139,12 +139,23 @@
     width: 100%;
 }
 
+.assetBalanceLogo {
+    width: 32px;
+    height: 32px;
+    flex: 0 0 32px;
+    object-fit: contain;
+}
+
 .assetBalanceDetailsRow {
     display: flex;
     flex-direction: row;
     gap: var(--space-eight);
     width: 100%;
     min-width: 0;
+}
+
+.assetBalanceDetailsRowCentered {
+    align-items: center;
 }
 
 .assetBalanceDetailsCol {

--- a/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.test.tsx
+++ b/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.test.tsx
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { CoinCode, CoinUnit, Fiat } from '@/api/account';
+import { AppContext } from '@/contexts/AppContext';
+import { LocalizationContext } from '@/contexts/localization-context';
+import { RatesContext } from '@/contexts/RatesContext';
+import { useCoinUnitPrice } from '@/hooks/coin-unit-price';
+import { AssetBalanceWithUnitPrice } from './asset-balance-with-unit-price';
+
+vi.mock('@/hooks/mediaquery', () => ({
+  useMediaQuery: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/hooks/coin-unit-price', () => ({
+  useCoinUnitPrice: vi.fn(() => ({
+    amount: '1',
+    unit: 'BTC',
+    conversions: {
+      BTC: '1',
+      sat: '100000000',
+      USD: '60000.00',
+    },
+    estimated: false,
+  })),
+}));
+
+type TProps = {
+  children: ReactNode;
+  defaultCurrency: Fiat;
+};
+
+const Wrapper = ({
+  children,
+  defaultCurrency,
+}: TProps) => (
+  <AppContext.Provider value={{
+    activeSidebar: false,
+    chartDisplay: 'year',
+    firmwareUpdateDialogOpen: false,
+    guideExists: false,
+    guideShown: false,
+    hideAmounts: false,
+    isDevServers: false,
+    isTesting: false,
+    nativeLocale: 'en-US',
+    sessionConfig: {},
+    setActiveSidebar: vi.fn(),
+    setChartDisplay: vi.fn(),
+    setFirmwareUpdateDialogOpen: vi.fn(),
+    setGuideExists: vi.fn(),
+    setHideAmounts: vi.fn(),
+    setVendorIframeActive: vi.fn(),
+    toggleGuide: vi.fn(),
+    toggleHideAmounts: vi.fn(),
+    toggleSidebar: vi.fn(),
+    updateSessionConfig: vi.fn(),
+    vendorIframeActive: false,
+  }}>
+    <LocalizationContext.Provider value={{ decimal: '.', group: '\'' }}>
+      <RatesContext.Provider value={{
+        activeCurrencies: [defaultCurrency],
+        addToActiveCurrencies: vi.fn(),
+        btcUnit: 'default',
+        defaultCurrency,
+        removeFromActiveCurrencies: vi.fn(),
+        rotateBtcUnit: vi.fn(),
+        rotateDefaultCurrency: vi.fn(),
+        updateDefaultCurrency: vi.fn(),
+      }}>
+        {children}
+      </RatesContext.Provider>
+    </LocalizationContext.Provider>
+  </AppContext.Provider>
+);
+
+const renderAssetBalance = (
+  defaultCurrency: Fiat,
+  coinCode: CoinCode,
+  coinName: string,
+  unit: CoinUnit,
+  showUnitPrice?: boolean,
+) => render(
+  <Wrapper defaultCurrency={defaultCurrency}>
+    <AssetBalanceWithUnitPrice
+      amount={{
+        amount: '0.99951787',
+        unit,
+        conversions: {
+          BTC: '0.99951787',
+          sat: '99951787',
+          USD: '59971.07',
+        },
+        estimated: false,
+      }}
+      coinCode={coinCode}
+      coinName={coinName}
+      showUnitPrice={showUnitPrice}
+    />
+  </Wrapper>
+);
+
+const mockUseCoinUnitPrice = vi.mocked(useCoinUnitPrice);
+
+describe('AssetBalanceWithUnitPrice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides Bitcoin Testnet unit prices when the display currency is BTC', () => {
+    renderAssetBalance('BTC', 'tbtc', 'Bitcoin Testnet', 'TBTC');
+
+    expect(screen.queryByTestId('unit-price-amount')).not.toBeInTheDocument();
+  });
+
+  it('hides Bitcoin unit prices when the display currency is sat', () => {
+    renderAssetBalance('sat', 'btc', 'Bitcoin', 'BTC');
+
+    expect(screen.queryByTestId('unit-price-amount')).not.toBeInTheDocument();
+  });
+
+  it('hides unit prices when showUnitPrice is false', () => {
+    renderAssetBalance('USD', 'btc', 'Bitcoin', 'BTC', false);
+
+    expect(screen.queryByTestId('unit-price-amount')).not.toBeInTheDocument();
+  });
+
+  it('shows Bitcoin unit prices for fiat display currencies', () => {
+    renderAssetBalance('USD', 'btc', 'Bitcoin', 'BTC');
+
+    expect(screen.getByTestId('unit-price-amount')).toHaveTextContent('60000 USD');
+    expect(mockUseCoinUnitPrice).toHaveBeenCalledWith('btc', 'BTC');
+  });
+});

--- a/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.tsx
+++ b/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.tsx
@@ -1,27 +1,43 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactNode } from 'react';
+import { ReactNode, useContext } from 'react';
 import { CoinCode, TAmountWithConversions } from '@/api/account';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import { Logo } from '@/components/icon/logo';
 import { Skeleton } from '@/components/skeleton/skeleton';
+import { RatesContext } from '@/contexts/RatesContext';
 import { useCoinUnitPrice } from '@/hooks/coin-unit-price';
+import { isBitcoinOnly } from '@/routes/account/utils';
 import style from './accountssummary.module.css';
 
-type Props = {
+type TProps = {
   amount?: TAmountWithConversions;
   coinCode: CoinCode;
   coinName: ReactNode;
   dataTestId?: string;
+  showUnitPrice?: boolean;
 };
 
-export const AssetBalanceWithUnitPrice = ({ amount, coinCode, coinName, dataTestId }: Props) => {
+export const AssetBalanceWithUnitPrice = ({
+  amount,
+  coinCode,
+  coinName,
+  dataTestId,
+  showUnitPrice = true,
+}: TProps) => {
+  const { defaultCurrency } = useContext(RatesContext);
   const unitPrice = useCoinUnitPrice(coinCode, amount?.unit);
+  const shouldShowUnitPrice = showUnitPrice
+    && (!isBitcoinOnly(coinCode) || (defaultCurrency !== 'BTC' && defaultCurrency !== 'sat'));
+
   return (
     <div className={style.assetBalanceRow}>
       <div className={style.assetBalanceInfoFull}>
-        <Logo coinCode={coinCode} active={true} alt={coinCode} />
-        <div className={style.assetBalanceDetailsRow}>
+        <Logo className={style.assetBalanceLogo} coinCode={coinCode} active={true} alt={coinCode} />
+        <div className={`
+          ${style.assetBalanceDetailsRow || ''}
+          ${!shouldShowUnitPrice ? style.assetBalanceDetailsRowCentered || '' : ''}
+        `}>
           <div className={style.assetBalanceDetailsCol}>
             <span
               className={`${style.assetBalanceName || ''}
@@ -31,15 +47,17 @@ export const AssetBalanceWithUnitPrice = ({ amount, coinCode, coinName, dataTest
               {coinName}
             </span>
 
-            <div data-testid="unit-price-amount">
-              <AmountWithUnit
-                alwaysShowAmounts
-                amountClassName={style.unitPrice}
-                amount={unitPrice}
-                convertToFiat
-                removeTrailingZeros
-              />
-            </div>
+            {shouldShowUnitPrice && (
+              <div data-testid="unit-price-amount">
+                <AmountWithUnit
+                  alwaysShowAmounts
+                  amountClassName={style.unitPrice}
+                  amount={unitPrice}
+                  convertToFiat
+                  removeTrailingZeros
+                />
+              </div>
+            )}
           </div>
           <div className={style.assetBalanceAmounts}>
             {amount ? (

--- a/frontends/web/src/routes/account/summary/total-balance-for-all-keystores.test.tsx
+++ b/frontends/web/src/routes/account/summary/total-balance-for-all-keystores.test.tsx
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../../__mocks__/i18n';
+import { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { CoinCode, CoinFormattedAmount, CoinUnit, Fiat, TChartData } from '@/api/account';
+import { AppContext } from '@/contexts/AppContext';
+import { LocalizationContext } from '@/contexts/localization-context';
+import { RatesContext } from '@/contexts/RatesContext';
+import { TotalBalanceForAllKeystores } from './total-balance-for-all-keystores';
+
+vi.mock('@/hooks/mediaquery', () => ({
+  useMediaQuery: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/hooks/coin-unit-price', () => ({
+  useCoinUnitPrice: vi.fn(() => ({
+    amount: '1',
+    unit: 'BTC',
+    conversions: {
+      BTC: '1',
+      sat: '100000000',
+      USD: '60000.00',
+    },
+    estimated: false,
+  })),
+}));
+
+const chartData = (chartFiat: Fiat): TChartData => ({
+  chartDataMissing: false,
+  chartDataDaily: [],
+  chartDataHourly: [],
+  chartFiat,
+  chartTotal: 1,
+  formattedChartTotal: '1',
+  chartIsUpToDate: true,
+  lastTimestamp: 0,
+});
+
+const btcBalance: CoinFormattedAmount = {
+  coinCode: 'btc',
+  coinName: 'Bitcoin',
+  formattedAmount: {
+    amount: '1.00000000',
+    unit: 'BTC',
+    conversions: {
+      BTC: '1',
+      sat: '100000000',
+      USD: '60000.00',
+    },
+    estimated: false,
+  },
+};
+
+const bitcoinBalance = (
+  coinCode: CoinCode,
+  coinName: string,
+  unit: CoinUnit,
+): CoinFormattedAmount => ({
+  ...btcBalance,
+  coinCode,
+  coinName,
+  formattedAmount: {
+    ...btcBalance.formattedAmount,
+    unit,
+  },
+});
+
+type TProps = {
+  children: ReactNode;
+  defaultCurrency: Fiat;
+};
+
+const Wrapper = ({
+  children,
+  defaultCurrency,
+}: TProps) => (
+  <AppContext.Provider value={{
+    activeSidebar: false,
+    chartDisplay: 'year',
+    firmwareUpdateDialogOpen: false,
+    guideExists: false,
+    guideShown: false,
+    hideAmounts: false,
+    isDevServers: false,
+    isTesting: false,
+    nativeLocale: 'en-US',
+    sessionConfig: {},
+    setActiveSidebar: vi.fn(),
+    setChartDisplay: vi.fn(),
+    setFirmwareUpdateDialogOpen: vi.fn(),
+    setGuideExists: vi.fn(),
+    setHideAmounts: vi.fn(),
+    setVendorIframeActive: vi.fn(),
+    toggleGuide: vi.fn(),
+    toggleHideAmounts: vi.fn(),
+    toggleSidebar: vi.fn(),
+    updateSessionConfig: vi.fn(),
+    vendorIframeActive: false,
+  }}>
+    <LocalizationContext.Provider value={{ decimal: '.', group: '\'' }}>
+      <RatesContext.Provider value={{
+        activeCurrencies: [defaultCurrency],
+        addToActiveCurrencies: vi.fn(),
+        btcUnit: 'default',
+        defaultCurrency,
+        removeFromActiveCurrencies: vi.fn(),
+        rotateBtcUnit: vi.fn(),
+        rotateDefaultCurrency: vi.fn(),
+        updateDefaultCurrency: vi.fn(),
+      }}>
+        {children}
+      </RatesContext.Provider>
+    </LocalizationContext.Provider>
+  </AppContext.Provider>
+);
+
+const renderTotalAssets = (
+  defaultCurrency: Fiat,
+  balance: CoinFormattedAmount = btcBalance,
+) => render(
+  <Wrapper defaultCurrency={defaultCurrency}>
+    <TotalBalanceForAllKeystores
+      summaryData={chartData(defaultCurrency)}
+      coinsBalances={[balance]}
+    />
+  </Wrapper>
+);
+
+describe('TotalBalanceForAllKeystores', () => {
+  it('hides the BTC unit price when the display currency is BTC', () => {
+    renderTotalAssets('BTC');
+
+    expect(screen.queryByTestId('unit-price-amount')).not.toBeInTheDocument();
+  });
+
+  it('hides the BTC unit price when the display currency is sat', () => {
+    renderTotalAssets('sat');
+
+    expect(screen.queryByTestId('unit-price-amount')).not.toBeInTheDocument();
+  });
+
+  it('hides the Bitcoin Testnet unit price when the display currency is BTC', () => {
+    renderTotalAssets('BTC', bitcoinBalance('tbtc', 'Bitcoin Testnet', 'TBTC'));
+
+    expect(screen.queryByTestId('unit-price-amount')).not.toBeInTheDocument();
+  });
+
+  it('shows the BTC unit price for fiat display currencies', () => {
+    renderTotalAssets('USD');
+
+    expect(screen.getByTestId('unit-price-amount')).toHaveTextContent('60000 USD');
+  });
+});


### PR DESCRIPTION
- Hide the redundant BTC unit price in account summaries when the selected currency is BTC or sat.
- Normalize native BTC/sat exchange rates in the backend so CoinGecko BTC/BTC drift cannot affect totals,