### PR TITLE
frontend: LN screens replace back button to chevron

### DIFF
--- a/frontends/web/src/routes/lightning/activate.tsx
+++ b/frontends/web/src/routes/lightning/activate.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Logo } from '@/components/icon/logo';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { UseDisableBackButton } from '@/hooks/backbutton';
@@ -19,6 +19,7 @@ import { postActivate } from '../../api/lightning';
 import { Status } from '../../components/status/status';
 import { LightningDisclaimerContent } from './disclaimer';
 import { LightningTorProxyWarning } from '@/components/banners/lightning-tor-proxy-warning';
+import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import styles from './activate.module.css';
 
 const CONTENT_MIN_HEIGHT = '38em';
@@ -89,6 +90,26 @@ export const LightningActivate = () => {
     }
   }, [activationStarted, lightningAccount, step]);
 
+  const handleBack = () => {
+    switch (step) {
+    case 'information':
+      setStep('intro');
+      return;
+    case 'disclaimer':
+      setStep('information');
+      return;
+    case 'intro':
+    case 'connect':
+      navigate(-1);
+      return;
+    }
+  };
+
+  const backEnabled = step === 'intro'
+    || step === 'information'
+    || step === 'disclaimer'
+    || step === 'connect';
+
   const renderSteps = () => {
     switch (step) {
     case 'intro':
@@ -105,9 +126,9 @@ export const LightningActivate = () => {
             <Button primary onClick={() => setStep('information')}>
               {t('button.next')}
             </Button>
-            <BackButton onClick={() => navigate(-1)}>
+            <DesktopBackButton onClick={handleBack}>
               {t('button.back')}
-            </BackButton>
+            </DesktopBackButton>
           </ViewButtons>
         </View>
       );
@@ -131,9 +152,9 @@ export const LightningActivate = () => {
             <Button primary disabled={!agree} onClick={() => setStep('disclaimer')}>
               {t('button.next')}
             </Button>
-            <BackButton onClick={() => setStep('intro')}>
+            <DesktopBackButton onClick={handleBack}>
               {t('button.back')}
-            </BackButton>
+            </DesktopBackButton>
           </ViewButtons>
         </View>
       );
@@ -143,9 +164,9 @@ export const LightningActivate = () => {
           <Button primary onClick={() => waitForConnect()}>
             {t('lightning.disclaimer.continue')}
           </Button>
-          <BackButton onClick={() => setStep('information')}>
+          <DesktopBackButton onClick={handleBack}>
             {t('button.back')}
-          </BackButton>
+          </DesktopBackButton>
         </LightningDisclaimerContent>
       );
     case 'connect':
@@ -158,9 +179,9 @@ export const LightningActivate = () => {
             <PointToBitBox02 />
           </ViewContent>
           <ViewButtons>
-            <BackButton onClick={() => navigate(-1)}>
+            <DesktopBackButton onClick={handleBack}>
               {t('button.back')}
-            </BackButton>
+            </DesktopBackButton>
           </ViewButtons>
         </View>
       );
@@ -230,7 +251,16 @@ export const LightningActivate = () => {
           {setupError}
         </Status>
       </ContentWrapper>
-      <Header title={t('lightning.activate.title')} />
+      <Header title={
+        <>
+          <h2 className="hide-on-small">{t('lightning.activate.title')}</h2>
+          <MobileHeader
+            onClick={handleBack}
+            title={t('lightning.activate.title')}
+            variant={backEnabled ? 'back' : 'titleOnly'}
+          />
+        </>
+      } />
       {renderSteps()}
     </Main>
   );

--- a/frontends/web/src/routes/lightning/claim-top-up/claim-top-up.test.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/claim-top-up.test.tsx
@@ -2,7 +2,7 @@
 
 import '../../../../__mocks__/i18n';
 import type { ReactNode } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TAccount, TAmountWithConversions } from '@/api/account';
@@ -152,6 +152,8 @@ describe('routes/lightning/claim-top-up', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'lightning.claimTopUp.claimButton' }));
     fireEvent.click(screen.getByRole('button', { name: 'lightning.claimTopUp.confirm.claimButton' }));
+    expect(await screen.findByText('lightning.claimTopUp.failure.claimFailedMessage')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'dialog.cancel' })).toBeInTheDocument();
     fireEvent.click(await screen.findByRole('button', { name: 'lightning.claimTopUp.refundButton' }));
 
     expect(screen.getByText('lightning.claimTopUp.confirm.refundDestination')).toBeInTheDocument();
@@ -191,5 +193,54 @@ describe('routes/lightning/claim-top-up', () => {
       bitcoinAccount.code,
       3,
     ));
+  });
+
+  it('allows back from confirmation but blocks Android back while submitting', async () => {
+    vi.mocked(window.matchMedia).mockImplementation(query => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    vi.mocked(lightningApi.getListPayments).mockResolvedValue([deposit(100)]);
+    let resolveClaim: (result: { txId: string }) => void = () => {};
+    vi.mocked(lightningApi.postClaimTopUp).mockReturnValue(new Promise(resolve => {
+      resolveClaim = resolve;
+    }));
+
+    render(
+      <MemoryRouter initialEntries={[`/lightning/claim-top-up?paymentId=${encodeURIComponent(paymentID)}`]}>
+        <BackButtonProvider>
+          <LightningClaimTopUp activeAccounts={[]} />
+        </BackButtonProvider>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'lightning.claimTopUp.claimButton' }));
+    expect(screen.getByText('lightning.claimTopUp.confirm.claimTitle')).toBeInTheDocument();
+    act(() => {
+      expect(window.onBackButtonPressed?.()).toBe(false);
+    });
+    expect(screen.getByRole('button', { name: 'lightning.claimTopUp.claimButton' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'lightning.claimTopUp.claimButton' }));
+    const confirmButton = screen.getByRole('button', { name: 'lightning.claimTopUp.confirm.claimButton' });
+    fireEvent.click(confirmButton);
+    await waitFor(() => expect(lightningApi.postClaimTopUp).toHaveBeenCalledOnce());
+
+    act(() => {
+      expect(window.onBackButtonPressed?.()).toBe(false);
+    });
+    expect(confirmButton).toBeDisabled();
+    expect(screen.getByText('lightning.claimTopUp.confirm.claimTitle')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveClaim({ txId: 'claim-txid' });
+    });
+    expect(await screen.findByText('lightning.claimTopUp.success.claimMessage')).toBeInTheDocument();
   });
 });

--- a/frontends/web/src/routes/lightning/claim-top-up/claim-top-up.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/claim-top-up.tsx
@@ -15,7 +15,9 @@ import { TLightningErrorCode, TSdkError, toLightningErrorMessage } from '@/api/l
 import { Header, Main } from '@/components/layout';
 import { Spinner } from '@/components/spinner/Spinner';
 import { useLoad } from '@/hooks/api';
+import { UseDisableBackButton } from '@/hooks/backbutton';
 import { useMountedRef } from '@/hooks/mount';
