### PR TITLE
backend: require HTTPS AOPP callbacks

### DIFF
--- a/backend/aopp.go
+++ b/backend/aopp.go
@@ -248,9 +248,15 @@ func (backend *Backend) handleAOPP(uri url.URL) {
 		backend.aoppSetError(errAOPPInvalidRequest)
 		return
 	}
-	_, err := url.Parse(callback)
+	callbackURL, err := url.Parse(callback)
 	if err != nil {
 		log.WithError(err).Error("Invalid callback")
+		backend.aoppSetError(errAOPPInvalidRequest)
+		return
+	}
+	if !strings.EqualFold(callbackURL.Scheme, "https") ||
+		callbackURL.Host == "" {
+		log.Error("Invalid callback")
 		backend.aoppSetError(errAOPPInvalidRequest)
 		return
 	}
@@ -466,7 +472,23 @@ loop:
 		backend.aoppSetError(errAOPPUnknown)
 		return
 	}
-	resp, err := backend.httpClient.Post(backend.aopp.Callback, "application/json", bytes.NewBuffer(jsonBody))
+	// Only follow redirects while HTTPS is preserved, so signed data is never resent over a
+	// cleartext connection.
+	httpClient := *backend.httpClient
+	checkRedirect := httpClient.CheckRedirect
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !strings.EqualFold(req.URL.Scheme, "https") || req.URL.Host == "" {
+			return http.ErrUseLastResponse
+		}
+		if checkRedirect != nil {
+			return checkRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return http.ErrUseLastResponse
+		}
+		return nil
+	}
+	resp, err := httpClient.Post(backend.aopp.Callback, "application/json", bytes.NewBuffer(jsonBody))
 	if err != nil {
 		log.WithError(err).Error("Error calling callback")
 		backend.aoppSetError(errAOPPCallback)

--- a/backend/aopp_test.go
+++ b/backend/aopp_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	accountsTypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
@@ -35,7 +36,7 @@ func defaultParams() url.Values {
 	params.Set("msg", dummyMsg)
 	params.Set("format", "any")
 	params.Set("asset", "btc")
-	params.Set("callback", "http://localhost/aopp/")
+	params.Set("callback", "https://localhost/aopp/")
 	return params
 }
 
@@ -164,11 +165,12 @@ func TestAOPPSuccess(t *testing.T) {
 				)
 				w.WriteHeader(http.StatusNoContent)
 			})
-			server := httptest.NewServer(handler)
+			server := httptest.NewTLSServer(handler)
 			defer server.Close()
 
 			b := newBackend(t, testnetDisabled, regtestDisabled)
 			defer b.Close()
+			b.httpClient = server.Client()
 
 			// Add a second account so we can test the choosing-account step. If there is only one
 			// account, the account is used automatically, skipping the step where the user chooses
@@ -263,13 +265,14 @@ func TestAOPPSuccess(t *testing.T) {
 
 	// There is only one account, so the choosing-account step is skipped.
 	t.Run("one-account", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 		}))
 		defer server.Close()
 
 		b := newBackend(t, testnetDisabled, regtestDisabled)
 		defer b.Close()
+		b.httpClient = server.Client()
 		params := defaultParams()
 		params.Set("callback", server.URL)
 		b.HandleURI(uriPrefix + params.Encode())
@@ -280,15 +283,40 @@ func TestAOPPSuccess(t *testing.T) {
 		require.Equal(t, aoppStateSuccess, b.AOPP().State)
 	})
 
-	// Keystore is already registered before the AOPP request.
-	t.Run("user-approve", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	t.Run("https-redirect", func(t *testing.T) {
+		var callbackReceived atomic.Bool
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/redirect" {
+				http.Redirect(w, r, "/callback", http.StatusTemporaryRedirect)
+				return
+			}
+			callbackReceived.Store(true)
 			w.WriteHeader(http.StatusNoContent)
 		}))
 		defer server.Close()
 
 		b := newBackend(t, testnetDisabled, regtestDisabled)
 		defer b.Close()
