### PR TITLE
frontend: fix back navigation not working in lightning menus

### DIFF
--- a/frontends/web/src/routes/account/send/components/inputs/scan-qr.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/scan-qr.tsx
@@ -2,6 +2,7 @@
 
 import { MouseEvent, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useBackButton } from '@/hooks/backbutton';
 import { useQRScanner } from '@/hooks/qrcodescanner';
 import { CloseXWhite, FlashWhite, FlashYellow } from '@/components/icon';
 import { SpinnerRingAnimated } from '@/components/spinner/SpinnerAnimation';
@@ -63,6 +64,11 @@ export const ScanQR = ({
     setOpen(false);
     closeTimer.current = setTimeout(onClosed, ANIMATION_MS);
   }, [onClose]);
+
+  useBackButton(() => {
+    requestClose();
+    return false;
+  });
 
   const handleValue = useCallback(async (value: string) => {
     const text = value.trim();

--- a/frontends/web/src/routes/lightning/activate.tsx
+++ b/frontends/web/src/routes/lightning/activate.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Logo } from '@/components/icon/logo';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { UseDisableBackButton } from '@/hooks/backbutton';
@@ -104,9 +105,9 @@ export const LightningActivate = () => {
             <Button primary onClick={() => setStep('information')}>
               {t('button.next')}
             </Button>
-            <Button secondary onClick={() => navigate(-1)}>
+            <BackButton onClick={() => navigate(-1)}>
               {t('button.back')}
-            </Button>
+            </BackButton>
           </ViewButtons>
         </View>
       );
@@ -130,9 +131,9 @@ export const LightningActivate = () => {
             <Button primary disabled={!agree} onClick={() => setStep('disclaimer')}>
               {t('button.next')}
             </Button>
-            <Button secondary onClick={() => setStep('intro')}>
+            <BackButton onClick={() => setStep('intro')}>
               {t('button.back')}
-            </Button>
+            </BackButton>
           </ViewButtons>
         </View>
       );
@@ -142,9 +143,9 @@ export const LightningActivate = () => {
           <Button primary onClick={() => waitForConnect()}>
             {t('lightning.disclaimer.continue')}
           </Button>
-          <Button secondary onClick={() => setStep('information')}>
+          <BackButton onClick={() => setStep('information')}>
             {t('button.back')}
-          </Button>
+          </BackButton>
         </LightningDisclaimerContent>
       );
     case 'connect':
@@ -157,9 +158,9 @@ export const LightningActivate = () => {
             <PointToBitBox02 />
           </ViewContent>
           <ViewButtons>
-            <Button secondary onClick={() => navigate(-1)}>
+            <BackButton onClick={() => navigate(-1)}>
               {t('button.back')}
-            </Button>
+            </BackButton>
           </ViewButtons>
         </View>
       );

--- a/frontends/web/src/routes/lightning/claim-top-up/claim-top-up.test.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/claim-top-up.test.tsx
@@ -9,6 +9,7 @@ import type { TAccount, TAmountWithConversions } from '@/api/account';
 import type { TLightningPayment } from '@/api/lightning';
 import * as lightningApi from '@/api/lightning';
 import { TLightningErrorCode, TSdkError } from '@/api/lightning-errors';
+import { BackButtonProvider } from '@/contexts/BackButtonContext';
 import { LightningClaimTopUp } from './claim-top-up';
 
 vi.mock('@/components/layout', () => ({
@@ -91,7 +92,9 @@ describe('routes/lightning/claim-top-up', () => {
 
     render(
       <MemoryRouter initialEntries={[`/lightning/claim-top-up?paymentId=${encodeURIComponent(paymentID)}`]}>
-        <LightningClaimTopUp activeAccounts={[]} />
+        <BackButtonProvider>
+          <LightningClaimTopUp activeAccounts={[]} />
+        </BackButtonProvider>
       </MemoryRouter>
     );
 
@@ -113,7 +116,9 @@ describe('routes/lightning/claim-top-up', () => {
 
     render(
       <MemoryRouter initialEntries={[`/lightning/claim-top-up?paymentId=${encodeURIComponent(paymentID)}`]}>
-        <LightningClaimTopUp activeAccounts={[]} />
+        <BackButtonProvider>
+          <LightningClaimTopUp activeAccounts={[]} />
+        </BackButtonProvider>
       </MemoryRouter>
     );
 
@@ -139,7 +144,9 @@ describe('routes/lightning/claim-top-up', () => {
 
     render(
       <MemoryRouter initialEntries={[`/lightning/claim-top-up?paymentId=${encodeURIComponent(paymentID)}`]}>
-        <LightningClaimTopUp activeAccounts={[bitcoinAccount]} />
+        <BackButtonProvider>
+          <LightningClaimTopUp activeAccounts={[bitcoinAccount]} />
+        </BackButtonProvider>
       </MemoryRouter>
     );
 
@@ -164,7 +171,9 @@ describe('routes/lightning/claim-top-up', () => {
 
     render(
       <MemoryRouter initialEntries={[`/lightning/claim-top-up?paymentId=${encodeURIComponent(paymentID)}`]}>
-        <LightningClaimTopUp activeAccounts={[bitcoinAccount]} />
+        <BackButtonProvider>
+          <LightningClaimTopUp activeAccounts={[bitcoinAccount]} />
+        </BackButtonProvider>
       </MemoryRouter>
     );
 

--- a/frontends/web/src/routes/lightning/claim-top-up/confirm-step.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/confirm-step.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslation } from 'react-i18next';
 import type { AccountCode, TAccount, TAmountWithConversions } from '@/api/account';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { GroupedAccountSelector } from '@/components/groupedaccountselector/groupedaccountselector';
 import { Message } from '@/components/message/message';
@@ -93,9 +94,9 @@ export const ClaimTopUpConfirm = ({
             {t('lightning.claimTopUp.confirm.refundButton')}
           </Button>
         )}
-        <Button secondary disabled={isSubmitting} onClick={onCancel}>
+        <BackButton disabled={isSubmitting} onClick={onCancel}>
           {t('dialog.cancel')}
-        </Button>
+        </BackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/claim-top-up/failure-step.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/failure-step.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useTranslation } from 'react-i18next';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
 import { CONTENT_MIN_HEIGHT, type TAction } from './constants';
@@ -43,9 +44,9 @@ export const ClaimTopUpFailure = ({
             : t('button.done')}
         </Button>
         {canTryRefund && (
-          <Button className={styles.doneButton} secondary onClick={onDone}>
+          <BackButton className={styles.doneButton} onClick={onDone}>
             {t('dialog.cancel')}
-          </Button>
+          </BackButton>
         )}
       </ViewButtons>
     </View>

--- a/frontends/web/src/routes/lightning/claim-top-up/overview-step.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/overview-step.tsx
@@ -3,6 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import type { TAmountWithConversions } from '@/api/account';
 import type { TLightningPayment } from '@/api/lightning';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
 import { AmountBlock } from './amount-block';
@@ -130,9 +131,9 @@ export const ClaimTopUpOverview = ({
         </div>
       </ViewContent>
       <ViewButtons>
-        <Button secondary onClick={onCancel}>
+        <BackButton onClick={onCancel}>
           {t('dialog.cancel')}
-        </Button>
+        </BackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { getLightningBalance, postCloseWithdraw, postPrepareCloseWithdraw, type TCloseWithdrawQuote } from '@/api/lightning';
 import type { AccountCode, TAccount, TAmountWithConversions } from '@/api/account';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { Header, Main } from '@/components/layout';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
@@ -160,9 +161,9 @@ export const LightningCloseWithdrawFunds = ({
             <Button primary onClick={() => navigate(primaryAction.route)}>
               {primaryAction.label}
             </Button>
-            <Button secondary onClick={() => navigate('/settings/lightning-settings')}>
+            <BackButton onClick={() => navigate('/settings/lightning-settings')}>
               {t('button.back')}
-            </Button>
+            </BackButton>
           </ViewButtons>
         </View>
       );

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
@@ -3,6 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import type { AccountCode, TAccount, TAmountWithConversions } from '@/api/account';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Button, Checkbox } from '@/components/forms';
 import { GroupedAccountSelector } from '@/components/groupedaccountselector/groupedaccountselector';
 import { Message } from '@/components/message/message';
@@ -134,9 +135,9 @@ export const CloseWithdrawConfirm = ({
         <Button danger disabled={!canClose || isClosing} onClick={onClose}>
           {t('lightning.settings.closeAndWithdrawFunds')}
         </Button>
-        <Button secondary disabled={isClosing} onClick={onCancel}>
+        <BackButton disabled={isClosing} onClick={onCancel}>
           {t('dialog.cancel')}
-        </Button>
+        </BackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/failure-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/failure-step.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useTranslation } from 'react-i18next';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
 import { CONTENT_MIN_HEIGHT } from './constants';
@@ -39,9 +40,9 @@ export const CloseWithdrawFailure = ({
             ? 'lightning.closeWithdrawFunds.partialFailure.action'
             : 'lightning.closeWithdrawFunds.failure.tryAgain')}
         </Button>
-        <Button className={styles.doneButton} secondary onClick={onCancel}>
+        <BackButton className={styles.doneButton} onClick={onCancel}>
           {t('dialog.cancel')}
-        </Button>
+        </BackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/deactivate.tsx
+++ b/frontends/web/src/routes/lightning/deactivate.tsx
@@ -7,6 +7,7 @@ import { Header, Main } from '../../components/layout';
 import { View, ViewButtons, ViewContent } from '../../components/view/view';
 import { MultilineMarkup } from '../../utils/markup';
 import { Button, Checkbox } from '../../components/forms';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { postDeactivate } from '../../api/lightning';
 import { Status } from '../../components/status/status';
 import { Spinner } from '../../components/spinner/Spinner';
@@ -56,9 +57,9 @@ export const LightningDeactivate = () => {
             <Button danger disabled={!agree} onClick={() => deactivateWallet()}>
               Shut down lightning wallet
             </Button>
-            <Button secondary onClick={() => navigate(-1)}>
+            <BackButton onClick={() => navigate(-1)}>
               {t('button.back')}
-            </Button>
+            </BackButton>
           </ViewButtons>
         </View>
       );

--- a/frontends/web/src/routes/lightning/receive/receive.test.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.test.tsx
@@ -7,6 +7,7 @@ import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as lightningApi from '@/api/lightning';
+import { BackButtonProvider } from '@/contexts/BackButtonContext';
 import { RatesContext } from '@/contexts/RatesContext';
 import { Receive } from './receive';
 
@@ -66,18 +67,20 @@ const balance: lightningApi.TLightningBalance = {
 
 const renderReceive = () => render(
   <MemoryRouter>
-    <RatesContext.Provider value={{
-      defaultCurrency: 'EUR',
-      activeCurrencies: ['EUR'],
-      btcUnit: 'sat',
-      rotateDefaultCurrency: vi.fn(),
-      rotateBtcUnit: vi.fn(),
-      addToActiveCurrencies: vi.fn(),
-      updateDefaultCurrency: vi.fn(),
-      removeFromActiveCurrencies: vi.fn(),
-    }}>
-      <Receive />
-    </RatesContext.Provider>
+    <BackButtonProvider>
+      <RatesContext.Provider value={{
+        defaultCurrency: 'EUR',
+        activeCurrencies: ['EUR'],
+        btcUnit: 'sat',
+        rotateDefaultCurrency: vi.fn(),
+        rotateBtcUnit: vi.fn(),
+        addToActiveCurrencies: vi.fn(),
+        updateDefaultCurrency: vi.fn(),
+        removeFromActiveCurrencies: vi.fn(),
+      }}>
+        <Receive />
+      </RatesContext.Provider>
+    </BackButtonProvider>
   </MemoryRouter>
 );
 

--- a/frontends/web/src/routes/lightning/receive/receive.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Column, Grid, GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
 import { Button, Input, NumberInput, OptionalLabel } from '@/components/forms';
+import { BackButton } from '@/components/backbutton/backbutton';
 import {
   TReceivePaymentResponse,
   getLightningBalance,
@@ -185,9 +186,9 @@ export function Receive() {
             </div>
           </ViewContent>
           <ViewButtons>
-            <Button secondary onClick={back}>
+            <BackButton onClick={back}>
               {t('button.back')}
-            </Button>
+            </BackButton>
           </ViewButtons>
         </View>
       );
@@ -240,9 +241,9 @@ export function Receive() {
             <Button primary onClick={receivePayment} disabled={!canCreateInvoice}>
               {t('lightning.receive.invoice.create')}
             </Button>
-            <Button secondary onClick={back}>
+            <BackButton onClick={back}>
               {t('button.back')}
-            </Button>
+            </BackButton>
           </ViewButtons>
         </View>
       );
@@ -289,9 +290,9 @@ export function Receive() {
             </div>
           </ViewContent>
           <ViewButtons>
-            <Button secondary onClick={cancelInvoice}>
+            <BackButton onClick={cancelInvoice}>
               {t('dialog.cancel')}
-            </Button>
+            </BackButton>
           </ViewButtons>
         </View>
       );

--- a/frontends/web/src/routes/lightning/send/components/bitcoin-address-review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/bitcoin-address-review-step.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TPaymentInputType, type TLightningBitcoinPaymentInput } from '@/api/lightning';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { Column, Grid } from '@/components/layout';
 import { Status } from '@/components/status/status';
@@ -87,9 +88,9 @@ export const BitcoinAddressReviewStep = ({
           disabled={!canSend}>
           {t('generic.send')}
         </Button>
-        <Button secondary onClick={() => backToPaymentInput()}>
+        <BackButton onClick={() => backToPaymentInput()}>
           {t('button.back')}
-        </Button>
+        </BackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/send/components/bolt11-review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/bolt11-review-step.tsx
@@ -3,6 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
 import { TPaymentInputType, type TLightningBolt11Invoice } from '@/api/lightning';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { Column, Grid } from '@/components/layout';
 import { Spinner } from '@/components/spinner/Spinner';
@@ -89,9 +90,9 @@ export const Bolt11ReviewStep = ({
           disabled={!canSend}>
           {t('generic.send')}
         </Button>
-        <Button secondary onClick={() => backToPaymentInput()}>
+        <BackButton onClick={() => backToPaymentInput()}>
           {t('button.back')}
-        </Button>
+        </BackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/send/components/lnurl-pay-review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/lnurl-pay-review-step.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TPaymentInputType, type TLightningLNURLPay } from '@/api/lightning';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { Column, Grid } from '@/components/layout';
 import { Status } from '@/components/status/status';
@@ -81,9 +82,9 @@ export const LNURLPayReviewStep = ({
           disabled={!canSend}>
           {t('generic.send')}
         </Button>
-        <Button secondary onClick={() => backToPaymentInput()}>
+        <BackButton onClick={() => backToPaymentInput()}>
           {t('button.back')}
-        </Button>
+        </BackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/set-lnurl-address.tsx
+++ b/frontends/web/src/routes/lightning/set-lnurl-address.tsx
@@ -11,6 +11,7 @@ import {
   postRegisterLightningAddress,
 } from '@/api/lightning';
 import { toLightningErrorMessage } from '@/api/lightning-errors';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Button, Input } from '@/components/forms';
 import { Cancel, Checked, Sync, SyncLight } from '@/components/icon';
 import { Header, Main } from '@/components/layout';
@@ -220,9 +221,9 @@ export const LightningSetLnurlAddress = () => {
             <p>{t('unknownError', { errorMessage: error })}</p>
           </ViewContent>
           <ViewButtons>
-            <Button secondary onClick={() => navigate(-1)}>
+            <BackButton onClick={() => navigate(-1)}>
               {t('button.back')}
-            </Button>
+            </BackButton>
           </ViewButtons>
         </View>
       );
@@ -264,9 +265,9 @@ export const LightningSetLnurlAddress = () => {
             <Button primary disabled={availability !== 'available' || isSaving} onClick={saveAddress}>
               {t('button.save')}
             </Button>
-            <Button secondary disabled={isSaving} onClick={() => navigate(-1)}>
+            <BackButton disabled={isSaving} onClick={() => navigate(-1)}>
               {t('dialog.cancel')}
-            </Button>
+            </BackButton>
           </ViewButtons>
         </View>
       );

--- a/frontends/web/src/routes/lightning/topup/topup-form.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup-form.tsx
@@ -3,6 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import type { AccountCode, CoinCode, ConversionUnit, FeeTargetCode, TAccount, TAmountWithConversions, TBalance, TTxProposalResult } from '@/api/account';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Button, NumberInput } from '@/components/forms';
 import { GroupedAccountSelector } from '@/components/groupedaccountselector/groupedaccountselector';
 import { HideAmountsButton } from '@/components/hideamountsbutton/hideamountsbutton';
@@ -172,9 +173,9 @@ export const TopUpForm = ({
                     onNoteChange={onNoteChange}
                   />
                   <ColumnButtons className="m-top-default m-bottom-xlarge" inline>
-                    <Button secondary onClick={onBack}>
+                    <BackButton onClick={onBack}>
                       {t('button.back')}
-                    </Button>
+                    </BackButton>
                     <Button
                       primary
                       onClick={onReview}

--- a/frontends/web/src/routes/lightning/topup/topup-result.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup-result.tsx
@@ -3,6 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import type { TAccount } from '@/api/account';
+import { BackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
@@ -72,9 +73,9 @@ export const TopUpNoBitcoinAccounts = ({ hasAccounts }: TTopUpNoBitcoinAccountsP
               <Button primary onClick={() => navigate(primaryAction.route)}>
                 {primaryAction.label}
               </Button>
-              <Button secondary onClick={() => navigate('/lightning')}>
+              <BackButton onClick={() => navigate('/lightning')}>
                 {t('button.back')}
-              </Button>
+              </BackButton>
             </ViewButtons>
           </View>
         </Main>
@@ -103,9 +104,9 @@ export const TopUpNoFundedBitcoinAccounts = ({ btcAccounts }: TTopUpNoFundedBitc
               <Button primary onClick={() => navigate(receiveRoute)}>
                 {t('generic.receive', { context: 'bitcoin' })}
               </Button>
-              <Button secondary onClick={() => navigate('/lightning')}>
+              <BackButton onClick={() => navigate('/lightning')}>
                 {t('button.back')}
-              </Button>
+              </BackButton>
             </ViewButtons>
           </View>
         </Main>


### PR DESCRIPTION
BackButton component should be used for back buttons to enable back navigation gestures on iOS and Android.

Also enables back navigation for the QR scanner.

