### PR TITLE
ios: disable web view inspection

### DIFF
--- a/frontends/ios/BitBoxApp/BitBoxApp/WebView.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/WebView.swift
@@ -181,7 +181,9 @@ struct WebView: UIViewRepresentable {
         webView.configuration.userContentController.addUserScript(userScript)
          
         if #available(iOS 16.4, *) {
-            webView.isInspectable = true
+            // Set to true locally to debug with Safari Web Inspector, but keep it
+            // disabled in release builds to prevent access to the native bridge.
+            webView.isInspectable = false
         }
         
         return webView


### PR DESCRIPTION
iOS 16.4 allows apps to opt embedded web views into Safari Web Inspector access. Keeping this enabled in production lets an attached inspector execute JavaScript in the app context and reach the native bridge, including the Lightning payment endpoint.

Explicitly disable inspection so release builds do not expose the bridge through Safari developer tooling.