+import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { ClaimTopUpConfirm } from './confirm-step';
 import { ClaimTopUpFailure } from './failure-step';
 import { ClaimTopUpOverview } from './overview-step';
@@ -148,6 +150,20 @@ const LightningClaimTopUpInner = ({ activeAccounts, deposit, reloadDeposit }: TI
     startAction('refund');
   };
 
+  const handleBack = () => {
+    if (step === 'confirm') {
+      setStep('overview');
+      return;
+    }
+    navigate(-1);
+  };
+
+  const headerBackEnabled = step === 'overview'
+    || (step === 'confirm' && !isSubmitting);
+  const headerTitle = step === 'success'
+    ? t(`lightning.claimTopUp.success.${action}Title`)
+    : t('lightning.claimTopUp.title');
+
   const renderContent = () => {
     if (deposit === undefined) {
       return <Spinner text={t('lightning.initializing')} />;
@@ -184,7 +200,7 @@ const LightningClaimTopUpInner = ({ activeAccounts, deposit, reloadDeposit }: TI
           refundDestinationAccountCode={refundDestinationAccountCode}
           refundUnavailable={!isClaim && refundUnavailable}
           topUpAmount={deposit?.amount}
-          onCancel={() => setStep('overview')}
+          onCancel={handleBack}
           onConfirm={confirmAction}
           onRefundDestinationChange={setRefundDestinationAccountCode}
         />
@@ -198,7 +214,7 @@ const LightningClaimTopUpInner = ({ activeAccounts, deposit, reloadDeposit }: TI
         canRefund={canStartRefund}
         refundFeeRateSatPerVbyte={refundFeeRateSatPerVbyte}
         refundUnavailable={refundUnavailable}
-        onCancel={() => navigate(-1)}
+        onCancel={handleBack}
         onClaim={() => startAction('claim')}
         onRefund={() => startAction('refund')}
       />
@@ -208,12 +224,19 @@ const LightningClaimTopUpInner = ({ activeAccounts, deposit, reloadDeposit }: TI
   return (
     <Main>
       <Header
-        title={step === 'success'
-          ? t(`lightning.claimTopUp.success.${action}Title`)
-          : t('lightning.claimTopUp.title')
+        title={
+          <>
+            <h2 className="hide-on-small">{headerTitle}</h2>
+            <MobileHeader
+              onClick={handleBack}
+              title={headerTitle}
+              variant={headerBackEnabled ? 'back' : 'titleOnly'}
+            />
+          </>
         }
       />
       {renderContent()}
+      {isSubmitting && <UseDisableBackButton />}
     </Main>
   );
 };

--- a/frontends/web/src/routes/lightning/claim-top-up/confirm-step.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/confirm-step.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslation } from 'react-i18next';
 import type { AccountCode, TAccount, TAmountWithConversions } from '@/api/account';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { GroupedAccountSelector } from '@/components/groupedaccountselector/groupedaccountselector';
 import { Message } from '@/components/message/message';
@@ -94,9 +94,9 @@ export const ClaimTopUpConfirm = ({
             {t('lightning.claimTopUp.confirm.refundButton')}
           </Button>
         )}
-        <BackButton disabled={isSubmitting} onClick={onCancel}>
+        <DesktopBackButton disabled={isSubmitting} onClick={onCancel}>
           {t('dialog.cancel')}
-        </BackButton>
+        </DesktopBackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/claim-top-up/overview-step.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/overview-step.tsx
@@ -3,7 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import type { TAmountWithConversions } from '@/api/account';
 import type { TLightningPayment } from '@/api/lightning';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
 import { AmountBlock } from './amount-block';
@@ -131,9 +131,9 @@ export const ClaimTopUpOverview = ({
         </div>
       </ViewContent>
       <ViewButtons>
-        <BackButton onClick={onCancel}>
+        <DesktopBackButton onClick={onCancel}>
           {t('dialog.cancel')}
-        </BackButton>
+        </DesktopBackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.test.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.test.tsx
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../../__mocks__/i18n';
+import type { ReactNode } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TAccount, TAmountWithConversions } from '@/api/account';
+import * as lightningApi from '@/api/lightning';
+import { BackButtonProvider } from '@/contexts/BackButtonContext';
+import { LightningCloseWithdrawFunds } from './close-withdraw-funds';
+
+vi.mock('@/i18n/i18n');
+
+vi.mock('@/components/layout', () => ({
+  Header: ({ title }: { title: ReactNode }) => <header>{title}</header>,
+  Main: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+}));
+
+vi.mock('@/components/amount/amount-with-unit', () => ({
+  AmountWithUnit: ({ amount: displayedAmount }: { amount?: TAmountWithConversions }) => (
+    <span>{displayedAmount?.amount}</span>
+  ),
+}));
+
+vi.mock('@/components/groupedaccountselector/groupedaccountselector', () => ({
+  GroupedAccountSelector: () => <div />,
+}));
+
+vi.mock('@/api/lightning', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/lightning')>();
+  return {
+    ...actual,
+    getLightningBalance: vi.fn(),
+    postCloseWithdraw: vi.fn(),
+    postPrepareCloseWithdraw: vi.fn(),
+  };
+});
+
+const amount = (value: string): TAmountWithConversions => ({
+  amount: value,
+  conversions: {},
+  estimated: false,
+  unit: 'sat',
+});
+
+const bitcoinAccount = {
+  active: true,
+  blockExplorerTxPrefix: '',
+  code: 'btc-0',
+  coinCode: 'btc',
+} as TAccount;
+
+const setMobileViewport = () => {
+  vi.mocked(window.matchMedia).mockImplementation(query => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+};
+
+const SettingsPage = () => {
+  const navigate = useNavigate();
+  return <button onClick={() => navigate(-1)}>settings back</button>;
+};
+
+describe('Lightning Close & Withdraw back navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMobileViewport();
+    vi.mocked(lightningApi.getLightningBalance).mockResolvedValue({
+      available: amount('10000'),
+      fundingLimit: {
+        limitSat: 20000,
+        marginSat: 10000,
+      },
+      hasAvailable: true,
+      hasIncoming: false,
+      incoming: amount('0'),
+    });
+    vi.mocked(lightningApi.postPrepareCloseWithdraw).mockResolvedValue({
+      balance: amount('10000'),
+      balanceSat: 10000,
+      fee: amount('100'),
+      feeSat: 100,
+    });
+  });
+
+  it('blocks Android back while closing', async () => {
+    let resolveClose: (result: { txId: string; walletClosed: boolean }) => void = () => {};
+    vi.mocked(lightningApi.postCloseWithdraw).mockReturnValue(new Promise(resolve => {
+      resolveClose = resolve;
+    }));
+
+    render(
+      <MemoryRouter initialEntries={['/lightning/close-withdraw-funds']}>
+        <BackButtonProvider>
+          <LightningCloseWithdrawFunds activeAccounts={[bitcoinAccount]} hasAccounts />
+        </BackButtonProvider>
+      </MemoryRouter>
+    );
+
+    const confirmation = await screen.findByLabelText('lightning.closeWithdrawFunds.confirm');
+    fireEvent.click(confirmation);
+    const closeButton = screen.getByRole('button', { name: 'lightning.settings.closeAndWithdrawFunds' });
+    await waitFor(() => expect(closeButton).toBeEnabled());
+    fireEvent.click(closeButton);
+    await waitFor(() => expect(lightningApi.postCloseWithdraw).toHaveBeenCalledOnce());
+
+    expect(document.querySelector('header button')).not.toBeInTheDocument();
+    act(() => {
+      expect(window.onBackButtonPressed?.()).toBe(false);
+    });
+    expect(confirmation).toBeDisabled();
+    expect(closeButton).toBeDisabled();
+
+    await act(async () => {
+      resolveClose({ txId: 'close-txid', walletClosed: true });
+    });
+    expect(await screen.findByText('lightning.closeWithdrawFunds.success.message')).toBeInTheDocument();
+  });
+
+  it('pops the fallback route instead of adding Lightning Settings to history', async () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/settings/advanced-settings',
+          '/settings/lightning-settings',
+          '/lightning/close-withdraw-funds',
+        ]}
+        initialIndex={2}
+      >
+        <BackButtonProvider>
+          <Routes>
+            <Route path="/settings/advanced-settings" element={<span>advanced settings</span>} />
+            <Route path="/settings/lightning-settings" element={<SettingsPage />} />
+            <Route
+              path="/lightning/close-withdraw-funds"
+              element={<LightningCloseWithdrawFunds activeAccounts={[]} hasAccounts={false} />}
+            />
+          </Routes>
+        </BackButtonProvider>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('lightning.topUp.noBitcoinAccounts')).toBeInTheDocument();
+    act(() => {
+      expect(window.onBackButtonPressed?.()).toBe(false);
+    });
+    fireEvent.click(await screen.findByRole('button', { name: 'settings back' }));
+
+    expect(await screen.findByText('advanced settings')).toBeInTheDocument();
+    expect(screen.queryByText('lightning.topUp.noBitcoinAccounts')).not.toBeInTheDocument();
+  });
+
+  it('keeps failure Cancel in the body and pops back to Lightning Settings', async () => {
+    vi.mocked(lightningApi.postPrepareCloseWithdraw).mockRejectedValue(new Error('prepare failed'));
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/settings/advanced-settings',
+          '/settings/lightning-settings',
+          '/lightning/close-withdraw-funds',
+        ]}
+        initialIndex={2}
+      >
+        <BackButtonProvider>
+          <Routes>
+            <Route path="/settings/advanced-settings" element={<span>advanced settings</span>} />
+            <Route path="/settings/lightning-settings" element={<SettingsPage />} />
+            <Route
+              path="/lightning/close-withdraw-funds"
+              element={<LightningCloseWithdrawFunds activeAccounts={[bitcoinAccount]} hasAccounts />}
+            />
+          </Routes>
+        </BackButtonProvider>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'dialog.cancel' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'settings back' }));
+
+    expect(await screen.findByText('advanced settings')).toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
@@ -5,11 +5,13 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { getLightningBalance, postCloseWithdraw, postPrepareCloseWithdraw, type TCloseWithdrawQuote } from '@/api/lightning';
 import type { AccountCode, TAccount, TAmountWithConversions } from '@/api/account';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { Header, Main } from '@/components/layout';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { UseDisableBackButton } from '@/hooks/backbutton';
 import { useMountedRef } from '@/hooks/mount';
