### PR TITLE
Frontend upgrade fw during setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Revamp QR Scanner
 - Mobile: Move settings into bottom navigation
 - Enable Tether USDT for BTC Direct
+- Allow users to upgrade firmware during setup
 
 ## v4.51.4
 - Bundle BitBox02 and BitBox02 Nova firmware version v9.26.5

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -875,7 +875,8 @@
       },
       "title": "Firmware",
       "upToDate": "Your device is up to date",
-      "upgradeAvailable": "New upgrade available",
+      "upgradeAvailable": "New BitBox upgrade available",
+      "upgradeAvailableDescription": "A firmware upgrade is available. Upgrade now for the latest security improvements and features.",
       "version": {
         "label": "Version"
       }
@@ -1062,6 +1063,7 @@
     "sell_crypto": "Sell crypto",
     "send": "Send",
     "sent": "Sent",
+    "skip": "Skip",
     "spend_bitcoin": "Spend bitcoin",
     "spend_crypto": "Spend crypto",
     "swap": "Swap",

--- a/frontends/web/src/routes/device/bitbox02/setup/choose.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/choose.tsx
@@ -4,13 +4,14 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { VersionInfo } from '@/api/bitbox02';
 import { useMediaQuery } from '@/hooks/mediaquery';
-import { View, ViewContent, ViewHeader } from '@/components/view/view';
+import { View, ViewButtons, ViewContent, ViewHeader } from '@/components/view/view';
 import { Column, ColumnButtons, Grid, ResponsiveGrid } from '@/components/layout';
 import { Button, Label } from '@/components/forms';
 import { Toggle } from '@/components/toggle/toggle';
 import { InfoBlue } from '@/components/icon';
 import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { MobileHeader } from '@/routes/settings/components/mobile-header';
+import { FirmwareSetting } from '@/routes/settings/components/device-settings/firmware-setting';
 import style from './choose.module.css';
 
 export type TWalletSetupChoices = 'create-wallet' | 'restore-sdcard' | 'restore-mnemonic';
