### PR TITLE
frontend: remove Lightning from accounts list

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -153,8 +153,7 @@ export const App = () => {
     // if no accounts are registered on specified views route to /
     const canNavigateWithLightningAccount =
       currentURL.startsWith('/account-summary')
-      || currentURL === '/settings/more'
-      || currentURL === '/accounts/all';
+      || currentURL === '/settings/more';
     const requiresRegularAccount =
       currentURL.startsWith('/account-summary')
       || currentURL.startsWith('/add-account')

--- a/frontends/web/src/routes/accounts/all-accounts.tsx
+++ b/frontends/web/src/routes/accounts/all-accounts.tsx
@@ -6,7 +6,6 @@ import { Link } from 'react-router-dom';
 import { useOnlyVisitableOnMobile } from '@/hooks/onlyvisitableonmobile';
 import * as accountApi from '@/api/account';
 import { getBalance } from '@/api/account';
-import { getLightningBalance } from '@/api/lightning';
 import { Logo } from '@/components/icon/logo';
 import { View, ViewContent } from '@/components/view/view';
 import { getAccountsByKeystore } from '@/routes/account/utils';
@@ -17,7 +16,6 @@ import { AllAccountsGuide } from '@/routes/accounts/all-accounts-guide';
 import { useMountedRef } from '@/hooks/mount';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import { ConnectedKeystore } from '@/components/keystore/connected-keystore';
-import { useLightning } from '@/hooks/lightning';
 import styles from './all-accounts.module.css';
 
 type AllAccountsProps = {
@@ -85,48 +83,11 @@ const AccountItem = ({ account }: TAccountItemProp) => {
   );
 };
 
-const LightningItem = () => {
-  const { t } = useTranslation();
-  const { isLightningReady } = useLightning();
-  const [balance, setBalance] = useState<accountApi.TAmountWithConversions>();
-  const mounted = useMountedRef();
-
-  useEffect(() => {
-    if (!isLightningReady) {
-      return;
-    }
-
-    const fetchBalance = async () => {
-      try {
-        const response = await getLightningBalance();
-        if (!mounted.current) {
-          return;
-        }
-        setBalance(response.available);
-      } catch (error) {
-        console.error('Failed to fetch lightning balance', error);
-      }
-    };
-
-    fetchBalance();
-  }, [isLightningReady, mounted]);
-
-  return (
-    <AccountRow
-      balance={balance}
-      coinCode="lightning"
-      name={t('lightning.accountLabel')}
-      to="/lightning"
-    />
-  );
-};
-
 /**
  * This component will only be shown on mobile.
  **/
 export const AllAccounts = ({ accounts = [] }: AllAccountsProps) => {
   const { t } = useTranslation();
-  const { lightningAccount } = useLightning();
   const accountsByKeystore = getAccountsByKeystore(accounts);
   useOnlyVisitableOnMobile('/account-summary');
 
@@ -138,11 +99,6 @@ export const AllAccounts = ({ accounts = [] }: AllAccountsProps) => {
       <View width="768px" fullscreen={false}>
         <ViewContent>
           <div className={styles.container} data-testid="all-accounts-keystores">
-            {lightningAccount && (
-              <div className={styles.accountsList}>
-                <LightningItem />
-              </div>
-            )}
             {accountsByKeystore.map(keystore => (
               <div key={`keystore-${keystore.keystore.rootFingerprint}`}>
                 <ConnectedKeystore


### PR DESCRIPTION
The mobile bottom navigation now provides a dedicated Lightning shortcut. Keeping another Lightning entry in the accounts list duplicates navigation and leaves a regular-account-only view available when empty.

Remove the Lightning row and its balance request. Redirect an empty accounts list to the portfolio when Lightning is available, or home when no wallet accounts exist. Cover both outcomes with route tests.