+import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { CloseWithdrawConfirm } from './confirm-step';
 import { CloseWithdrawFailure } from './failure-step';
 import { CloseWithdrawSuccess } from './success-step';
@@ -141,6 +143,11 @@ export const LightningCloseWithdrawFunds = ({
     }
   }, [destinationAccountCode, mounted, quote]);
 
+  const handleBack = () => navigate(-1);
+
+  const headerBackEnabled = !btcAccounts.length
+    || (step === 'confirm' && !isClosing);
+
   const renderStep = () => {
     if (!btcAccounts.length) {
       const primaryAction = hasAccounts
@@ -161,9 +168,9 @@ export const LightningCloseWithdrawFunds = ({
             <Button primary onClick={() => navigate(primaryAction.route)}>
               {primaryAction.label}
             </Button>
-            <BackButton onClick={() => navigate('/settings/lightning-settings')}>
+            <DesktopBackButton onClick={handleBack}>
               {t('button.back')}
-            </BackButton>
+            </DesktopBackButton>
           </ViewButtons>
         </View>
       );
@@ -183,7 +190,7 @@ export const LightningCloseWithdrawFunds = ({
           incoming={incoming}
           incomingConfirmed={incomingConfirmed}
           isClosing={isClosing}
-          onCancel={() => navigate(-1)}
+          onCancel={handleBack}
           onClose={closeWithdraw}
           onConfirmChange={() => setConfirmed(current => !current)}
           onIncomingConfirmChange={() => setIncomingConfirmed(current => !current)}
@@ -198,7 +205,7 @@ export const LightningCloseWithdrawFunds = ({
       return (
         <CloseWithdrawFailure
           partial={step === 'partialFailure'}
-          onCancel={() => navigate('/settings/lightning-settings')}
+          onCancel={() => navigate(-1)}
           onTryAgain={() => {
             if (step === 'partialFailure') {
               navigate('/lightning/deactivate/');
@@ -221,8 +228,18 @@ export const LightningCloseWithdrawFunds = ({
 
   return (
     <Main>
-      <Header title={t('lightning.settings.closeAndWithdrawFunds')} />
+      <Header title={
+        <>
+          <h2 className="hide-on-small">{t('lightning.settings.closeAndWithdrawFunds')}</h2>
+          <MobileHeader
+            onClick={handleBack}
+            title={t('lightning.settings.closeAndWithdrawFunds')}
+            variant={headerBackEnabled ? 'back' : 'titleOnly'}
+          />
+        </>
+      } />
       {renderStep()}
+      {isClosing && <UseDisableBackButton />}
     </Main>
   );
 };

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
@@ -3,7 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import type { AccountCode, TAccount, TAmountWithConversions } from '@/api/account';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button, Checkbox } from '@/components/forms';
 import { GroupedAccountSelector } from '@/components/groupedaccountselector/groupedaccountselector';
 import { Message } from '@/components/message/message';
@@ -135,9 +135,9 @@ export const CloseWithdrawConfirm = ({
         <Button danger disabled={!canClose || isClosing} onClick={onClose}>
           {t('lightning.settings.closeAndWithdrawFunds')}
         </Button>
-        <BackButton disabled={isClosing} onClick={onCancel}>
+        <DesktopBackButton disabled={isClosing} onClick={onCancel}>
           {t('dialog.cancel')}
-        </BackButton>
+        </DesktopBackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/deactivate.tsx
+++ b/frontends/web/src/routes/lightning/deactivate.tsx
@@ -7,11 +7,12 @@ import { Header, Main } from '../../components/layout';
 import { View, ViewButtons, ViewContent } from '../../components/view/view';
 import { MultilineMarkup } from '../../utils/markup';
 import { Button, Checkbox } from '../../components/forms';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { postDeactivate } from '../../api/lightning';
 import { Status } from '../../components/status/status';
 import { Spinner } from '../../components/spinner/Spinner';
 import { route } from '../../utils/route';
+import { MobileHeader } from '@/routes/settings/components/mobile-header';
 
 const CONTENT_MIN_HEIGHT = '38em';
 
@@ -57,9 +58,9 @@ export const LightningDeactivate = () => {
             <Button danger disabled={!agree} onClick={() => deactivateWallet()}>
               Shut down lightning wallet
             </Button>
-            <BackButton onClick={() => navigate(-1)}>
+            <DesktopBackButton onClick={() => navigate(-1)}>
               {t('button.back')}
-            </BackButton>
+            </DesktopBackButton>
           </ViewButtons>
         </View>
       );
@@ -86,7 +87,16 @@ export const LightningDeactivate = () => {
       <Status dismissibleKey="" type="warning" hidden={!deactivateError}>
         {deactivateError}
       </Status>
-      <Header title="Shut down lightning wallet" />
+      <Header title={
+        <>
+          <h2 className="hide-on-small">Shut down lightning wallet</h2>
+          <MobileHeader
+            onClick={() => navigate(-1)}
+            title="Shut down lightning wallet"
+            variant={step === 'intro' ? 'back' : 'titleOnly'}
+          />
+        </>
+      } />
       {renderSteps()}
     </Main>
   );

--- a/frontends/web/src/routes/lightning/receive/receive.test.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.test.tsx
@@ -2,9 +2,9 @@
 
 import '../../../../__mocks__/i18n';
 import type { ReactNode } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as lightningApi from '@/api/lightning';
 import { BackButtonProvider } from '@/contexts/BackButtonContext';
@@ -65,8 +65,26 @@ const balance: lightningApi.TLightningBalance = {
   incoming: amount('0'),
 };
 
+const LocationPath = () => {
+  const location = useLocation();
+  return <span data-testid="location-path">{location.pathname}</span>;
+};
+
+const setMobileViewport = (matches: boolean) => {
+  vi.mocked(window.matchMedia).mockImplementation(query => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+};
+
 const renderReceive = () => render(
-  <MemoryRouter>
+  <MemoryRouter initialEntries={['/lightning/receive']}>
     <BackButtonProvider>
       <RatesContext.Provider value={{
         defaultCurrency: 'EUR',
@@ -80,13 +98,21 @@ const renderReceive = () => render(
       }}>
         <Receive />
       </RatesContext.Provider>
+      <LocationPath />
     </BackButtonProvider>
   </MemoryRouter>
 );
 
+const pressSystemBack = () => {
+  act(() => {
+    expect(window.onBackButtonPressed?.()).toBe(false);
+  });
+};
+
 describe('Lightning receive funding limit', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    setMobileViewport(false);
     vi.spyOn(lightningApi, 'getLightningAddress').mockResolvedValue('test@bitbox.swiss');
     vi.spyOn(lightningApi, 'subscribeLightningAddress').mockReturnValue(vi.fn());
     vi.spyOn(lightningApi, 'getLightningBalance').mockResolvedValue(balance);
@@ -114,5 +140,27 @@ describe('Lightning receive funding limit', () => {
       amountSat: 250000,
       description: '',
     });
+  });
+
+  it('uses the mobile header callback for the address, form, and invoice stages', async () => {
+    setMobileViewport(true);
+    renderReceive();
+
+    expect(await screen.findByText('test@bitbox.swiss', { selector: 'p' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'lightning.receive.invoice.create' }));
+    expect(await screen.findByLabelText('lightning.receive.description.label')).toBeInTheDocument();
+
+    pressSystemBack();
+    expect(screen.getByText('test@bitbox.swiss', { selector: 'p' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'lightning.receive.invoice.create' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'lightning.receive.invoice.create' }));
+    expect(await screen.findByTestId('invoice-qr')).toBeInTheDocument();
+
+    pressSystemBack();
+    expect(screen.getByText('test@bitbox.swiss', { selector: 'p' })).toBeInTheDocument();
+
+    pressSystemBack();
+    expect(screen.getByTestId('location-path')).toHaveTextContent('/lightning');
   });
 });

--- a/frontends/web/src/routes/lightning/receive/receive.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Column, Grid, GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
 import { Button, Input, NumberInput, OptionalLabel } from '@/components/forms';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import {
   TReceivePaymentResponse,
   getLightningBalance,
@@ -32,6 +32,7 @@ import {
   getLightningFundingLimitError,
 } from '../limits';
 import { LightningReceiveGuide } from '../guide';
+import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import styles from './receive.module.css';
 
 export function Receive() {
@@ -186,9 +187,9 @@ export function Receive() {
             </div>
           </ViewContent>
           <ViewButtons>
-            <BackButton onClick={back}>
+            <DesktopBackButton onClick={back}>
               {t('button.back')}
-            </BackButton>
+            </DesktopBackButton>
           </ViewButtons>
         </View>
       );
@@ -241,9 +242,9 @@ export function Receive() {
             <Button primary onClick={receivePayment} disabled={!canCreateInvoice}>
               {t('lightning.receive.invoice.create')}
             </Button>
-            <BackButton onClick={back}>
+            <DesktopBackButton onClick={back}>
               {t('button.back')}
-            </BackButton>
+            </DesktopBackButton>
           </ViewButtons>
         </View>
       );
@@ -290,9 +291,9 @@ export function Receive() {
             </div>
           </ViewContent>
           <ViewButtons>
-            <BackButton onClick={cancelInvoice}>
+            <DesktopBackButton onClick={cancelInvoice}>
               {t('dialog.cancel')}
-            </BackButton>
+            </DesktopBackButton>
           </ViewButtons>
         </View>
       );
@@ -342,7 +343,17 @@ export function Receive() {
           <Status dismissibleKey="" type="warning" hidden={!receiveError}>
             {receiveError}
           </Status>
-          <Header title={<h2>{t('lightning.receive.title')}</h2>} />
+          <Header title={
+            <>
+              <h2 className="hide-on-small">{t('lightning.receive.title')}</h2>
+              <MobileHeader
+                onClick={step === 'invoice' ? cancelInvoice : back}
+                title={t('lightning.receive.title')}
+                variant={step === 'wait' || step === 'success' ? 'titleOnly' : 'back'}
+                withGuide
+              />
+            </>
+          } />
           {renderSteps()}
         </Main>
       </GuidedContent>

--- a/frontends/web/src/routes/lightning/send/components/bitcoin-address-review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/bitcoin-address-review-step.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TPaymentInputType, type TLightningBitcoinPaymentInput } from '@/api/lightning';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { Column, Grid } from '@/components/layout';
 import { Status } from '@/components/status/status';
@@ -16,12 +16,14 @@ import { type TPaymentReviewDetails, usePaymentReview } from '../hooks/use-payme
 type TProps = {
   bitcoinAddress: TLightningBitcoinPaymentInput;
   backToPaymentInput: (nextInputError?: string) => void;
+  onSendingChange: (isSending: boolean) => void;
   onSuccess: () => void;
 };
 
 export const BitcoinAddressReviewStep = ({
   bitcoinAddress,
   backToPaymentInput,
+  onSendingChange,
   onSuccess,
 }: TProps) => {
   const { t } = useTranslation();
@@ -42,6 +44,7 @@ export const BitcoinAddressReviewStep = ({
   } = usePaymentReview({
     paymentDetails,
     backToPaymentInput,
+    onSendingChange,
     onSuccess,
   });
 
@@ -88,9 +91,9 @@ export const BitcoinAddressReviewStep = ({
           disabled={!canSend}>
           {t('generic.send')}
         </Button>
-        <BackButton onClick={() => backToPaymentInput()}>
+        <DesktopBackButton onClick={() => backToPaymentInput()}>
           {t('button.back')}
-        </BackButton>
+        </DesktopBackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/send/components/bolt11-review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/bolt11-review-step.tsx
@@ -3,7 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
 import { TPaymentInputType, type TLightningBolt11Invoice } from '@/api/lightning';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { Column, Grid } from '@/components/layout';
 import { Spinner } from '@/components/spinner/Spinner';
@@ -17,12 +17,14 @@ import { SendingSpinner } from './sending-spinner';
 type TProps = {
   invoice: TLightningBolt11Invoice;
   backToPaymentInput: (nextInputError?: string) => void;
+  onSendingChange: (isSending: boolean) => void;
   onSuccess: () => void;
 };
 
 export const Bolt11ReviewStep = ({
   invoice,
   backToPaymentInput,
+  onSendingChange,
   onSuccess,
 }: TProps) => {
   const { t } = useTranslation();
@@ -43,6 +45,7 @@ export const Bolt11ReviewStep = ({
   } = usePaymentReview({
     paymentDetails,
     backToPaymentInput,
+    onSendingChange,
     onSuccess,
   });
 
@@ -90,9 +93,9 @@ export const Bolt11ReviewStep = ({
           disabled={!canSend}>
           {t('generic.send')}
         </Button>
-        <BackButton onClick={() => backToPaymentInput()}>
+        <DesktopBackButton onClick={() => backToPaymentInput()}>
           {t('button.back')}
-        </BackButton>
+        </DesktopBackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/send/components/lnurl-pay-review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/lnurl-pay-review-step.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TPaymentInputType, type TLightningLNURLPay } from '@/api/lightning';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { Column, Grid } from '@/components/layout';
 import { Status } from '@/components/status/status';
@@ -16,12 +16,14 @@ import { SendingSpinner } from './sending-spinner';
 type TProps = {
   lnurlPay: TLightningLNURLPay;
   backToPaymentInput: (nextInputError?: string) => void;
+  onSendingChange: (isSending: boolean) => void;
   onSuccess: () => void;
 };
 
 export const LNURLPayReviewStep = ({
   lnurlPay,
   backToPaymentInput,
+  onSendingChange,
   onSuccess,
 }: TProps) => {
   const { t } = useTranslation();
@@ -42,6 +44,7 @@ export const LNURLPayReviewStep = ({
   } = usePaymentReview({
     paymentDetails,
     backToPaymentInput,
+    onSendingChange,
     onSuccess,
   });
 
@@ -82,9 +85,9 @@ export const LNURLPayReviewStep = ({
           disabled={!canSend}>
           {t('generic.send')}
         </Button>
-        <BackButton onClick={() => backToPaymentInput()}>
+        <DesktopBackButton onClick={() => backToPaymentInput()}>
           {t('button.back')}
-        </BackButton>
+        </DesktopBackButton>
       </ViewButtons>
     </View>
   );

--- a/frontends/web/src/routes/lightning/send/components/review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/review-step.tsx
@@ -8,12 +8,14 @@ import { LNURLPayReviewStep } from './lnurl-pay-review-step';
 type TProps = {
   paymentInput: TPaymentInput;
   backToPaymentInput: (nextInputError?: string) => void;
+  onSendingChange: (isSending: boolean) => void;
   onSuccess: () => void;
 };
 
 export const ReviewStep = ({
   paymentInput,
   backToPaymentInput,
+  onSendingChange,
   onSuccess,
 }: TProps) => {
   switch (paymentInput.type) {
@@ -22,6 +24,7 @@ export const ReviewStep = ({
       <BitcoinAddressReviewStep
         bitcoinAddress={paymentInput.bitcoinAddress}
         backToPaymentInput={backToPaymentInput}
+        onSendingChange={onSendingChange}
         onSuccess={onSuccess}
       />
     );
@@ -30,6 +33,7 @@ export const ReviewStep = ({
       <Bolt11ReviewStep
         invoice={paymentInput.invoice}
         backToPaymentInput={backToPaymentInput}
+        onSendingChange={onSendingChange}
         onSuccess={onSuccess}
       />
     );
@@ -38,6 +42,7 @@ export const ReviewStep = ({
       <LNURLPayReviewStep
         lnurlPay={paymentInput.lnurlPay}
         backToPaymentInput={backToPaymentInput}
+        onSendingChange={onSendingChange}
         onSuccess={onSuccess}
       />
     );

--- a/frontends/web/src/routes/lightning/send/hooks/use-payment-review.ts
+++ b/frontends/web/src/routes/lightning/send/hooks/use-payment-review.ts
@@ -31,6 +31,7 @@ export type TPaymentReviewDetails = {
 type TUsePaymentReviewProps = {
   paymentDetails: TPaymentReviewDetails;
   backToPaymentInput: (nextInputError?: string) => void;
+  onSendingChange: (isSending: boolean) => void;
   onSuccess: () => void;
 };
 
@@ -67,6 +68,7 @@ const insufficientFundsFees = (error: unknown): TPreparePaymentResponse | undefi
 export const usePaymentReview = ({
   paymentDetails,
   backToPaymentInput,
+  onSendingChange,
   onSuccess,
 }: TUsePaymentReviewProps) => {
   const { t } = useTranslation();
@@ -259,6 +261,10 @@ export const usePaymentReview = ({
     preparePayment,
     t,
   ]);
+
+  useEffect(() => {
+    onSendingChange(isSending);
+  }, [isSending, onSendingChange]);
 
   useEffect(() => {
     setCustomAmount(undefined);

--- a/frontends/web/src/routes/lightning/send/send.test.tsx
+++ b/frontends/web/src/routes/lightning/send/send.test.tsx
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../../__mocks__/i18n';
+import type { ReactNode } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TPaymentInputType } from '@/api/lightning';
+import * as lightningApi from '@/api/lightning';
+import { BackButtonProvider } from '@/contexts/BackButtonContext';
+import { Send } from './send';
+
+vi.mock('@/i18n/i18n');
+
+vi.mock('@/components/layout', () => ({
+  Column: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Grid: ({ children }: { children: ReactNode }) => <>{children}</>,
+  GuideWrapper: ({ children }: { children: ReactNode }) => <>{children}</>,
+  GuidedContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Header: ({ title }: { title: ReactNode }) => <header>{title}</header>,
+  Main: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+}));
+
+vi.mock('@/components/status/status', () => ({
+  Status: ({ children, hidden }: { children: ReactNode; hidden?: boolean }) => hidden ? null : <>{children}</>,
+}));
+
+vi.mock('@/api/lightning', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/lightning')>();
+  return {
+    ...actual,
+    getParsePaymentInput: vi.fn(),
+    postPreparePayment: vi.fn(),
+    postSendPayment: vi.fn(),
+  };
+});
+
+vi.mock('../guide', () => ({
+  LightningSendGuide: () => null,
+}));
+
+vi.mock('./components/select-payment-input-step', () => ({
+  SelectPaymentInputStep: ({
+    onSubmit,
+  }: {
+    onSubmit: (input: string) => Promise<boolean>;
+  }) => <button onClick={() => onSubmit('lnbc1invoice')}>review payment</button>,
+}));
+
+vi.mock('./components/custom-payment-amount', () => ({
+  CustomPaymentAmount: () => null,
+  PaymentBalance: () => null,
+}));
+
+vi.mock('./components/payment-input-details', () => ({
+  BitcoinAddressRecipientDetails: () => null,
+  Bolt11PaymentDetails: () => null,
+  LNURLPayRecipientDetails: () => null,
+  PaymentAmountDetails: () => null,
+  PaymentFeeDetails: () => null,
+  PaymentNoteDetails: () => null,
+}));
+
+vi.mock('./components/success-step', () => ({
+  SuccessStep: () => <span>payment sent</span>,
+}));
+
+const LocationPath = () => {
+  const location = useLocation();
+  return <span data-testid="location-path">{location.pathname}</span>;
+};
+
+const renderSend = () => render(
+  <MemoryRouter initialEntries={['/lightning/send']}>
+    <BackButtonProvider>
+      <Send activeAccounts={[]} />
+      <LocationPath />
+    </BackButtonProvider>
+  </MemoryRouter>
+);
+
+const pressSystemBack = () => {
+  act(() => {
+    expect(window.onBackButtonPressed?.()).toBe(false);
+  });
+};
+
+describe('Lightning Send back navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(window.matchMedia).mockImplementation(query => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    vi.mocked(lightningApi.getParsePaymentInput).mockResolvedValue({
+      type: TPaymentInputType.BOLT11,
+      invoice: {
+        amountSat: 100,
+        invoice: 'lnbc1invoice',
+      },
+    });
+    vi.mocked(lightningApi.postPreparePayment).mockResolvedValue({
+      amountSat: 100,
+      feeSat: 1,
+      totalDebitSat: 101,
+    });
+  });
+
+  it('allows back from review but blocks it while sending', async () => {
+    let resolvePayment: () => void = () => {};
+    vi.mocked(lightningApi.postSendPayment).mockReturnValue(new Promise<void>(resolve => {
+      resolvePayment = resolve;
+    }));
+    renderSend();
+
+    fireEvent.click(screen.getByRole('button', { name: 'review payment' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'generic.send' })).toBeEnabled());
+
+    pressSystemBack();
+    expect(screen.getByRole('button', { name: 'review payment' })).toBeInTheDocument();
+    expect(screen.getByTestId('location-path')).toHaveTextContent('/lightning/send');
+
+    fireEvent.click(screen.getByRole('button', { name: 'review payment' }));
+    const sendButton = await screen.findByRole('button', { name: 'generic.send' });
+    await waitFor(() => expect(sendButton).toBeEnabled());
+    fireEvent.click(sendButton);
+
+    expect(await screen.findByText('lightning.send.sending.connecting')).toBeInTheDocument();
+    await waitFor(() => expect(document.querySelector('header button')).not.toBeInTheDocument());
+    pressSystemBack();
+
+    expect(screen.getByText('lightning.send.sending.connecting')).toBeInTheDocument();
+    expect(screen.getByTestId('location-path')).toHaveTextContent('/lightning/send');
+
+    await act(async () => {
+      resolvePayment();
+    });
+    expect(await screen.findByText('payment sent')).toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/routes/lightning/send/send.tsx
+++ b/frontends/web/src/routes/lightning/send/send.tsx
@@ -6,6 +6,8 @@ import { useNavigate } from 'react-router-dom';
 import type { TAccount } from '@/api/account';
 import { type TPaymentInput, getParsePaymentInput } from '@/api/lightning';
 import { GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
+import { UseDisableBackButton } from '@/hooks/backbutton';
+import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { ReviewStep } from './components/review-step';
 import { SelectPaymentInputStep } from './components/select-payment-input-step';
 import { SuccessStep } from './components/success-step';
@@ -24,8 +26,10 @@ export const Send = ({ activeAccounts }: TProps) => {
   const [step, setStep] = useState<TSendStep>('select-payment-input');
   const [paymentInput, setPaymentInput] = useState<TPaymentInput>();
   const [inputError, setInputError] = useState<string>();
+  const [isSending, setIsSending] = useState(false);
 
   const resetToPaymentInputEntry = useCallback((nextInputError?: string) => {
+    setIsSending(false);
     setStep('select-payment-input');
     setPaymentInput(undefined);
     setInputError(nextInputError);
@@ -46,8 +50,17 @@ export const Send = ({ activeAccounts }: TProps) => {
   }, [t]);
 
   const showSuccess = useCallback(() => {
+    setIsSending(false);
     setStep('success');
   }, []);
+
+  const handleBack = () => {
+    if (step === 'review') {
+      resetToPaymentInputEntry();
+      return;
+    }
+    navigate('/lightning');
+  };
 
   useEffect(() => {
     if (step !== 'success') {
@@ -62,7 +75,18 @@ export const Send = ({ activeAccounts }: TProps) => {
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <Header title={<h2>{t('lightning.send.title')}</h2>} />
+          {isSending && <UseDisableBackButton />}
+          <Header title={
+            <>
+              <h2 className="hide-on-small">{t('lightning.send.title')}</h2>
+              <MobileHeader
+                onClick={handleBack}
+                title={t('lightning.send.title')}
+                variant={step === 'success' || isSending ? 'titleOnly' : 'back'}
+                withGuide
+              />
+            </>
+          } />
           {step === 'select-payment-input' && (
             <SelectPaymentInputStep
               activeAccounts={activeAccounts}
@@ -76,6 +100,7 @@ export const Send = ({ activeAccounts }: TProps) => {
             <ReviewStep
               paymentInput={paymentInput}
               backToPaymentInput={resetToPaymentInputEntry}
+              onSendingChange={setIsSending}
               onSuccess={showSuccess}
             />
           )}

--- a/frontends/web/src/routes/lightning/set-lnurl-address.test.tsx
+++ b/frontends/web/src/routes/lightning/set-lnurl-address.test.tsx
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../__mocks__/i18n';
+import type { ReactNode } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as lightningApi from '@/api/lightning';
+import { BackButtonProvider } from '@/contexts/BackButtonContext';
+import { LightningSetLnurlAddress } from './set-lnurl-address';
+
+vi.mock('@/i18n/i18n');
+
+vi.mock('@/components/layout', () => ({
+  Header: ({ title }: { title: ReactNode }) => <header>{title}</header>,
+  Main: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+}));
+
+vi.mock('@/hooks/debounce', () => ({
+  useDebounce<T>(value: T) {
+    return value;
+  },
+}));
+
+vi.mock('@/api/lightning', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/lightning')>();
+  return {
+    ...actual,
+    getLightningAddress: vi.fn(),
+    getLightningAddressAvailability: vi.fn(),
+    getLightningAddressDomain: vi.fn(),
+    postRegisterLightningAddress: vi.fn(),
+  };
+});
+
+const SettingsPage = () => {
+  const navigate = useNavigate();
+  return <button onClick={() => navigate(-1)}>settings back</button>;
+};
+
+describe('Set Lightning address back navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(window.matchMedia).mockImplementation(query => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    vi.mocked(lightningApi.getLightningAddress).mockResolvedValue('old@example.com');
+    vi.mocked(lightningApi.getLightningAddressDomain).mockResolvedValue('example.com');
+    vi.mocked(lightningApi.getLightningAddressAvailability).mockResolvedValue({
+      address: 'new@example.com',
+      available: true,
+      username: 'new',
+    });
+  });
+
+  it('blocks Android back while saving and returns without creating a history loop', async () => {
+    let resolveSave: (address: string) => void = () => {};
+    vi.mocked(lightningApi.postRegisterLightningAddress).mockReturnValue(new Promise(resolve => {
+      resolveSave = resolve;
+    }));
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/settings/advanced-settings',
+          '/settings/lightning-settings',
+          '/lightning/set-lnurl-address',
+        ]}
+        initialIndex={2}
+      >
+        <BackButtonProvider>
+          <Routes>
+            <Route path="/settings/advanced-settings" element={<span>advanced settings</span>} />
+            <Route path="/settings/lightning-settings" element={<SettingsPage />} />
+            <Route path="/lightning/set-lnurl-address" element={<LightningSetLnurlAddress />} />
+          </Routes>
+        </BackButtonProvider>
+      </MemoryRouter>
+    );
+
+    const addressInput = await screen.findByLabelText('lightning.lnurlAddress.label');
+    fireEvent.input(addressInput, { target: { value: 'new' } });
+    expect(await screen.findByText('lightning.lnurlAddress.availability.available')).toBeInTheDocument();
+
+    const saveButton = screen.getByRole('button', { name: 'button.save' });
+    fireEvent.click(saveButton);
+    await waitFor(() => expect(lightningApi.postRegisterLightningAddress).toHaveBeenCalledWith('new'));
+
+    expect(document.querySelector('header button')).not.toBeInTheDocument();
+    act(() => {
+      expect(window.onBackButtonPressed?.()).toBe(false);
+    });
+    expect(saveButton).toBeDisabled();
+
+    await act(async () => {
+      resolveSave('new@example.com');
+    });
+    fireEvent.click(await screen.findByRole('button', { name: 'button.done' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'settings back' }));
+
+    expect(await screen.findByText('advanced settings')).toBeInTheDocument();
+    expect(screen.queryByText('lightning.lnurlAddress.description')).not.toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/routes/lightning/set-lnurl-address.tsx
+++ b/frontends/web/src/routes/lightning/set-lnurl-address.tsx
@@ -11,16 +11,18 @@ import {
   postRegisterLightningAddress,
 } from '@/api/lightning';
 import { toLightningErrorMessage } from '@/api/lightning-errors';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button, Input } from '@/components/forms';
 import { Cancel, Checked, Sync, SyncLight } from '@/components/icon';
 import { Header, Main } from '@/components/layout';
 import { Spinner } from '@/components/spinner/Spinner';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { UseDisableBackButton } from '@/hooks/backbutton';
 import { useDarkmode } from '@/hooks/darkmode';
 import { useDebounce } from '@/hooks/debounce';
 import { useMountedRef } from '@/hooks/mount';
 import { SimpleMarkup } from '@/utils/markup';
+import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import styles from './set-lnurl-address.module.css';
 
 const CONTENT_MIN_HEIGHT = '38em';
@@ -221,9 +223,9 @@ export const LightningSetLnurlAddress = () => {
             <p>{t('unknownError', { errorMessage: error })}</p>
           </ViewContent>
           <ViewButtons>
-            <BackButton onClick={() => navigate(-1)}>
+            <DesktopBackButton onClick={() => navigate(-1)}>
               {t('button.back')}
-            </BackButton>
+            </DesktopBackButton>
           </ViewButtons>
         </View>
       );
@@ -265,9 +267,9 @@ export const LightningSetLnurlAddress = () => {
             <Button primary disabled={availability !== 'available' || isSaving} onClick={saveAddress}>
               {t('button.save')}
             </Button>
-            <BackButton disabled={isSaving} onClick={() => navigate(-1)}>
+            <DesktopBackButton disabled={isSaving} onClick={() => navigate(-1)}>
               {t('dialog.cancel')}
-            </BackButton>
+            </DesktopBackButton>
           </ViewButtons>
         </View>
       );
@@ -279,7 +281,7 @@ export const LightningSetLnurlAddress = () => {
             <span className={styles.successAddress}>{address}</span>
           </ViewContent>
           <ViewButtons>
-            <Button primary onClick={() => navigate('/settings/lightning-settings')}>
+            <Button primary onClick={() => navigate(-1)}>
               {t('button.done')}
             </Button>
           </ViewButtons>
@@ -288,10 +290,24 @@ export const LightningSetLnurlAddress = () => {
     }
   };
 
+  const headerBackEnabled = step === 'form'
+    && !isSaving
+    && (!!domain || !!error);
+
   return (
     <Main>
-      <Header title={t('lightning.lnurlAddress.title')} />
+      <Header title={
+        <>
+          <h2 className="hide-on-small">{t('lightning.lnurlAddress.title')}</h2>
+          <MobileHeader
+            onClick={() => navigate(-1)}
+            title={t('lightning.lnurlAddress.title')}
+            variant={headerBackEnabled ? 'back' : 'titleOnly'}
+          />
+        </>
+      } />
       {renderStep()}
+      {isSaving && <UseDisableBackButton />}
     </Main>
   );
 };

--- a/frontends/web/src/routes/lightning/topup/topup-form.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup-form.tsx
@@ -3,7 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import type { AccountCode, CoinCode, ConversionUnit, FeeTargetCode, TAccount, TAmountWithConversions, TBalance, TTxProposalResult } from '@/api/account';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button, NumberInput } from '@/components/forms';
 import { GroupedAccountSelector } from '@/components/groupedaccountselector/groupedaccountselector';
 import { HideAmountsButton } from '@/components/hideamountsbutton/hideamountsbutton';
@@ -15,6 +15,7 @@ import { FeeTargets } from '@/routes/account/send/feetargets';
 import { FiatInput } from '@/routes/account/send/components/inputs/fiat-input';
 import { NoteInput } from '@/routes/account/send/components/inputs/note-input';
 import type { TProposalError } from '@/routes/account/send/services';
+import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import styles from './topup.module.css';
 
 type TReadonlyAccountRowProps = {
@@ -102,7 +103,12 @@ export const TopUpForm = ({
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <Header title={<h2>{t('lightning.topUp.title')}</h2>}>
+          <Header title={
+            <>
+              <h2 className="hide-on-small">{t('lightning.topUp.title')}</h2>
+              <MobileHeader onClick={onBack} title={t('lightning.topUp.title')} />
+            </>
+          }>
             <HideAmountsButton />
           </Header>
           <Status dismissibleKey="" type="error" hidden={!balanceLimitError}>
@@ -173,9 +179,9 @@ export const TopUpForm = ({
                     onNoteChange={onNoteChange}
                   />
                   <ColumnButtons className="m-top-default m-bottom-xlarge" inline>
-                    <BackButton onClick={onBack}>
+                    <DesktopBackButton onClick={onBack}>
                       {t('button.back')}
-                    </BackButton>
+                    </DesktopBackButton>
                     <Button
                       primary
                       onClick={onReview}

--- a/frontends/web/src/routes/lightning/topup/topup-result.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup-result.tsx
@@ -3,11 +3,12 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import type { TAccount } from '@/api/account';
-import { BackButton } from '@/components/backbutton/backbutton';
+import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
 import { SendAbortedResult } from '@/routes/account/send/components/result';
+import { MobileHeader } from '@/routes/settings/components/mobile-header';
 
 type TTopUpAbortedProps = {
   onRetry: () => void;
@@ -29,7 +30,12 @@ export const TopUpSuccess = () => {
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <Header title={<h2>{t('lightning.topUp.title')}</h2>} />
+          <Header title={
+            <>
+              <h2 className="hide-on-small">{t('lightning.topUp.title')}</h2>
+              <MobileHeader title={t('lightning.topUp.title')} variant="titleOnly" />
+            </>
+          } />
           <View textCenter verticallyCentered>
             <ViewContent withIcon="success">
               <p>{t('lightning.topUp.success.message')}</p>
@@ -64,7 +70,15 @@ export const TopUpNoBitcoinAccounts = ({ hasAccounts }: TTopUpNoBitcoinAccountsP
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <Header title={<h2>{t('lightning.topUp.title')}</h2>} />
+          <Header title={
+            <>
+              <h2 className="hide-on-small">{t('lightning.topUp.title')}</h2>
+              <MobileHeader
+                onClick={() => navigate('/lightning')}
+                title={t('lightning.topUp.title')}
+              />
+            </>
+          } />
           <View textCenter verticallyCentered>
             <ViewContent>
               <p>{t('lightning.topUp.noBitcoinAccounts')}</p>
@@ -73,9 +87,9 @@ export const TopUpNoBitcoinAccounts = ({ hasAccounts }: TTopUpNoBitcoinAccountsP
               <Button primary onClick={() => navigate(primaryAction.route)}>
                 {primaryAction.label}
               </Button>
-              <BackButton onClick={() => navigate('/lightning')}>
+              <DesktopBackButton onClick={() => navigate('/lightning')}>
                 {t('button.back')}
-              </BackButton>
+              </DesktopBackButton>
             </ViewButtons>
           </View>
         </Main>
@@ -95,7 +109,15 @@ export const TopUpNoFundedBitcoinAccounts = ({ btcAccounts }: TTopUpNoFundedBitc
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <Header title={<h2>{t('lightning.topUp.title')}</h2>} />
+          <Header title={
+            <>
+              <h2 className="hide-on-small">{t('lightning.topUp.title')}</h2>
+              <MobileHeader
+                onClick={() => navigate('/lightning')}
+                title={t('lightning.topUp.title')}
+              />
+            </>
+          } />
           <View textCenter verticallyCentered>
             <ViewContent>
               <p>{t('lightning.topUp.noFundedBitcoinAccounts')}</p>
@@ -104,9 +126,9 @@ export const TopUpNoFundedBitcoinAccounts = ({ btcAccounts }: TTopUpNoFundedBitc
               <Button primary onClick={() => navigate(receiveRoute)}>
                 {t('generic.receive', { context: 'bitcoin' })}
               </Button>
-              <BackButton onClick={() => navigate('/lightning')}>
+              <DesktopBackButton onClick={() => navigate('/lightning')}>
                 {t('button.back')}
-              </BackButton>
+              </DesktopBackButton>
             </ViewButtons>
           </View>
         </Main>

--- a/frontends/web/vite.setup-tests.mjs
+++ b/frontends/web/vite.setup-tests.mjs
@@ -1,6 +1,20 @@
-import { afterEach } from 'vitest';
+import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
 
 // runs a cleanup after each test case (e.g. clearing jsdom)
 afterEach(() => {


### PR DESCRIPTION
To maintain the UI's consistency, as what we did in https://github.com/BitBoxSwiss/bitbox-wallet-app/pull/4197 we are replacing the back button in various LN-related pages to Chevron back on the header (mobile).

Eight routes were updated, covering 21 views/stages and replacing 20 body Back/Cancel controls on mobile.

| Route | Impacted views/stages |
| --- | --- |
| `/lightning/send` | Manual payment entry; BOLT11 review; LNURL Pay review; Bitcoin address/BIP21 review |
| `/lightning/receive` | Lightning-address view; create-invoice form; generated-invoice view |
| `/lightning/topup` | Top-up form; no-Bitcoin-account fallback; no-funded-Bitcoin-account fallback |
| `/lightning/activate` | Intro; information/consent; embedded disclaimer; connect-device view |
| `/lightning/deactivate` | Intro/confirmation view |
| `/lightning/set-lnurl-address` | Load-error view; address form |
| `/lightning/claim-top-up` | Overview; claim/refund confirmation |
| `/lightning/close-withdraw-funds` | No-Bitcoin-account fallback; close-and-withdraw confirmation |

**Behavior:**

- Mobile (`≤768px`): header chevron.
- Desktop (`>768px`): body Back/Cancel button remains.
- "Busy" and "terminal" stages hide the chevron.

1) Busy: activating/deactivating, creating an invoice, saving an LN address, submitting a claim/refund, or closing the wallet.

2) Terminal: success screens after Send, Receive, Top-up, activation, deactivation, claim/refund, etc.

**Not converted:**

- `/lightning` -> top-level page, no Back control.
- `/lightning/disclaimer` ->  already used a header chevron.
- `/settings/lightning-settings` ->  already used a header chevron.
- Send QR scanner ->  retains its fullscreen X.
- Claim Top-up failure Cancel ->  intentionally remains in the body.
- Close & Withdraw failure Cancel ->  intentionally remains in the body.