### PR TITLE
frontend: reduce page load flicker

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -30,6 +30,7 @@ import { RouterWatcher } from './utils/route';
 import { Darkmode } from './components/darkmode/darkmode';
 import { AuthRequired } from './components/auth/authrequired';
 import { WCSigningRequest } from './components/wallet-connect/incoming-signing-request';
+import { GlobalBannersProvider } from './contexts/global-banners-provider';
 import { Providers } from './contexts/providers';
 import { AppContext } from './contexts/AppContext';
 import { BottomNavigation } from './components/bottom-navigation/bottom-navigation';
@@ -90,15 +91,17 @@ const AppFrame = ({
               return null;
             })
           }
-          <div key={tabKey} className={styles.tabTransition}>
-            <AppRouter
-              accounts={accounts}
-              activeAccounts={activeAccounts}
-              devices={devices}
-              devicesKey={devicesKey}
-              showBottomNavigation={showMobileBottomNavigation}
-            />
-          </div>
+          <GlobalBannersProvider devices={devices}>
+            <div key={tabKey} className={styles.tabTransition}>
+              <AppRouter
+                accounts={accounts}
+                activeAccounts={activeAccounts}
+                devices={devices}
+                devicesKey={devicesKey}
+                showBottomNavigation={showMobileBottomNavigation}
+              />
+            </div>
+          </GlobalBannersProvider>
           <RouterWatcher />
         </div>
         {showMobileBottomNavigation && (

--- a/frontends/web/src/components/balance/balance.tsx
+++ b/frontends/web/src/components/balance/balance.tsx
@@ -9,10 +9,12 @@ import style from './balance.module.css';
 
 type TProps = {
   balance?: TBalance;
+  className?: string;
 };
 
 export const Balance = ({
   balance,
+  className = '',
 }: TProps) => {
   const { t } = useTranslation();
   if (!balance) {
@@ -22,7 +24,7 @@ export const Balance = ({
   }
 
   return (
-    <header className={style.balanceContainer}>
+    <header className={`${style.balanceContainer || ''} ${className}`}>
       <SubTitle className={style.availableBalanceTitle}>
         {t('accountSummary.availableBalance')}
       </SubTitle>

--- a/frontends/web/src/components/banners/global-banners.module.css
+++ b/frontends/web/src/components/banners/global-banners.module.css
@@ -1,0 +1,4 @@
+.container {
+    flex-shrink: 0;
+    width: 100%;
+}

--- a/frontends/web/src/components/banners/index.tsx
+++ b/frontends/web/src/components/banners/index.tsx
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AccountCode } from '@/api/account';
 import type { TDevices } from '@/api/devices';
 import { Testing } from './testing';
 import { Update } from './update';
@@ -11,12 +10,10 @@ import { Offline } from './offline';
 import { SDCardWarning } from './sdcard';
 
 type Props = {
-  code?: AccountCode;
   devices: TDevices;
 };
 
 export const GlobalBanners = ({
-  code,
   devices,
 }: Props) => {
   return (
@@ -29,7 +26,7 @@ export const GlobalBanners = ({
       <Banner msgKey="bitbox02nova" />
       <MobileDataWarning />
       <Offline />
-      <SDCardWarning code={code} devices={devices} />
+      <SDCardWarning devices={devices} />
     </>
   );
 };

--- a/frontends/web/src/components/banners/sdcard.tsx
+++ b/frontends/web/src/components/banners/sdcard.tsx
@@ -1,24 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import type { AccountCode } from '@/api/account';
 import type { TDevices } from '@/api/devices';
 import type { KeysOf } from '@/utils/types';
 import { useSDCard } from '@/hooks/sdcard';
 import { Message } from '@/components/message/message';
 
 type Props = {
-  code?: AccountCode;
   devices: TDevices;
 };
 
 export const SDCardWarning = ({
-  code,
   devices,
 }: Props) => {
   const { t } = useTranslation();
-  const hasCard = useSDCard(devices, code ? [code] : undefined);
+  const { key: locationKey } = useLocation();
+  const hasCard = useSDCard(devices, [locationKey]);
 
   const deviceList: KeysOf<TDevices> = Object.keys(devices);
   const firstDevice = deviceList[0];

--- a/frontends/web/src/components/layout/main.test.tsx
+++ b/frontends/web/src/components/layout/main.test.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GlobalBannersContainerContext } from '@/contexts/global-banners-context';
+import { Main } from './main';
+
+describe('Main', () => {
+  it('moves the persistent global banners into the active scroll container', () => {
+    const fallbackContainer = document.createElement('div');
+    const bannersContainer = document.createElement('div');
+    const banner = document.createElement('div');
+    bannersContainer.appendChild(banner);
+    fallbackContainer.appendChild(bannersContainer);
+    const globalBannersContainer = {
+      element: bannersContainer,
+      restore: vi.fn(() => fallbackContainer.appendChild(bannersContainer)),
+    };
+
+    const { container, rerender } = render(
+      <GlobalBannersContainerContext.Provider value={globalBannersContainer}>
+        <Main key="first">First page</Main>
+      </GlobalBannersContainerContext.Provider>,
+    );
+
+    expect(container.querySelector('main')?.firstChild).toBe(bannersContainer);
+
+    rerender(
+      <GlobalBannersContainerContext.Provider value={globalBannersContainer}>
+        <div>Page without a scroll container</div>
+      </GlobalBannersContainerContext.Provider>,
+    );
+
+    expect(globalBannersContainer.restore).toHaveBeenCalledOnce();
+    expect(fallbackContainer.firstChild).toBe(bannersContainer);
+
+    rerender(
+      <GlobalBannersContainerContext.Provider value={globalBannersContainer}>
+        <Main key="second">Second page</Main>
+      </GlobalBannersContainerContext.Provider>,
+    );
+
+    expect(container.querySelector('main')?.firstChild).toBe(bannersContainer);
+    expect(bannersContainer.firstChild).toBe(banner);
+  });
+});

--- a/frontends/web/src/components/layout/main.tsx
+++ b/frontends/web/src/components/layout/main.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactNode } from 'react';
+import { ReactNode, useLayoutEffect, useRef } from 'react';
+import { useGlobalBannersContainer } from '@/contexts/global-banners-context';
 import style from './main.module.css';
 
 type TMainProps = {
@@ -8,8 +9,25 @@ type TMainProps = {
 };
 
 export const Main = ({ children }: TMainProps) => {
+  const mainRef = useRef<HTMLElement>(null);
+  const globalBannersContainer = useGlobalBannersContainer();
+
+  useLayoutEffect(() => {
+    const main = mainRef.current;
+    if (!main || !globalBannersContainer) {
+      return;
+    }
+    const { element, restore } = globalBannersContainer;
+    main.prepend(element);
+    return () => {
+      if (element.parentElement === main) {
+        restore();
+      }
+    };
+  }, [globalBannersContainer]);
+
   return (
-    <main className={style.main}>
+    <main className={style.main} ref={mainRef}>
       {children}
     </main>
   );

--- a/frontends/web/src/contexts/global-banners-context.ts
+++ b/frontends/web/src/contexts/global-banners-context.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { createContext, useContext } from 'react';
+
+export type TGlobalBannersContainer = {
+  element: HTMLDivElement;
+  restore: () => void;
+};
+
+export const GlobalBannersContainerContext = createContext<TGlobalBannersContainer | null>(null);
+
+export const useGlobalBannersContainer = () => useContext(GlobalBannersContainerContext);

--- a/frontends/web/src/contexts/global-banners-provider.tsx
+++ b/frontends/web/src/contexts/global-banners-provider.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ReactNode, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { TDevices } from '@/api/devices';
+import { GlobalBanners } from '@/components/banners';
+import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
+import { GlobalBannersContainerContext } from './global-banners-context';
+import style from '@/components/banners/global-banners.module.css';
+
+type TProps = {
+  children: ReactNode;
+  devices: TDevices;
+};
+
+export const GlobalBannersProvider = ({ children, devices }: TProps) => {
+  const fallbackRef = useRef<HTMLDivElement>(null);
+  const [container] = useState(() => {
+    const element = document.createElement('div');
+    element.className = style.container || '';
+    return element;
+  });
+  const restore = useCallback(() => {
+    fallbackRef.current?.append(container);
+  }, [container]);
+  const contextValue = useMemo(() => ({
+    element: container,
+    restore,
+  }), [container, restore]);
+
+  useLayoutEffect(() => {
+    if (!container.parentElement) {
+      restore();
+    }
+  }, [container, restore]);
+
+  return (
+    <GlobalBannersContainerContext.Provider value={contextValue}>
+      <div ref={fallbackRef} />
+      {children}
+      {createPortal(
+        <ContentWrapper>
+          <GlobalBanners devices={devices} />
+        </ContentWrapper>,
+        container,
+      )}
+    </GlobalBannersContainerContext.Provider>
+  );
+};

--- a/frontends/web/src/hooks/sdcard.test.ts
+++ b/frontends/web/src/hooks/sdcard.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { useSDCard } from './sdcard';
 import { DeviceInfo } from '@/api/bitbox01';
 import * as bitbox01Apis from '@/api/bitbox01';
@@ -23,6 +23,7 @@ describe('useSDCard', () => {
   describe('using any valid device, should call the appropriate checking method and return proper value', () => {
 
     beforeEach(() => {
+      vi.clearAllMocks();
       useMountedRefSpy.mockReturnValue({ current: true });
     });
 
@@ -59,7 +60,33 @@ describe('useSDCard', () => {
       await waitFor(() => expect(result.current).toBe(true));
     });
 
+    it('ignores a superseded SD card check', async () => {
+      let resolveFirst = (_value: boolean) => {};
+      let resolveSecond = (_value: boolean) => {};
+      checkSDCardSpy
+        .mockImplementationOnce(() => new Promise<boolean>((resolve) => {
+          resolveFirst = resolve;
+        }))
+        .mockImplementationOnce(() => new Promise<boolean>((resolve) => {
+          resolveSecond = resolve;
+        }));
+
+      const { result, rerender } = renderHook(
+        ({ locationKey }) => useSDCard({ '000': 'bitbox02' }, [locationKey]),
+        { initialProps: { locationKey: 'first' } },
+      );
+      await waitFor(() => expect(checkSDCard).toHaveBeenCalledTimes(1));
+
+      rerender({ locationKey: 'second' });
+      await waitFor(() => expect(checkSDCard).toHaveBeenCalledTimes(2));
+
+      await act(async () => resolveSecond(true));
+      await waitFor(() => expect(result.current).toBe(true));
+
+      await act(async () => resolveFirst(false));
+      expect(result.current).toBe(true);
+    });
+
   });
 
 });
-

--- a/frontends/web/src/hooks/sdcard.ts
+++ b/frontends/web/src/hooks/sdcard.ts
@@ -18,6 +18,7 @@ export const useSDCard = (
   const [sdcard, setSDCard] = useState<boolean>(false);
   const mounted = useMountedRef();
   useEffect(() => {
+    let cancelled = false;
     const deviceIDs = Object.keys(devices);
     Promise.all(deviceIDs.map(deviceID => {
       switch (devices[deviceID]) {
@@ -32,11 +33,14 @@ export const useSDCard = (
     }))
       .then(sdcards => sdcards.some(sdcard => sdcard))
       .then(result => {
-        if (mounted.current) {
+        if (mounted.current && !cancelled) {
           setSDCard(result);
         }
       })
       .catch(console.error);
+    return () => {
+      cancelled = true;
+    };
     // disable warning about mounted not in the dependency list
   }, [devices, ...(dependencies || [])]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/frontends/web/src/routes/account/account.module.css
+++ b/frontends/web/src/routes/account/account.module.css
@@ -227,6 +227,26 @@
     margin-top: var(--space-quarter);
 }
 
+.fadeIn {
+    animation: fade-in 200ms ease-out;
+}
+
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .fadeIn {
+        animation: none;
+    }
+}
+
 .searchContainer {
     overflow: hidden;
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import * as accountApi from '@/api/account';
 import { statusChanged, syncAddressesCount, syncdone, transactionsChanged } from '@/api/accountsync';
-import { TDevices } from '@/api/devices';
 import { getMarketVendors, MarketVendors } from '@/api/market';
 import { Balance } from '@/components/balance/balance';
 import { HeadersSync } from '@/components/headerssync/headerssync';
@@ -28,7 +27,6 @@ import { Dialog } from '@/components/dialog/dialog';
 import { A } from '@/components/anchor/anchor';
 import { i18n } from '@/i18n/i18n';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { View, ViewContent, ViewHeader } from '@/components/view/view';
 import { TransactionList } from './components/transaction-list';
 import { TransactionDetails } from '@/components/transactions/details';
@@ -43,7 +41,6 @@ import { useMediaQuery } from '@/hooks/mediaquery';
 type Props = {
   accounts: accountApi.TAccount[];
   code: accountApi.AccountCode;
-  devices: TDevices;
 };
 
 export const Account = (props: Props) => {
@@ -69,7 +66,6 @@ const getBitsuranceGuideLink = (
 const RemountAccount = ({
   accounts,
   code,
-  devices,
 }: Props) => {
   const { t } = useTranslation();
   const isMobile = useMediaQuery('(max-width: 768px)');
@@ -216,7 +212,6 @@ const RemountAccount = ({
         <Main>
           <ContentWrapper>
             <OfflineError error={status?.offlineError} />
-            <GlobalBanners code={code} devices={devices} />
             <Message
               className={style.status}
               hidden={status === undefined || status.synced || !!status.offlineError}
@@ -257,79 +252,83 @@ const RemountAccount = ({
           <View>
             <ViewHeader>
               <div className={style.balanceHeader}>
-                <Balance balance={balance} />
+                <Balance balance={balance} className={style.fadeIn} />
                 {!isAccountEmpty && <ActionButtons {...actionButtonsProps} />}
               </div>
             </ViewHeader>
             <ViewContent>
-              <div className={style.accountHeader}>
-                {isAccountEmpty && (
-                  <BuyReceiveCTA
-                    account={account}
-                    code={code}
-                    unit={balance.available.unit}
-                    balanceList={[balance]}
-                  />
-                )}
-
-                {transactions?.success === false ? (
-                  <p className={style.errorLoadTransactions}>
-                    {t('transactions.errorLoadTransactions')}
-                  </p>
-                ) : !isAccountEmpty && (
-                  <>
-                    <div className={style.titleRow}>
-                      <SubTitle className={style.titleWithButton}>
-                        {t('accountSummary.transactionHistory')}
-                      </SubTitle>
-
-                      <Button
-                        className={style.searchButton}
-                        transparent
-                        disabled={!hasTransactions}
-                        onClick={() => {
-                          if (showSearchBar) {
-                            setShowSearchBar(false);
-                            setSearchTerm('');
-                          } else {
-                            setShowSearchBar(true);
-                          }
-                        }}
-                      >
-                        {showSearchBar ? (
-                          <>✕ {t('generic.close')}</>
-                        ) : (
-                          <>
-                            <LoupeBlue className={style.loupe} />
-                            {t('generic.searchButton')}
-                          </>
-                        )}
-                      </Button>
-                    </div>
-
-                    <div className={`
-                      ${style.searchContainer || ''}
-                      ${!showSearchBar && style.searchHidden || ''}
-                    `}>
-                      <SearchInput
-                        ref={searchInputRef}
-                        placeholder={t('accountSummary.searchPlaceholder')}
-                        value={searchTerm}
-                        onChange={(e) => setSearchTerm(e.currentTarget.value)}
+              {loadingTransactions ? (
+                <TransactionHistorySkeleton />
+              ) : (
+                <div className={style.fadeIn}>
+                  <div className={style.accountHeader}>
+                    {isAccountEmpty && (
+                      <BuyReceiveCTA
+                        account={account}
+                        code={code}
+                        unit={balance.available.unit}
+                        balanceList={[balance]}
                       />
-                    </div>
-                  </>
-                )}
-              </div>
+                    )}
 
-              {loadingTransactions && <TransactionHistorySkeleton />}
+                    {transactions?.success === false ? (
+                      <p className={style.errorLoadTransactions}>
+                        {t('transactions.errorLoadTransactions')}
+                      </p>
+                    ) : !isAccountEmpty && (
+                      <>
+                        <div className={style.titleRow}>
+                          <SubTitle className={style.titleWithButton}>
+                            {t('accountSummary.transactionHistory')}
+                          </SubTitle>
 
-              <TransactionList
-                transactionSuccess={transactions?.success ?? false}
-                filteredTransactions={filteredTransactions}
-                debouncedSearchTerm={debouncedSearchTerm}
-                onShowDetail={setDetailID}
-              />
+                          <Button
+                            className={style.searchButton}
+                            transparent
+                            disabled={!hasTransactions}
+                            onClick={() => {
+                              if (showSearchBar) {
+                                setShowSearchBar(false);
+                                setSearchTerm('');
+                              } else {
+                                setShowSearchBar(true);
+                              }
+                            }}
+                          >
+                            {showSearchBar ? (
+                              <>✕ {t('generic.close')}</>
+                            ) : (
+                              <>
+                                <LoupeBlue className={style.loupe} />
+                                {t('generic.searchButton')}
+                              </>
+                            )}
+                          </Button>
+                        </div>
+
+                        <div className={`
+                          ${style.searchContainer || ''}
+                          ${!showSearchBar && style.searchHidden || ''}
+                        `}>
+                          <SearchInput
+                            ref={searchInputRef}
+                            placeholder={t('accountSummary.searchPlaceholder')}
+                            value={searchTerm}
+                            onChange={(e) => setSearchTerm(e.currentTarget.value)}
+                          />
+                        </div>
+                      </>
+                    )}
+                  </div>
+
+                  <TransactionList
+                    transactionSuccess={transactions?.success ?? false}
+                    filteredTransactions={filteredTransactions}
+                    debouncedSearchTerm={debouncedSearchTerm}
+                    onShowDetail={setDetailID}
+                  />
+                </div>
+              )}
 
               <TransactionDetails
                 accountCode={code}
@@ -345,7 +344,7 @@ const RemountAccount = ({
         account={account}
         unit={balance?.available.unit}
         hasIncomingBalance={balance && balance.hasIncoming}
-        hasTransactions={transactions !== undefined && transactions.success && transactions.list.length > 0}
+        hasTransactions={hasTransactions}
         hasNoBalance={balance && !balance.hasAvailable}
       />
     </GuideWrapper>

--- a/frontends/web/src/routes/account/addresses/addresses.test.tsx
+++ b/frontends/web/src/routes/account/addresses/addresses.test.tsx
@@ -19,9 +19,6 @@ vi.mock('@/api/backend', async (importOriginal) => {
     cancelConnectKeystore: vi.fn().mockResolvedValue(undefined),
   };
 });
-vi.mock('@/components/banners', () => ({
-  GlobalBanners: () => null,
-}));
 vi.mock('@/api/system', () => ({
   open: vi.fn().mockResolvedValue({ success: true }),
 }));
@@ -94,9 +91,9 @@ const renderWithRoute = (initialEntry: string, initialAccounts: accountApi.TAcco
     return (
       <BackButtonProvider>
         <Routes>
-          <Route path="/account/:code/addresses" element={<Addresses code={accountCode} accounts={accounts} devices={{}} />} />
-          <Route path="/account/:code/addresses/:addressID" element={<Addresses code={accountCode} accounts={accounts} devices={{}} />} />
-          <Route path="/account/:code/addresses/:addressID/verify" element={<Addresses code={accountCode} accounts={accounts} devices={{}} />} />
+          <Route path="/account/:code/addresses" element={<Addresses code={accountCode} accounts={accounts} />} />
+          <Route path="/account/:code/addresses/:addressID" element={<Addresses code={accountCode} accounts={accounts} />} />
+          <Route path="/account/:code/addresses/:addressID/verify" element={<Addresses code={accountCode} accounts={accounts} />} />
         </Routes>
       </BackButtonProvider>
     );

--- a/frontends/web/src/routes/account/addresses/addresses.tsx
+++ b/frontends/web/src/routes/account/addresses/addresses.tsx
@@ -6,10 +6,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useLoad } from '@/hooks/api';
 import * as accountApi from '@/api/account';
 import { AccountCode, TAccount } from '@/api/account';
-import { TDevices } from '@/api/devices';
 import { Header, Main } from '@/components/layout';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { View, ViewContent } from '@/components/view/view';
 import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { findAccount } from '@/routes/account/utils';
@@ -180,18 +177,14 @@ export const AddressesContent = ({ code, accounts }: TAddressesContentProps) => 
 type TProps = {
   code: AccountCode;
   accounts: TAccount[];
-  devices: TDevices;
 };
 
-export const Addresses = ({ code, accounts, devices }: TProps) => {
+export const Addresses = ({ code, accounts }: TProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
   return (
     <Main>
-      <ContentWrapper>
-        <GlobalBanners devices={devices} />
-      </ContentWrapper>
       <Header
         hideSidebarToggler
         title={

--- a/frontends/web/src/routes/account/info/info.tsx
+++ b/frontends/web/src/routes/account/info/info.tsx
@@ -7,11 +7,8 @@ import { useSync } from '@/hooks/api';
 import { useMountedRef } from '@/hooks/mount';
 import { TAccount, AccountCode, TStatus, getStatus, exportAccount, getTransactionList, TTransactions } from '@/api/account';
 import { findAccount, isBitcoinBased, isMessageSigningSupported } from '@/routes/account/utils';
-import { TDevices } from '@/api/devices';
 import { Header, Main } from '@/components/layout';
 import { View, ViewContent } from '@/components/view/view';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { BackButton } from '@/components/backbutton/backbutton';
 import { ActionableItem } from '@/components/actionable-item/actionable-item';
@@ -24,13 +21,11 @@ import style from './info.module.css';
 type TProps = {
   accounts: TAccount[];
   code: AccountCode;
-  devices: TDevices;
 };
 
 export const Info = ({
   accounts,
   code,
-  devices,
 }: TProps) => {
   const { t } = useTranslation();
   const { isDarkMode } = useDarkmode();
@@ -93,9 +88,6 @@ export const Info = ({
 
   return (
     <Main>
-      <ContentWrapper>
-        <GlobalBanners devices={devices} />
-      </ContentWrapper>
       <Header hideSidebarToggler title={
         <>
           <h2 className="hide-on-small">{t('accountInfo.title')}</h2>

--- a/frontends/web/src/routes/account/summary/accountssummary.module.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.module.css
@@ -183,3 +183,23 @@
 .unitPrice {
     color: var(--color-secondary);
 }
+
+.fadeIn {
+    animation: fade-in 200ms ease-out;
+}
+
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .fadeIn {
+        animation: none;
+    }
+}

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useRef, useCallback, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as accountApi from '@/api/account';
-import { TDevices } from '@/api/devices';
 import { statusChanged, syncdone } from '@/api/accountsync';
 import { subscribeLightningBalance } from '@/api/lightning';
 import { unsubscribe } from '@/utils/subscriptions';
@@ -23,7 +22,6 @@ import { AppContext } from '@/contexts/AppContext';
 import { getAccountsByKeystore, getAccountsPerCoin, isBitcoinOnly } from '@/routes/account/utils';
 import { RatesContext } from '@/contexts/RatesContext';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { BackupReminder } from '@/components/banners/backup';
 import { OfflineError } from '@/components/banners/offline-error';
 import { isLightningFeatureAvailable } from '@/utils/env';
@@ -31,7 +29,6 @@ import style from './accountssummary.module.css';
 
 type TProps = {
   accounts: accountApi.TAccount[];
-  devices: TDevices;
 };
 
 export type Balances = {
@@ -40,7 +37,6 @@ export type Balances = {
 
 export const AccountsSummary = ({
   accounts,
-  devices,
 }: TProps) => {
   const { t } = useTranslation();
   const summaryReqTimerID = useRef<number>();
@@ -190,7 +186,6 @@ export const AccountsSummary = ({
         <Main>
           <ContentWrapper>
             <OfflineError error={offlineError} />
-            <GlobalBanners devices={devices} />
             {accountsByKeystore.map(({ keystore }) => (
               <BackupReminder
                 key={keystore.rootFingerprint}
@@ -204,6 +199,7 @@ export const AccountsSummary = ({
           </Header>
           <View>
             <Chart
+              className={chartData ? style.fadeIn : ''}
               hideAmounts={hideAmounts}
               data={chartData}
               noDataPlaceholder={

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -19,6 +19,7 @@ import { LinechartGray } from '@/components/icon';
 import styles from './chart.module.css';
 
 type TProps = {
+  className?: string;
   data?: TChartData;
   noDataPlaceholder?: JSX.Element;
   hideAmounts?: boolean;
@@ -160,6 +161,7 @@ const autoScaleProvider: AutoscaleInfoProvider = (original) => {
 };
 
 export const Chart = ({
+  className = '',
   data = defaultData,
   noDataPlaceholder,
   hideAmounts = false
@@ -631,7 +633,7 @@ export const Chart = ({
   const chartHeight = `${!isMobile ? height : mobileHeight}px`;
 
   return (
-    <section className={styles.chart}>
+    <section className={`${styles.chart || ''} ${className}`}>
       <header>
         <div className={styles.summary}>
           <div className={styles.totalValue}>

--- a/frontends/web/src/routes/device/no-device-connected.tsx
+++ b/frontends/web/src/routes/device/no-device-connected.tsx
@@ -4,9 +4,7 @@ import { useTranslation } from 'react-i18next';
 import type { TPagePropsWithSettingsTabs } from '../settings/types';
 import { Bluetooth } from '@/components/bluetooth/bluetooth';
 import { GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { ViewContent, View } from '@/components/view/view';
-import { GlobalBanners } from '@/components/banners';
 import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { WithSettingsTabs } from '@/routes/settings/components/tabs';
 import { ManageDeviceGuide } from './bitbox02/settings-guide';
@@ -22,9 +20,6 @@ export const NoDeviceConnected = ({
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners devices={devices} />
-          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -11,8 +11,6 @@ import { useKeystores } from '@/hooks/backend';
 import { useDarkmode } from '@/hooks/darkmode';
 import { useDefault } from '@/hooks/default';
 import { Bluetooth } from '@/components/bluetooth/bluetooth';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { Entry } from '@/components/guide/entry';
 import { Guide } from '@/components/guide/guide';
 import { Spinner } from '@/components/spinner/Spinner';
@@ -51,9 +49,6 @@ export const Waiting = () => {
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners devices={devices} />
-          </ContentWrapper>
           <Header title={<h2>{t('welcome.title')}</h2>}>
             <OutlinedSettingsButton />
           </Header>

--- a/frontends/web/src/routes/lightning/lightning.module.css
+++ b/frontends/web/src/routes/lightning/lightning.module.css
@@ -1,0 +1,19 @@
+.fadeIn {
+    animation: fade-in 200ms ease-out;
+}
+
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .fadeIn {
+        animation: none;
+    }
+}

--- a/frontends/web/src/routes/lightning/lightning.test.tsx
+++ b/frontends/web/src/routes/lightning/lightning.test.tsx
@@ -2,15 +2,28 @@
 
 import '../../../__mocks__/i18n';
 import type { ReactNode } from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { MemoryRouter } from 'react-router-dom';
+import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as devicesApi from '@/api/devices';
 import * as lightningApi from '@/api/lightning';
+import { GlobalBannersContainerContext } from '@/contexts/global-banners-context';
+import { Main } from '@/components/layout';
 import { ConfigContext } from '@/contexts/ConfigContext';
 import { RatesContext } from '@/contexts/RatesContext';
 import { Lightning } from './lightning';
+
+type TLightningState = {
+  isLightningReady: boolean | undefined;
+  lightningAccount: {
+    code: string;
+    num: number;
+    rootFingerprint: string;
+  } | null | undefined;
+};
+
+const useLightningMock = vi.hoisted(() => vi.fn<() => TLightningState>());
 
 vi.mock('@/i18n/i18n');
 
@@ -22,10 +35,6 @@ vi.mock('@/components/balance/balance', () => ({
   Balance: () => <div>Balance</div>,
 }));
 
-vi.mock('@/components/banners', () => ({
-  GlobalBanners: () => null,
-}));
-
 vi.mock('@/components/banners/lightning-tor-proxy-warning', () => ({
   LightningTorProxyWarning: () => null,
 }));
@@ -35,10 +44,7 @@ vi.mock('@/components/hideamountsbutton/hideamountsbutton', () => ({
 }));
 
 vi.mock('@/hooks/lightning', () => ({
-  useLightning: () => ({
-    isLightningReady: true,
-    lightningAccount: { code: 'v0-test-ln-0', num: 0, rootFingerprint: 'f23ab988' },
-  }),
+  useLightning: useLightningMock,
 }));
 
 vi.mock('@/hooks/mediaquery', () => ({
@@ -92,6 +98,10 @@ const renderLightning = () => render(
 describe('Lightning funding limit', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    useLightningMock.mockReturnValue({
+      isLightningReady: true,
+      lightningAccount: { code: 'v0-test-ln-0', num: 0, rootFingerprint: 'f23ab988' },
+    });
     vi.spyOn(devicesApi, 'getDeviceList').mockResolvedValue({});
     vi.spyOn(lightningApi, 'getBlockExplorerTxPrefix').mockResolvedValue('https://example.com/tx/');
     vi.spyOn(lightningApi, 'getLightningBalance').mockResolvedValue(balance);
@@ -110,5 +120,57 @@ describe('Lightning funding limit', () => {
     expect(screen.getByRole('link', { name: 'lightning.limit.moveCoins' })).toHaveAttribute('href', '/lightning/send');
     expect(container.querySelector('a[href="/lightning/receive"]')).toBeInTheDocument();
     expect(container.querySelector('a[href="/lightning/topup"]')).not.toBeInTheDocument();
+  });
+
+  it('keeps global banners attached when navigating before Lightning is ready', () => {
+    useLightningMock.mockReturnValue({
+      isLightningReady: undefined,
+      lightningAccount: undefined,
+    });
+    const pendingRequest = new Promise<never>(() => {});
+    vi.mocked(lightningApi.getBlockExplorerTxPrefix).mockReturnValue(pendingRequest);
+    vi.mocked(lightningApi.getLightningBalance).mockReturnValue(pendingRequest);
+    vi.mocked(lightningApi.getSparkStatus).mockReturnValue(pendingRequest);
+    const fallbackContainer = document.createElement('div');
+    const globalBannersElement = document.createElement('div');
+    const globalBannersContainer = {
+      element: globalBannersElement,
+      restore: vi.fn(() => fallbackContainer.appendChild(globalBannersElement)),
+    };
+
+    const { container } = render(
+      <GlobalBannersContainerContext.Provider value={globalBannersContainer}>
+        <MemoryRouter initialEntries={['/other']}>
+          <ConfigContext.Provider value={{ config: undefined, setConfig: vi.fn() }}>
+            <RatesContext.Provider value={{
+              defaultCurrency: 'EUR',
+              activeCurrencies: ['EUR'],
+              btcUnit: 'sat',
+              rotateDefaultCurrency: vi.fn(),
+              rotateBtcUnit: vi.fn(),
+              addToActiveCurrencies: vi.fn(),
+              updateDefaultCurrency: vi.fn(),
+              removeFromActiveCurrencies: vi.fn(),
+            }}>
+              <Routes>
+                <Route path="/other" element={(
+                  <Main>
+                    <Link to="/lightning">Open Lightning</Link>
+                  </Main>
+                )} />
+                <Route path="/lightning" element={<Lightning />} />
+              </Routes>
+            </RatesContext.Provider>
+          </ConfigContext.Provider>
+        </MemoryRouter>
+      </GlobalBannersContainerContext.Provider>,
+    );
+
+    expect(globalBannersElement.parentElement).toBe(container.querySelector('main'));
+
+    fireEvent.click(screen.getByRole('link', { name: 'Open Lightning' }));
+
+    expect(screen.getByText('lightning.initializing')).toBeInTheDocument();
+    expect(globalBannersElement.parentElement).toBe(container.querySelector('main'));
   });
 });

--- a/frontends/web/src/routes/lightning/lightning.tsx
+++ b/frontends/web/src/routes/lightning/lightning.tsx
@@ -3,7 +3,6 @@
 import { type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as accountApi from '../../api/account';
-import { getDeviceList } from '../../api/devices';
 import {
   TLightningBalance,
   TLightningPayment,
@@ -22,7 +21,6 @@ import { GuideWrapper, GuidedContent, Header, Main } from '../../components/layo
 import { Spinner } from '../../components/spinner/Spinner';
 import { ActionButtons } from './components/action-buttons';
 import { LightningGuide } from './guide';
-import { GlobalBanners } from '@/components/banners';
 import { LightningTorProxyWarning } from '@/components/banners/lightning-tor-proxy-warning';
 import { Status } from '../../components/status/status';
 import { HideAmountsButton } from '../../components/hideamountsbutton/hideamountsbutton';
@@ -48,6 +46,7 @@ import { useDebounce } from '@/hooks/debounce';
 import { useMediaQuery } from '@/hooks/mediaquery';
 import { useScrollIntoView } from '@/hooks/scroll-into-view';
 import accountStyle from '@/routes/account/account.module.css';
+import style from './lightning.module.css';
 
 const sparkStatusPollInterval = 60 * 1000;
 
@@ -111,7 +110,7 @@ const LightningPageLayout = ({
           <View>
             <ViewHeader>
               <div className={accountStyle.balanceHeader}>
-                <Balance balance={balance} />
+                <Balance balance={balance} className={style.fadeIn} />
                 <ActionButtons
                   accountDataLoaded={accountDataLoaded}
                   canSend={canSend}
@@ -178,17 +177,13 @@ const paymentToTransaction = (
 };
 
 type TLightningInnerProps = {
-  balance: TLightningBalance;
   explorerURL?: string;
   payments: TLightningPayment[];
-  statusBanners: ReactNode;
 };
 
 const LightningInner = ({
-  balance,
   explorerURL,
   payments,
-  statusBanners,
 }: TLightningInnerProps) => {
   const { t } = useTranslation();
   const isMobile = useMediaQuery('(max-width: 768px)');
@@ -234,12 +229,7 @@ const LightningInner = ({
   }, [showSearchBar, scrollSearchIntoView, isMobile]);
 
   return (
-    <LightningPageLayout
-      accountDataLoaded
-      balance={balance}
-      canSend={balance.hasAvailable}
-      statusBanners={statusBanners}
-    >
+    <div className={style.fadeIn}>
       <div className={accountStyle.accountHeader}>
         <div className={accountStyle.titleRow}>
           <SubTitle className={accountStyle.titleWithButton}>
@@ -296,7 +286,7 @@ const LightningInner = ({
         payment={payments.find(payment => payment.id === detailID)}
         onClose={() => setDetailID(null)}
       />
-    </LightningPageLayout>
+    </div>
   );
 };
 
@@ -311,7 +301,6 @@ export const Lightning = () => {
   const [error, setError] = useState<string>();
   const mounted = useMountedRef();
   const blockExplorerTxPrefix = useLoad(getBlockExplorerTxPrefix);
-  const devices = useLoad(getDeviceList);
 
   const onStateChange = useCallback(async () => {
     try {
@@ -378,7 +367,6 @@ export const Lightning = () => {
         type={sparkStatus?.status === 'major' ? 'error' : 'warning'}>
         {sparkStatus !== undefined && sparkStatus.status !== 'operational' && t(`lightning.sparkStatus.${sparkStatus.status}`)}
       </Status>
-      <GlobalBanners devices={devices || {}} />
     </>
   );
 
@@ -404,7 +392,14 @@ export const Lightning = () => {
     || isLightningReady === undefined
     || (lightningAccount && !isLightningReady)
   ) {
-    return <Spinner text={t('lightning.initializing')} />;
+    return (
+      <LightningPageLayout
+        accountDataLoaded={false}
+        statusBanners={statusBanners}
+      >
+        <Spinner text={t('lightning.initializing')} />
+      </LightningPageLayout>
+    );
   }
 
   const canSend = balance && balance.hasAvailable;
@@ -436,11 +431,16 @@ export const Lightning = () => {
   }
 
   return (
-    <LightningInner
+    <LightningPageLayout
+      accountDataLoaded
       balance={balance}
-      explorerURL={blockExplorerTxPrefix}
-      payments={payments}
+      canSend={canSend}
       statusBanners={statusBanners}
-    />
+    >
+      <LightningInner
+        explorerURL={blockExplorerTxPrefix}
+        payments={payments}
+      />
+    </LightningPageLayout>
   );
 };

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -120,13 +120,11 @@ export const AppRouter = ({
   const Acc = (<InjectParams>
     <Account
       code={'' /* dummy to satisfy TS */}
-      devices={devices}
       accounts={activeAccounts} />
   </InjectParams>);
 
   const AccountsSummaryEl = (<InjectParams>
     <AccountsSummary
-      devices={devices}
       accounts={activeAccounts} />
   </InjectParams>);
 
@@ -146,7 +144,6 @@ export const AppRouter = ({
   const AccInfo = (<InjectParams>
     <Info
       code={''}
-      devices={devices}
       accounts={activeAccounts} />
   </InjectParams>);
 
@@ -159,7 +156,6 @@ export const AppRouter = ({
   const AccAddresses = (<InjectParams>
     <Addresses
       code={''}
-      devices={devices}
       accounts={activeAccounts} />
   </InjectParams>);
 
@@ -398,7 +394,7 @@ export const AppRouter = ({
           <Route
             path="lightning-settings"
             element={lightningFeatureAvailable
-              ? <LightningSettings devices={devices} hasAccounts={hasAccounts} />
+              ? <LightningSettings />
               : <Navigate replace to="/settings/advanced-settings" />}
           />
           <Route path="electrum" element={<ElectrumSettings />} />

--- a/frontends/web/src/routes/settings/about.tsx
+++ b/frontends/web/src/routes/settings/about.tsx
@@ -9,8 +9,6 @@ import { MobileHeader } from './components/mobile-header';
 import { Guide } from '@/components/guide/guide';
 import { Entry } from '@/components/guide/entry';
 import { TPagePropsWithSettingsTabs } from './types';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { FeedbackLink } from './components/about/feedback-link-setting';
 import { SupportLink } from './components/about/support-link-setting';
 import { SettingsContent, type TSettingsContentSection } from './components/settings-content';
@@ -21,9 +19,6 @@ export const About = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) => {
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners devices={devices} />
-          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -20,8 +20,6 @@ import { MobileHeader } from './components/mobile-header';
 import { Guide } from '@/components/guide/guide';
 import { Entry } from '@/components/guide/entry';
 import { EnableAuthSetting } from './components/advanced-settings/enable-auth-setting';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { SettingsContent, type TSettingsContentSection } from './components/settings-content';
 import { AppContext } from '@/contexts/AppContext';
 import { isLightningFeatureAvailable } from '@/utils/env';
@@ -41,9 +39,6 @@ export const AdvancedSettings = ({ devices, hasAccounts }: TPagePropsWithSetting
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners devices={devices} />
-          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/bb02-settings.tsx
+++ b/frontends/web/src/routes/settings/bb02-settings.tsx
@@ -26,8 +26,6 @@ import { RootFingerprintSetting } from './components/device-settings/root-finger
 import { Bip85Setting } from './components/device-settings/bip85-setting';
 import { ManageDeviceGuide } from '@/routes/device/bitbox02/settings-guide';
 import { MobileHeader } from './components/mobile-header';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { SettingsContent, type TSettingsContentSection } from './components/settings-content';
 import { SubTitle } from '@/components/title';
 import {
@@ -58,9 +56,6 @@ const BB02Settings = ({ deviceID, devices, hasAccounts }: TWrapperProps) => {
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners devices={devices} />
-          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/general.tsx
+++ b/frontends/web/src/routes/settings/general.tsx
@@ -16,8 +16,6 @@ import { Entry } from '@/components/guide/entry';
 import { SettingsContent, type TSettingsContentSection } from './components/settings-content';
 import { SubTitle } from '@/components/title';
 import { TPagePropsWithSettingsTabs } from './types';
-import { GlobalBanners } from '@/components/banners';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { isNotesSettingsVisible } from './settings-availability';
 
 type TProps = {
@@ -30,9 +28,6 @@ export const General = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) =>
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners devices={devices} />
-          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/lightning-settings.tsx
+++ b/frontends/web/src/routes/settings/lightning-settings.tsx
@@ -3,8 +3,6 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { getLightningBalance, subscribeLightningBalance } from '@/api/lightning';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { Header, Main } from '@/components/layout';
 import { View, ViewContent } from '@/components/view/view';
 import { Checked } from '@/components/icon';
@@ -14,14 +12,11 @@ import { useLoad, useSubscribe } from '@/hooks/api';
 import { useLightning } from '@/hooks/lightning';
 import { SettingsItem } from './components/settingsItem/settingsItem';
 import { MobileHeader } from './components/mobile-header';
-import { TPagePropsWithSettingsTabs } from './types';
 import styles from './lightning-settings.module.css';
 
 const serviceProvider = 'Spark';
 
-export const LightningSettings = ({
-  devices,
-}: TPagePropsWithSettingsTabs) => {
+export const LightningSettings = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { isLightningReady, lightningAccount } = useLightning();
@@ -100,9 +95,6 @@ export const LightningSettings = ({
 
   return (
     <Main>
-      <ContentWrapper>
-        <GlobalBanners devices={devices} />
-      </ContentWrapper>
       <Header
         hideSidebarToggler
         title={

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -21,8 +21,6 @@ import { View, ViewContent } from '@/components/view/view';
 import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { AccountGuide } from './manage-account-guide';
 import { WatchonlySetting } from './components/manage-accounts/watchonlySetting';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { ConnectedKeystore } from '@/components/keystore/connected-keystore';
 import { TokenListItem } from '@/components/token-list-item/token-list-item';
 import style from './manage-accounts.module.css';
@@ -195,9 +193,6 @@ export const ManageAccounts = ({ accounts, devices, hasAccounts }: Props) => {
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners devices={devices} />
-          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/mobile-settings.tsx
+++ b/frontends/web/src/routes/settings/mobile-settings.tsx
@@ -5,8 +5,6 @@ import { View, ViewContent } from '@/components/view/view';
 import { Header, Main } from '@/components/layout';
 import { Tabs, WithSettingsTabs } from './components/tabs';
 import { TPagePropsWithSettingsTabs } from './types';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { useOnlyVisitableOnMobile } from '@/hooks/onlyvisitableonmobile';
 import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { useNavigate } from 'react-router-dom';
@@ -29,9 +27,6 @@ export const MobileSettings = ({ devices, hasAccounts, showBottomNavigation }: T
   useOnlyVisitableOnMobile('/settings/general');
   return (
     <Main>
-      <ContentWrapper>
-        <GlobalBanners devices={devices} />
-      </ContentWrapper>
       <Header
         title={
           <MobileHeader


### PR DESCRIPTION
Fast page loads and tab navigation caused visible flickering. This is because the global banners were mounted inside each route, so navigating remounted them and changed the page layout after rendering. 

Also loaded balances, charts, and transaction lists replaced the skeletons abruptly.

How we fix it in this PR:

- Mount global banners once above the router so their state survives navigation.
- Fade loaded balances, charts, and transaction lists into place.