@@ -21,6 +22,7 @@ export type TWalletCreateOptions = {
 };
 
 type Props = {
+  deviceID: string;
   onSelectSetup: (
     type: TWalletSetupChoices,
     options?: TWalletCreateOptions,
@@ -29,6 +31,7 @@ type Props = {
 };
 
 export const SetupOptions = ({
+  deviceID,
   onSelectSetup,
   versionInfo,
 }: Props) => {
@@ -37,11 +40,42 @@ export const SetupOptions = ({
   const [advanced, setAdvanced] = useState(false);
   const [withMnemonic, setWithMnemonic] = useState(false);
   const [with12Words, setWith12Words] = useState(false);
+  const [skipFWUpgrade, setSkipFWUpgrade] = useState(false);
   const handleAdvancedBack = () => {
     setWithMnemonic(false);
     setWith12Words(false);
     setAdvanced(false);
   };
+
+  if (versionInfo.canUpgrade && !skipFWUpgrade) {
+    return (
+      <View
+        fullscreen
+        textCenter
+        verticallyCentered
+        withBottomBar
+        width="620px">
+        <ViewHeader small title={t('deviceSettings.firmware.upgradeAvailable')}>
+        </ViewHeader>
+        <ViewContent>
+          <p>
+            {t('deviceSettings.firmware.upgradeAvailableDescription')}
+          </p>
+        </ViewContent>
+        <ViewButtons>
+          <FirmwareSetting
+            asButton
+            deviceID={deviceID}
+            versionInfo={versionInfo}
+            noSidebarOffset
+          />
+          <Button secondary onClick={() => setSkipFWUpgrade(true)}>
+            {t('generic.skip')}
+          </Button>
+        </ViewButtons>
+      </View>
+    );
+  }
 
   if (advanced) {
     const {

--- a/frontends/web/src/routes/device/bitbox02/wizard.tsx
+++ b/frontends/web/src/routes/device/bitbox02/wizard.tsx
@@ -100,6 +100,7 @@ export const Wizard = ({ deviceID }: TProps) => {
         <SetupOptions
           key="choose-setup"
           versionInfo={versionInfo}
+          deviceID={deviceID}
           onSelectSetup={(
             type: TWalletSetupChoices,
             createOptions?: TWalletCreateOptions,

--- a/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
@@ -80,7 +80,10 @@ const UpgradeDialog = ({
     return null;
   }
   return (
-    <Dialog onClose={onClose} open={open} title={t('upgradeFirmware.title')}>
+    <Dialog
+      onClose={confirming ? undefined : onClose}
+      open={open}
+      title={t('upgradeFirmware.title')}>
       <DialogScrollContent>
         {confirming ? t('confirmOnDevice') : (
           <p>{t('upgradeFirmware.description', {

--- a/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
@@ -6,6 +6,7 @@ import { AppContext } from '@/contexts/AppContext';
 import { VersionInfo, upgradeDeviceFirmware } from '@/api/bitbox02';
 import { Dialog, DialogButtons, DialogScrollContent } from '@/components/dialog/dialog';
 import { Button } from '@/components/forms';
+import { UseDisableBackButton } from '@/hooks/backbutton';
 import { Checked, PointToBitBox02, RedDot } from '@/components/icon';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
 
@@ -110,7 +111,9 @@ export const UpgradeDialog = ({
           })}</p>
         )}
       </DialogScrollContent>
-      { !confirming && (
+      { confirming ? (
+        <UseDisableBackButton />
+      ) : (
         <DialogButtons>
           <Button
             primary

--- a/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
@@ -6,24 +6,22 @@ import { AppContext } from '@/contexts/AppContext';
 import { VersionInfo, upgradeDeviceFirmware } from '@/api/bitbox02';
 import { Dialog, DialogButtons, DialogScrollContent } from '@/components/dialog/dialog';
 import { Button } from '@/components/forms';
-import { Checked, RedDot } from '@/components/icon';
+import { Checked, PointToBitBox02, RedDot } from '@/components/icon';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
 
 export type TProps = {
   deviceID: string;
   versionInfo: VersionInfo;
   asButton?: boolean;
+  noSidebarOffset?: boolean;
 };
 
-export type TUpgradeDialogProps = {
-  open: boolean;
-  versionInfo: VersionInfo;
-  confirming: boolean;
-  onUpgradeFirmware: () => void;
-  onClose: () => void;
-};
-
-const FirmwareSetting = ({ deviceID, versionInfo, asButton = false }: TProps) => {
+const FirmwareSetting = ({
+  deviceID,
+  versionInfo,
+  asButton = false,
+  noSidebarOffset,
+}: TProps) => {
   const { t } = useTranslation();
   const { setFirmwareUpdateDialogOpen, firmwareUpdateDialogOpen } = useContext(AppContext);
   const [confirming, setConfirming] = useState(false);
@@ -35,9 +33,12 @@ const FirmwareSetting = ({ deviceID, versionInfo, asButton = false }: TProps) =>
 
   const handleUpgradeFirmware = async () => {
     setConfirming(true);
-    await upgradeDeviceFirmware(deviceID);
-    setConfirming(false);
-    setFirmwareUpdateDialogOpen(false);
+    try {
+      await upgradeDeviceFirmware(deviceID);
+      setFirmwareUpdateDialogOpen(false);
+    } finally {
+      setConfirming(false);
+    }
   };
 
   return (
@@ -61,6 +62,7 @@ const FirmwareSetting = ({ deviceID, versionInfo, asButton = false }: TProps) =>
         open={firmwareUpdateDialogOpen && canUpgrade}
         versionInfo={versionInfo}
         confirming={confirming}
+        noSidebarOffset={noSidebarOffset}
         onUpgradeFirmware={handleUpgradeFirmware}
         onClose={() => setFirmwareUpdateDialogOpen(false)}
       />
@@ -68,10 +70,20 @@ const FirmwareSetting = ({ deviceID, versionInfo, asButton = false }: TProps) =>
   );
 };
 
-const UpgradeDialog = ({
+export type TUpgradeDialogProps = {
+  open: boolean;
+  versionInfo: VersionInfo;
+  confirming: boolean;
+  noSidebarOffset?: boolean;
+  onUpgradeFirmware: () => void;
+  onClose: () => void;
+};
+
+export const UpgradeDialog = ({
   open,
   versionInfo,
   confirming,
+  noSidebarOffset,
   onUpgradeFirmware,
   onClose
 }: TUpgradeDialogProps) => {
@@ -81,11 +93,17 @@ const UpgradeDialog = ({
   }
   return (
     <Dialog
+      noSidebarOffset={noSidebarOffset}
       onClose={confirming ? undefined : onClose}
       open={open}
       title={t('upgradeFirmware.title')}>
       <DialogScrollContent>
-        {confirming ? t('confirmOnDevice') : (
+        {confirming ? (
+          <>
+            {t('confirmOnDevice')}
+            <PointToBitBox02 />
+          </>
+        ) : (
           <p>{t('upgradeFirmware.description', {
             currentVersion: versionInfo.currentVersion,
             newVersion: versionInfo.newVersion,

--- a/frontends/web/tests/helpers/simulator.ts
+++ b/frontends/web/tests/helpers/simulator.ts
@@ -120,24 +120,36 @@ export function stopSimulator(proc?: ChildProcess): Promise<void> {
  *
  * The flow is:
  * 1. Optionally click "Continue"
- * 2. Click "Create wallet"
- * 3. Type the device name into the focused input
- * 4. Click "Continue"
- * 5. Click all checkboxes
- * 6. Click "Continue"
- * 7. Click "Get started"
+ * 2. Optionally click "Skip" when a firmware upgrade is available
+ * 3. Click "Create wallet"
+ * 4. Type the device name into the focused input
+ * 5. Click "Continue"
+ * 6. Click all checkboxes
+ * 7. Click "Continue"
+ * 8. Click "Get started"
  */
 export async function completeWalletSetupFlow(page: Page, deviceName = 'simulator') {
   const continueButton = page.locator('button', { hasText: 'Continue' }).first();
   const createWalletButton = page.locator('button', { hasText: 'Create wallet' }).first();
+  const skipFirmwareUpgradeButton = page.getByRole('button', { name: 'Skip', exact: true });
 
   await Promise.race([
     continueButton.waitFor({ state: 'visible' }),
     createWalletButton.waitFor({ state: 'visible' }),
+    skipFirmwareUpgradeButton.waitFor({ state: 'visible' }),
   ]);
 
   if (await continueButton.isVisible()) {
     await continueButton.click();
+  }
+
+  await Promise.race([
+    createWalletButton.waitFor({ state: 'visible' }),
+    skipFirmwareUpgradeButton.waitFor({ state: 'visible' }),
+  ]);
+
+  if (await skipFirmwareUpgradeButton.isVisible()) {
+    await skipFirmwareUpgradeButton.click();
   }
 
   await clickButtonWithText(page, 'Create wallet');


### PR DESCRIPTION
In some cases users have installed a firmware but did not setup
a wallet yet.

Added a separate upgrade firmware step before the wallet setup, so
users can upgrade the firmware before setting up a wallet.

Added a separate step to not clutter the setup wallet UI and that
users don't miss it.

This also fixed an issue with the upgrade dialog which was closable
but should be blocking. Additionally added a point-to-device graphic
to indicate to continue on the device.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [x] updating the Changelog
- [ ] writing unit tests
- [x] checking if your changes affect other coins or tokens in unintended ways
- [x] testing on multiple environments (Qt, Android, ...)
- [x] having an AI review your changes
