### PR TITLE
backend: bind AOPP actions to requests

### DIFF
--- a/backend/aopp.go
+++ b/backend/aopp.go
@@ -98,6 +98,9 @@ const (
 
 // AOPP holds all the state needed to process an AOPP (Address Ownership Proof Protocol) request.
 type AOPP struct {
+	// RequestID identifies this request so frontend actions cannot be applied to a newer request
+	// that replaced the one the user acted on.
+	RequestID uint64 `json:"requestID,omitempty"`
 	// State is the current state the request is in. See `aoppState*` for the possible values.
 	State aoppState `json:"state"`
 	// ErrorCode is an "aopp*" error code. Only applies if State == aoppStateError.
@@ -144,9 +147,12 @@ func (backend *Backend) notifyAOPP() {
 	})
 }
 
-// AOPPCancel resets the aopp state.
-func (backend *Backend) AOPPCancel() {
+// AOPPCancel resets the aopp state if requestID identifies the current request.
+func (backend *Backend) AOPPCancel(requestID uint64) {
 	defer backend.accountsAndKeystoreLock.Lock()()
+	if backend.aopp.RequestID != requestID {
+		return
+	}
 	backend.aopp = AOPP{State: aoppStateInactive}
 	backend.notifyAOPP()
 }
@@ -230,7 +236,11 @@ func (backend *Backend) aoppKeystoreRegistered() {
 func (backend *Backend) handleAOPP(uri url.URL) {
 	defer backend.accountsAndKeystoreLock.Lock()()
 
-	backend.aopp = AOPP{State: aoppStateInactive}
+	backend.aoppRequestSerial++
+	backend.aopp = AOPP{
+		RequestID: backend.aoppRequestSerial,
+		State:     aoppStateInactive,
+	}
 
 	log := backend.log.WithField("aopp-uri", uri.String())
 	q := uri.Query()
@@ -285,9 +295,9 @@ func (backend *Backend) handleAOPP(uri url.URL) {
 // AOPPApprove is called when the user approves the AOPP request, moving the state from
 // `aoppStateUserApproval` to either `aoppStateAwaitingKeystore` or `aoppStateChoosingAccount`
 // depending on if there is a keystore.
-func (backend *Backend) AOPPApprove() {
+func (backend *Backend) AOPPApprove(requestID uint64) {
 	defer backend.accountsAndKeystoreLock.Lock()()
-	if backend.aopp.State != aoppStateUserApproval {
+	if backend.aopp.RequestID != requestID || backend.aopp.State != aoppStateUserApproval {
 		return
 	}
 	backend.aopp.State = aoppStateAwaitingKeystore
@@ -485,7 +495,10 @@ loop:
 
 // AOPPChooseAccount is called when an AOPP request is being processed and the user has chosen an
 // account.
-func (backend *Backend) AOPPChooseAccount(code accountsTypes.Code) {
+func (backend *Backend) AOPPChooseAccount(requestID uint64, code accountsTypes.Code) {
 	defer backend.accountsAndKeystoreLock.Lock()()
+	if backend.aopp.RequestID != requestID {
+		return
+	}
 	backend.aoppChooseAccount(code)
 }

--- a/backend/aopp_test.go
+++ b/backend/aopp_test.go
@@ -195,8 +195,10 @@ func TestAOPPSuccess(t *testing.T) {
 
 			require.Equal(t, AOPP{State: aoppStateInactive}, b.AOPP())
 			b.HandleURI(uriPrefix + params.Encode())
+			requestID := b.AOPP().RequestID
 			require.Equal(t,
 				AOPP{
+					RequestID:    requestID,
 					State:        aoppStateUserApproval,
 					Callback:     callback,
 					Message:      dummyMsg,
@@ -207,9 +209,10 @@ func TestAOPPSuccess(t *testing.T) {
 				b.AOPP(),
 			)
 
-			b.AOPPApprove()
+			b.AOPPApprove(requestID)
 			require.Equal(t,
 				AOPP{
+					RequestID:    requestID,
 					State:        aoppStateAwaitingKeystore,
 					Callback:     callback,
 					Message:      dummyMsg,
@@ -224,7 +227,8 @@ func TestAOPPSuccess(t *testing.T) {
 
 			require.Equal(t,
 				AOPP{
-					State: aoppStateChoosingAccount,
+					RequestID: requestID,
+					State:     aoppStateChoosingAccount,
 					Accounts: []account{
 						{Name: test.accountName, Code: test.accountCode},
 						{Name: "Second account", Code: regularAccountCode(rootFingerprint1, test.coinCode, 1)},
@@ -238,10 +242,11 @@ func TestAOPPSuccess(t *testing.T) {
 				b.AOPP(),
 			)
 
-			b.AOPPChooseAccount(test.accountCode)
+			b.AOPPChooseAccount(requestID, test.accountCode)
 			require.Equal(t,
 				AOPP{
-					State: aoppStateSuccess,
+					RequestID: requestID,
+					State:     aoppStateSuccess,
 					Accounts: []account{
 						{Name: test.accountName, Code: test.accountCode},
 						{Name: "Second account", Code: regularAccountCode(rootFingerprint1, test.coinCode, 1)},
@@ -274,7 +279,7 @@ func TestAOPPSuccess(t *testing.T) {
 		params.Set("callback", server.URL)
 		b.HandleURI(uriPrefix + params.Encode())
 		require.Equal(t, aoppStateUserApproval, b.AOPP().State)
-		b.AOPPApprove()
+		b.AOPPApprove(b.AOPP().RequestID)
 		require.Equal(t, aoppStateAwaitingKeystore, b.AOPP().State)
 		b.registerKeystore(makeKeystore(t, scriptTypeRef(signing.ScriptTypeP2WPKH), keystoreHelper))
 		require.Equal(t, aoppStateSuccess, b.AOPP().State)
@@ -294,7 +299,7 @@ func TestAOPPSuccess(t *testing.T) {
 		b.registerKeystore(makeKeystore(t, scriptTypeRef(signing.ScriptTypeP2WPKH), keystoreHelper))
 		b.HandleURI(uriPrefix + params.Encode())
 		require.Equal(t, aoppStateUserApproval, b.AOPP().State)
-		b.AOPPApprove()
+		b.AOPPApprove(b.AOPP().RequestID)
 		require.Equal(t, aoppStateSuccess, b.AOPP().State)
 	})
 	// Keystore is already registered before the AOPP request. Edge case: keystore is disconnected
@@ -307,7 +312,7 @@ func TestAOPPSuccess(t *testing.T) {
 		b.HandleURI(uriPrefix + params.Encode())
 		require.Equal(t, aoppStateUserApproval, b.AOPP().State)
 		b.DeregisterKeystore()
-		b.AOPPApprove()
+		b.AOPPApprove(b.AOPP().RequestID)
 		require.Equal(t, aoppStateAwaitingKeystore, b.AOPP().State)
 	})
 	//  Keystore watch-only is enabled, but the keystore is still required to sign, as its accounts are not available
@@ -330,7 +335,7 @@ func TestAOPPSuccess(t *testing.T) {
 
 		b.HandleURI("aopp:?" + params.Encode())
 		require.Equal(t, aoppStateUserApproval, b.AOPP().State)
-		b.AOPPApprove()
+		b.AOPPApprove(b.AOPP().RequestID)
 
 		for _, account := range b.AOPP().Accounts {
 			ac := b.accounts.lookup(account.Code)
@@ -340,6 +345,45 @@ func TestAOPPSuccess(t *testing.T) {
 			require.Equal(t, accountFingerprint, rootFingerprint2)
 		}
 	})
+}
+
+func TestAOPPRejectsStaleActions(t *testing.T) {
+	// From mnemonic: wisdom minute home employ west tail liquid mad deal catalog narrow mistake
+	rootKey := test.TstMustXKey("xprv9s21ZrQH143K3gie3VFLgx8JcmqZNsBcBc6vAdJrsf4bPRhx69U8qZe3EYAyvRWyQdEfz7ZpyYtL8jW2d2Lfkfh6g2zivq8JdZPQqxoxLwB")
+	keystoreHelper := software.NewKeystore(rootKey)
+
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	ks := makeKeystore(t, scriptTypeRef(signing.ScriptTypeP2WPKH), keystoreHelper)
+	b.registerKeystore(ks)
+	_, err := b.CreateAndPersistAccountConfig(coinpkg.CodeBTC, "Second account", ks)
+	require.NoError(t, err)
+
+	firstParams := defaultParams()
+	firstParams.Set("msg", "first request")
+	b.HandleURI(uriPrefix + firstParams.Encode())
+	firstRequestID := b.AOPP().RequestID
+
+	secondParams := defaultParams()
+	secondParams.Set("msg", "second request")
+	b.HandleURI(uriPrefix + secondParams.Encode())
+	secondRequestID := b.AOPP().RequestID
+	require.NotEqual(t, firstRequestID, secondRequestID)
+
+	// Actions from the first prompt must not approve or dismiss its replacement.
+	b.AOPPApprove(firstRequestID)
+	b.AOPPCancel(firstRequestID)
+	require.Equal(t, aoppStateUserApproval, b.AOPP().State)
+	require.Equal(t, secondRequestID, b.AOPP().RequestID)
+	require.Equal(t, "second request", b.AOPP().Message)
+
+	// Once the replacement reaches account selection, an old selection must not apply to it.
+	b.AOPPApprove(secondRequestID)
+	require.Equal(t, aoppStateChoosingAccount, b.AOPP().State)
+	b.AOPPChooseAccount(firstRequestID, "v0-55555555-btc-0")
+	require.Equal(t, aoppStateChoosingAccount, b.AOPP().State)
+	require.Empty(t, b.AOPP().AccountCode)
 }
 
 func TestAOPPFailures(t *testing.T) {
@@ -399,7 +443,7 @@ func TestAOPPFailures(t *testing.T) {
 		defer b.Close()
 		params := defaultParams()
 		b.HandleURI(uriPrefix + params.Encode())
-		b.AOPPApprove()
+		b.AOPPApprove(b.AOPP().RequestID)
 		ks2 := makeKeystore(t, scriptTypeRef(signing.ScriptTypeP2WPKH), keystoreHelper)
 		ks2.CanSignMessageFunc = func(coinpkg.Code) bool {
 			return false
@@ -415,7 +459,7 @@ func TestAOPPFailures(t *testing.T) {
 		b.registerKeystore(ks)
 		require.NoError(t, b.SetAccountActive("v0-55555555-btc-0", false))
 		b.HandleURI(uriPrefix + params.Encode())
-		b.AOPPApprove()
+		b.AOPPApprove(b.AOPP().RequestID)
 		require.Equal(t, aoppStateError, b.AOPP().State)
 		require.Equal(t, errAOPPNoAccounts, b.AOPP().ErrorCode)
 	})
@@ -425,7 +469,7 @@ func TestAOPPFailures(t *testing.T) {
 		params := defaultParams()
 		params.Set("format", "p2pkh")
 		b.HandleURI(uriPrefix + params.Encode())
-		b.AOPPApprove()
+		b.AOPPApprove(b.AOPP().RequestID)
 		b.registerKeystore(ks)
 		require.Equal(t, aoppStateError, b.AOPP().State)
 		require.Equal(t, errAOPPUnsupportedFormat, b.AOPP().ErrorCode)
@@ -435,13 +479,13 @@ func TestAOPPFailures(t *testing.T) {
 		defer b.Close()
 		params := defaultParams()
 		b.HandleURI(uriPrefix + params.Encode())
-		b.AOPPApprove()
+		b.AOPPApprove(b.AOPP().RequestID)
 		ks2 := makeKeystore(t, scriptTypeRef(signing.ScriptTypeP2WPKH), keystoreHelper)
 		ks2.SignBTCMessageFunc = func([]byte, signing.AbsoluteKeypath, signing.ScriptType, coinpkg.Code) ([]byte, error) {
 			return nil, errp.WithStack(keystorePkg.ErrSigningAborted)
 		}
 		b.registerKeystore(ks2)
-		b.AOPPChooseAccount("v0-55555555-btc-0")
+		b.AOPPChooseAccount(b.AOPP().RequestID, "v0-55555555-btc-0")
 		require.Equal(t, aoppStateError, b.AOPP().State)
 		require.Equal(t, errAOPPSigningAborted, b.AOPP().ErrorCode)
 	})
@@ -457,9 +501,9 @@ func TestAOPPFailures(t *testing.T) {
 		params := defaultParams()
 		params.Set("callback", server.URL)
 		b.HandleURI(uriPrefix + params.Encode())
-		b.AOPPApprove()
+		b.AOPPApprove(b.AOPP().RequestID)
 		b.registerKeystore(ks)
-		b.AOPPChooseAccount("v0-55555555-btc-0")
+		b.AOPPChooseAccount(b.AOPP().RequestID, "v0-55555555-btc-0")
 		require.Equal(t, aoppStateError, b.AOPP().State)
 		require.Equal(t, errAOPPCallback, b.AOPP().ErrorCode)
 	})

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -243,7 +243,8 @@ type Backend struct {
 
 	connectKeystore connectKeystore
 
-	aopp AOPP
+	aopp              AOPP
+	aoppRequestSerial uint64
 
 	// makeBtcAccount creates a BTC account. In production this is `btc.NewAccount`, but can be
 	// overridden in unit tests for mocking.

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -108,9 +108,9 @@ type Backend interface {
 	SetAccountReceiveScriptType(accountCode accountsTypes.Code, scriptType signing.ScriptType) error
 	RenameAccount(accountCode accountsTypes.Code, name string) error
 	AOPP() backend.AOPP
-	AOPPCancel()
-	AOPPApprove()
-	AOPPChooseAccount(code accountsTypes.Code)
+	AOPPCancel(requestID uint64)
+	AOPPApprove(requestID uint64)
+	AOPPChooseAccount(requestID uint64, code accountsTypes.Code)
 	GetAccountFromCode(code accountsTypes.Code) (accounts.Interface, error)
 	HTTPClient() *http.Client
 	LookupInsuredAccounts(accountCode accountsTypes.Code) ([]bitsurance.AccountDetails, error)
@@ -1684,23 +1684,48 @@ func (handlers *Handlers) postAOPPChooseAccount(r *http.Request) interface{} {
 
 	var request struct {
 		AccountCode accountsTypes.Code `json:"accountCode"`
+		RequestID   uint64             `json:"requestID"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return response{Success: false, ErrorMessage: err.Error()}
 	}
 
-	handlers.backend.AOPPChooseAccount(request.AccountCode)
+	handlers.backend.AOPPChooseAccount(request.RequestID, request.AccountCode)
 	return response{Success: true}
 }
 
 func (handlers *Handlers) postAOPPCancel(r *http.Request) interface{} {
-	handlers.backend.AOPPCancel()
-	return nil
+	type response struct {
+		Success      bool   `json:"success"`
+		ErrorMessage string `json:"errorMessage,omitempty"`
+	}
+
+	var request struct {
+		RequestID uint64 `json:"requestID"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		return response{Success: false, ErrorMessage: err.Error()}
+	}
+
+	handlers.backend.AOPPCancel(request.RequestID)
+	return response{Success: true}
 }
 
 func (handlers *Handlers) postAOPPApprove(r *http.Request) interface{} {
-	handlers.backend.AOPPApprove()
-	return nil
+	type response struct {
+		Success      bool   `json:"success"`
+		ErrorMessage string `json:"errorMessage,omitempty"`
+	}
+
+	var request struct {
+		RequestID uint64 `json:"requestID"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		return response{Success: false, ErrorMessage: err.Error()}
+	}
+
+	handlers.backend.AOPPApprove(request.RequestID)
+	return response{Success: true}
 }
 
 func (handlers *Handlers) postCancelConnectKeystore(r *http.Request) interface{} {

--- a/frontends/web/src/api/aopp.ts
+++ b/frontends/web/src/api/aopp.ts
@@ -15,22 +15,26 @@ type Accounts = NonEmptyArray<TAccount>;
 
 export type Aopp = {
   state: 'error';
+  requestID: number;
   errorCode: 'aoppUnsupportedAsset' | 'aoppVersion' | 'aoppInvalidRequest' | 'aoppNoAccounts' | 'aoppUnsupportedKeystore' | 'aoppUnknown' | 'aoppSigningAborted' | 'aoppCallback';
   callback: string;
 } | {
   state: 'inactive';
 } | {
   state: 'user-approval' | 'awaiting-keystore' | 'syncing';
+  requestID: number;
   message: string;
   callback: string;
   xpubRequired: boolean;
 } | {
   state: 'choosing-account';
+  requestID: number;
   accounts: Accounts;
   message: string;
   callback: string;
 } | {
   state: 'signing' | 'success';
+  requestID: number;
   address: string;
   displayAddress: string;
   addressID: string;
@@ -39,23 +43,23 @@ export type Aopp = {
   accountCode: AccountCode;
 };
 
-export const cancel = (): Promise<null> => {
-  return apiPost('aopp/cancel');
+export const cancel = (requestID: number): Promise<TActionResponse> => {
+  return apiPost('aopp/cancel', { requestID });
 };
 
-export const approve = (): Promise<null> => {
-  return apiPost('aopp/approve');
+export const approve = (requestID: number): Promise<TActionResponse> => {
+  return apiPost('aopp/approve', { requestID });
 };
 
-type TChooseAccountResponse = {
+type TActionResponse = {
   success: true;
 } | {
   success: false;
   errorMessage: string;
 };
 
-export const chooseAccount = (accountCode: AccountCode): Promise<TChooseAccountResponse> => {
-  return apiPost('aopp/choose-account', { accountCode });
+export const chooseAccount = (requestID: number, accountCode: AccountCode): Promise<TActionResponse> => {
+  return apiPost('aopp/choose-account', { requestID, accountCode });
 };
 
 export const getAOPP = (): Promise<Aopp> => {

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -50,8 +50,8 @@ export const Aopp = () => {
   }, [aopp, prevAopp]);
 
   const chooseAccount = (e: React.SyntheticEvent) => {
-    if (accountCode) {
-      aoppAPI.chooseAccount(accountCode);
+    if (accountCode && aopp?.state === 'choosing-account') {
+      aoppAPI.chooseAccount(aopp.requestID, accountCode);
     }
     e.preventDefault();
   };
@@ -76,7 +76,7 @@ export const Aopp = () => {
           </Message>
         </ViewContent>
         <ViewButtons>
-          <Button danger onClick={aoppAPI.cancel}>{t('button.dismiss')}</Button>
+          <Button danger onClick={() => aoppAPI.cancel(aopp.requestID)}>{t('button.dismiss')}</Button>
         </ViewButtons>
       </View>
     );
@@ -111,8 +111,8 @@ export const Aopp = () => {
           }
         </ViewContent>
         <ViewButtons>
-          <Button primary onClick={aoppAPI.approve}>{t('button.continue')}</Button>
-          <Button secondary onClick={aoppAPI.cancel}>{t('dialog.cancel')}</Button>
+          <Button primary onClick={() => aoppAPI.approve(aopp.requestID)}>{t('button.continue')}</Button>
+          <Button secondary onClick={() => aoppAPI.cancel(aopp.requestID)}>{t('dialog.cancel')}</Button>
         </ViewButtons>
       </View>
     );
@@ -147,7 +147,7 @@ export const Aopp = () => {
           </ViewContent>
           <ViewButtons>
             <Button primary type="submit">{t('button.next')}</Button>
-            <Button secondary onClick={aoppAPI.cancel}>{t('dialog.cancel')}</Button>
+            <Button secondary onClick={() => aoppAPI.cancel(aopp.requestID)}>{t('dialog.cancel')}</Button>
           </ViewButtons>
         </View>
       </form>
@@ -167,7 +167,7 @@ export const Aopp = () => {
           <p>{t('account.syncing')}</p>
         </ViewContent>
         <ViewButtons>
-          <Button secondary onClick={aoppAPI.cancel}>{t('dialog.cancel')}</Button>
+          <Button secondary onClick={() => aoppAPI.cancel(aopp.requestID)}>{t('dialog.cancel')}</Button>
         </ViewButtons>
       </View>
     );
@@ -233,7 +233,7 @@ export const Aopp = () => {
           </Field>
         </ViewContent>
         <ViewButtons>
-          <Button primary onClick={aoppAPI.cancel}>{t('button.done')}</Button>
+          <Button primary onClick={() => aoppAPI.cancel(aopp.requestID)}>{t('button.done')}</Button>
           <VerifyAddress
             accountCode={aopp.accountCode}
             displayAddress={aopp.displayAddress}


### PR DESCRIPTION
Attach a monotonically increasing request ID to each AOPP request and require
approve, cancel, and account-selection actions to echo that ID. Ignore actions
whose ID no longer matches the backend's current request.

Pass the ID through the frontend API and add a regression test covering stale
actions after a request is replaced.