+		b.httpClient = server.Client()
+		params := defaultParams()
+		params.Set("callback", server.URL+"/redirect")
+		b.HandleURI(uriPrefix + params.Encode())
+		b.AOPPApprove()
+		b.registerKeystore(makeKeystore(t, scriptTypeRef(signing.ScriptTypeP2WPKH), keystoreHelper))
+		require.Equal(t, aoppStateSuccess, b.AOPP().State)
+		require.True(t, callbackReceived.Load())
+	})
+
+	// Keystore is already registered before the AOPP request.
+	t.Run("user-approve", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+		b.httpClient = server.Client()
 		params := defaultParams()
 		params.Set("callback", server.URL)
 		b.registerKeystore(makeKeystore(t, scriptTypeRef(signing.ScriptTypeP2WPKH), keystoreHelper))
@@ -366,6 +394,32 @@ func TestAOPPFailures(t *testing.T) {
 		b.HandleURI(uriPrefix + params.Encode())
 		require.Equal(t, aoppStateError, b.AOPP().State)
 		require.Equal(t, errAOPPInvalidRequest, b.AOPP().ErrorCode)
+	})
+	t.Run("callback_validation", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			callback  string
+			wantState aoppState
+		}{
+			{name: "https", callback: "https://example.com/aopp", wantState: aoppStateUserApproval},
+			{name: "http", callback: "http://example.com/aopp", wantState: aoppStateError},
+			{name: "malformed", callback: ":not a valid url", wantState: aoppStateError},
+			{name: "relative", callback: "aopp/callback", wantState: aoppStateError},
+			{name: "missing host", callback: "https:aopp", wantState: aoppStateError},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				b := newBackend(t, testnetDisabled, regtestDisabled)
+				defer b.Close()
+				params := defaultParams()
+				params.Set("callback", test.callback)
+				b.HandleURI(uriPrefix + params.Encode())
+				require.Equal(t, test.wantState, b.AOPP().State)
+				if test.wantState == aoppStateError {
+					require.Equal(t, errAOPPInvalidRequest, b.AOPP().ErrorCode)
+				}
+			})
+		}
 	})
 	t.Run("invalid_callback", func(t *testing.T) {
 		b := newBackend(t, testnetDisabled, regtestDisabled)
@@ -449,10 +503,11 @@ func TestAOPPFailures(t *testing.T) {
 		b := newBackend(t, testnetDisabled, regtestDisabled)
 		defer b.Close()
 
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 		}))
 		defer server.Close()
+		b.httpClient = server.Client()
 
 		params := defaultParams()
 		params.Set("callback", server.URL)
@@ -462,5 +517,31 @@ func TestAOPPFailures(t *testing.T) {
 		b.AOPPChooseAccount("v0-55555555-btc-0")
 		require.Equal(t, aoppStateError, b.AOPP().State)
 		require.Equal(t, errAOPPCallback, b.AOPP().ErrorCode)
+	})
+	t.Run("http_redirect", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		var redirectFollowed atomic.Bool
+		redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			redirectFollowed.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer redirectTarget.Close()
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, redirectTarget.URL, http.StatusTemporaryRedirect)
+		}))
+		defer server.Close()
+		b.httpClient = server.Client()
+
+		params := defaultParams()
+		params.Set("callback", server.URL)
+		b.HandleURI(uriPrefix + params.Encode())
+		b.AOPPApprove()
+		b.registerKeystore(ks)
+		b.AOPPChooseAccount("v0-55555555-btc-0")
+		require.Equal(t, aoppStateError, b.AOPP().State)
+		require.Equal(t, errAOPPCallback, b.AOPP().ErrorCode)
+		require.False(t, redirectFollowed.Load())
 	})
 }

--- a/frontends/web/src/components/aopp/aopp.test.tsx
+++ b/frontends/web/src/components/aopp/aopp.test.tsx
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../__mocks__/i18n';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Aopp } from './aopp';
+
+const aoppAPIMocks = vi.hoisted(() => ({
+  cancel: vi.fn(),
+  getAOPP: vi.fn(),
+  subscribeAOPP: vi.fn(),
+}));
+
+vi.mock('@/api/aopp', () => aoppAPIMocks);
+
+describe('components/aopp/aopp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    aoppAPIMocks.subscribeAOPP.mockReturnValue(() => {});
+  });
+
+  it('renders an error without a callback', async () => {
+    aoppAPIMocks.getAOPP.mockResolvedValue({
+      state: 'error',
+      errorCode: 'aoppInvalidRequest',
+      callback: '',
+    });
+
+    render(<Aopp />);
+
+    expect(await screen.findByText('error.aoppInvalidRequest')).toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -23,7 +23,13 @@ const Banner = ({ children }: TProps) => (
   <div className={styles.banner}>{children}</div>
 );
 
-const domain = (callback: string): string => new URL(callback).host;
+const domain = (callback: string): string => {
+  try {
+    return new URL(callback).host;
+  } catch {
+    return '';
+  }
+};
 
 export const Aopp = () => {
   const { t } = useTranslation();

--- a/frontends/web/tests/aopp.test.ts
+++ b/frontends/web/tests/aopp.test.ts
@@ -6,7 +6,7 @@ import { ServeWallet } from './helpers/servewallet';
 import { launchRegtest, setupRegtestWallet, sendCoins, mineBlocks, cleanupRegtest } from './helpers/regtest';
 import { startSimulator, stopSimulator, completeWalletSetupFlow, cleanFakeMemoryFiles } from './helpers/simulator';
 import { ChildProcess } from 'child_process';
-import { startAOPPServer, generateAOPPRequest } from './helpers/aopp';
+import { startAOPPServer, generateAOPPRequest, type AOPPServer } from './helpers/aopp';
 import { assertFieldsCount } from './helpers/dom';
 import { deleteAccountsFile } from './helpers/fs';
 import { getAccountCodeFromUrl, getReceiveAddress, getReceiveAddressData, waitForAccountTransactions } from './helpers/account';
@@ -14,7 +14,7 @@ import { getAccountCodeFromUrl, getReceiveAddress, getReceiveAddressData, waitFo
 
 let servewallet: ServeWallet | undefined;
 let regtest: ChildProcess | undefined;
-let aoppServer: ChildProcess | undefined;
+let aoppServer: AOPPServer | undefined;
 let simulatorProc : ChildProcess | undefined;
 
 test('AOPP', async ({ page, host, frontendPort, servewalletPort }, testInfo) => {
@@ -104,7 +104,7 @@ test('AOPP', async ({ page, host, frontendPort, servewalletPort }, testInfo) => 
     aoppServer = await startAOPPServer();
     console.log('AOPP server started.');
     console.log('Generating AOPP request...');
-    aoppRequest = await generateAOPPRequest('rbtc');
+    aoppRequest = await generateAOPPRequest(aoppServer.caCertPath, 'rbtc');
     console.log(`AOPP Request URI: ${aoppRequest}`);
   });
 
@@ -121,8 +121,14 @@ test('AOPP', async ({ page, host, frontendPort, servewalletPort }, testInfo) => 
   await test.step('Kill servewallet and restart with AOPP request', async () => {
     await servewallet?.stop();
     console.log('Servewallet stopped.');
+    if (!aoppServer) {
+      throw new Error('AOPP server not started');
+    }
     servewallet = new ServeWallet(page, servewalletPort, frontendPort, host, testInfo.outputDir, { regtest: true, testnet: false, simulator: true });
-    await servewallet.start({ extraFlags: { aoppUrl: aoppRequest } });
+    await servewallet.start({
+      env: { SSL_CERT_FILE: aoppServer.caCertPath },
+      extraFlags: { aoppUrl: aoppRequest },
+    });
     console.log('Servewallet restarted with AOPP request.');
   });
 
@@ -198,7 +204,7 @@ test.beforeAll(async () => {
 test.afterAll(async () => {
   await servewallet?.stop();
   if (aoppServer) {
-    aoppServer.kill('SIGTERM');
+    aoppServer.process.kill('SIGTERM');
     aoppServer = undefined;
   }
   await cleanupRegtest(regtest);

--- a/frontends/web/tests/helpers/aopp.ts
+++ b/frontends/web/tests/helpers/aopp.ts
@@ -1,16 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawn, ChildProcessByStdio } from 'child_process';
+import * as fs from 'fs';
+import * as https from 'https';
 import path from 'path';
 import type { Readable } from 'stream';
 
+export interface AOPPServer {
+  process: ChildProcessByStdio<null, Readable, Readable>;
+  caCertPath: string;
+}
+
 /**
  * Starts the AOPP server and waits until it prints its "ready" line.
- * Returns the spawned child process.
+ * Returns the spawned child process and its temporary CA certificate.
  */
-export async function startAOPPServer(): Promise<
-  ChildProcessByStdio<null, Readable, Readable>
-> {
+export async function startAOPPServer(): Promise<AOPPServer> {
   const PROJECT_ROOT = process.env.GITHUB_WORKSPACE ||
     path.resolve(__dirname, '../../../..');
 
@@ -22,14 +27,14 @@ export async function startAOPPServer(): Promise<
     env: { ...process.env },
   });
 
-  const readyMsg = 'Listening on localhost:8888';
-
-  await new Promise<void>((resolve, reject) => {
+  const caCertPath = await new Promise<string>((resolve, reject) => {
+    let output = '';
     const onData = (data: Buffer) => {
-      const text = data.toString();
-      if (text.includes(readyMsg)) {
+      output += data.toString();
+      const match = output.match(/Listening on https:\/\/localhost:8888 with CA certificate (.+)/);
+      if (match?.[1]) {
         child.stdout.off('data', onData);
-        resolve();
+        resolve(match[1].trim());
       }
     };
 
@@ -42,13 +47,14 @@ export async function startAOPPServer(): Promise<
     child.on('error', onError);
   });
 
-  return child;
+  return { process: child, caCertPath };
 }
 
 /**
  * Perform a POST request to the AOPP server and return the cleaned `uri` string.
  */
 export async function generateAOPPRequest(
+  caCertPath: string,
   asset: 'rbtc' | 'btc' | 'eth' | 'tbtc' = 'rbtc'
 ): Promise<string> {
   const allowed = ['rbtc', 'btc', 'eth', 'tbtc'] as const;
@@ -56,15 +62,28 @@ export async function generateAOPPRequest(
     throw new Error(`Invalid asset: ${asset}. Allowed: ${allowed.join(', ')}`);
   }
 
-  const url = `http://localhost:8888/generate?asset=${asset}`;
+  const url = `https://localhost:8888/generate?asset=${asset}`;
+  const { statusCode, body } = await new Promise<{ statusCode: number; body: string }>((resolve, reject) => {
+    const request = https.request(url, {
+      method: 'POST',
+      ca: fs.readFileSync(caCertPath),
+    }, response => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk: string) => {
+        body += chunk;
+      });
+      response.on('end', () => resolve({ statusCode: response.statusCode ?? 0, body }));
+    });
+    request.on('error', reject);
+    request.end();
+  });
 
-  const res = await fetch(url, { method: 'POST' });
-
-  if (!res.ok) {
-    throw new Error(`AOPP server responded with ${res.status}`);
+  if (statusCode < 200 || statusCode >= 300) {
+    throw new Error(`AOPP server responded with ${statusCode}`);
   }
 
-  const json = await res.json();
+  const json = JSON.parse(body) as { uri?: unknown };
 
   if (!json.uri || typeof json.uri !== 'string') {
     throw new Error('AOPP server returned unexpected JSON');

--- a/frontends/web/tests/helpers/servewallet.ts
+++ b/frontends/web/tests/helpers/servewallet.ts
@@ -17,6 +17,7 @@ async function connectOnce(host: string, port: number): Promise<void> {
 }
 
 export interface ServeWalletOptions {
+  env?: NodeJS.ProcessEnv;
   simulator?: boolean;
   timeout?: number;
   testnet?: boolean;
@@ -115,6 +116,7 @@ export class ServeWallet {
       cwd: '../../', // maintain previous working dir
       stdio: ['ignore', this.outStream, this.outStream],
       detached: true,
+      env: { ...process.env, ...options.env },
     });
 
     await this.waitUntilReady(this.proc);

--- a/frontends/web/tests/util/aopp/server.py
+++ b/frontends/web/tests/util/aopp/server.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import http.server
-import socketserver
-import json
-import uuid
-import hashlib
 import base64
+import hashlib
+import json
+import socketserver
+import ssl
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
 from urllib.parse import urlparse, parse_qs
 
 from ecdsa import VerifyingKey, SECP256k1, util
@@ -93,7 +97,7 @@ def verify_address_ownership(r_s_bytes: bytes, message_digest: bytes, expected_a
     except Exception:
         return False
 
-# --- HTTP Request Handler ---
+# --- HTTPS Request Handler ---
 
 class AOPPRequestHandler(http.server.BaseHTTPRequestHandler):
 
@@ -124,7 +128,7 @@ class AOPPRequestHandler(http.server.BaseHTTPRequestHandler):
     def handle_generate(self):
         request_id = str(uuid.uuid4())
         msg = f"I confirm that I solely control this address. ID: {request_id}"
-        callback = f"http://localhost:{PORT}/cb?id={request_id}"
+        callback = f"https://localhost:{PORT}/cb?id={request_id}"
         asset = "rbtc"
         uri = f"aopp:?v=0&msg={msg}&asset={asset}&format=any&callback={callback}"
 
@@ -206,10 +210,23 @@ class AOPPRequestHandler(http.server.BaseHTTPRequestHandler):
 
 if __name__ == "__main__":
     socketserver.TCPServer.allow_reuse_address = True
-    with socketserver.TCPServer(("localhost", PORT), AOPPRequestHandler) as httpd:
-        print(f"Listening on localhost:{PORT}")
-        try:
-            httpd.serve_forever()
-        except KeyboardInterrupt:
-            print("\nShutting down server.")
-            httpd.shutdown()
+    with tempfile.TemporaryDirectory(prefix="bitbox-aopp-") as cert_dir:
+        cert_path = Path(cert_dir) / "cert.pem"
+        key_path = Path(cert_dir) / "key.pem"
+        subprocess.run([
+            "openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+            "-days", "1", "-subj", "/CN=localhost",
+            "-addext", "subjectAltName=DNS:localhost,IP:127.0.0.1",
+            "-keyout", str(key_path), "-out", str(cert_path),
+        ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        with socketserver.TCPServer(("localhost", PORT), AOPPRequestHandler) as httpd:
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain(certfile=cert_path, keyfile=key_path)
+            httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+            print(f"Listening on https://localhost:{PORT} with CA certificate {cert_path}")
+            try:
+                httpd.serve_forever()
+            except KeyboardInterrupt:
+                print("\nShutting down server.")
+                httpd.shutdown()


### PR DESCRIPTION
Reject AOPP requests whose callback is not an absolute HTTPS URL
with a non-empty host. Allow redirects only while HTTPS is preserved
so signed addresses and extended public keys cannot be downgraded to
cleartext transport.

Make AOPP error rendering tolerate missing or malformed callback URLs.
Cover callback validation, HTTPS redirects, HTTP downgrade rejection,
and missing callbacks in backend and frontend tests.