### PR TITLE
eth: parse ERC-681 payment requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Mobile: Move settings into bottom navigation
 - Enable Tether USDT for BTC Direct
 - Allow users to upgrade firmware during setup
+- Ethereum: improve QR code scanning and fix ERC20 QR payment requests
 
 ## v4.51.4
 - Bundle BitBox02 and BitBox02 Nova firmware version v9.26.5

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -38,6 +38,7 @@ import (
 )
 
 func isMixedCase(s string) bool {
+	s = strings.TrimPrefix(strings.TrimPrefix(s, "0x"), "0X")
 	return strings.ToLower(s) != s && strings.ToUpper(s) != s
 }
 
@@ -545,6 +546,11 @@ func (account *Account) newTx(args *accounts.TxProposalArgs) (*TxProposal, error
 			return nil, err
 		}
 		value = parsedAmount.BigInt()
+	}
+	if account.coin.erc20Token != nil {
+		if value.BitLen() > 256 {
+			return nil, errp.WithStack(errors.ErrInvalidAmount)
+		}
 	}
 
 	var message ethereum.CallMsg

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/errors"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth/erc20"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth/rpcclient"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth/rpcclient/mocks"
 	ethtypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth/types"
@@ -167,7 +168,7 @@ func TestTxProposal(t *testing.T) {
 	})
 	t.Run("valid-address-uppercase", func(t *testing.T) {
 		_, _, _, err := acct.TxProposal(&accounts.TxProposalArgs{
-			RecipientAddress: "0XA29163852021BF4C139D03DFF59AE763AC73E84E",
+			RecipientAddress: "0xA29163852021BF4C139D03DFF59AE763AC73E84E",
 			Amount:           coin.NewSendAmount("0.1"),
 			FeeTargetCode:    accounts.FeeTargetCodeCustom,
 			CustomFee:        "20",
@@ -194,6 +195,23 @@ func TestTxProposal(t *testing.T) {
 		})
 		require.Equal(t, errors.ErrInvalidAddress, errp.Cause(err))
 	})
+}
+
+func TestERC20TxProposalRejectsAmountOverflow(t *testing.T) {
+	acct := newAccount(t)
+	defer acct.Close()
+	acct.coin.erc20Token = erc20.NewToken("0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7", 0)
+	require.NoError(t, acct.Update(big.NewInt(1e18), big.NewInt(100), nil))
+	require.Eventually(t, acct.Synced, time.Second, time.Millisecond*200)
+
+	_, _, _, err := acct.TxProposal(&accounts.TxProposalArgs{
+		RecipientAddress: "0xa29163852021BF4C139D03Dff59ae763AC73e84e",
+		Amount: coin.NewSendAmount(
+			"115792089237316195423570985008687907853269984665640564039457584007913129639936"),
+		FeeTargetCode: accounts.FeeTargetCodeCustom,
+		CustomFee:     "20",
+	})
+	require.Equal(t, errors.ErrInvalidAmount, errp.Cause(err))
 }
 
 func newTestOutgoingTx() *gethtypes.Transaction {

--- a/backend/coins/eth/payment_request.go
+++ b/backend/coins/eth/payment_request.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package eth
+
+import (
+	"math/big"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	errInvalidPaymentRequest = errp.New("invalid Ethereum payment request")
+	// ERC-681 (EIP-681) URL grammar: https://eips.ethereum.org/EIPS/eip-681
+	paymentRequestTargetRE = regexp.MustCompile(`^(?:pay-)?(0x[0-9a-fA-F]{40})(?:@(\d+))?$`)
+	paymentRequestAmountRE = regexp.MustCompile(`^(\d+)(?:\.(\d+))?(?:[eE](\d+))?$`)
+)
+
+// ErrPaymentRequestAccountMismatch means that the request targets a different chain or asset than
+// the selected account.
+const ErrPaymentRequestAccountMismatch errp.ErrorCode = "accountMismatch"
+
+// PaymentRequest contains the recipient and optional amount from an ERC-681 payment request.
+type PaymentRequest struct {
+	Recipient string
+	Amount    string
+}
+
+// ParsePaymentRequest parses an ERC-681 payment request for this coin.
+func (coin *Coin) ParsePaymentRequest(input string) (*PaymentRequest, error) {
+	parsed, err := url.Parse(strings.TrimSpace(input))
+	if err != nil || !strings.EqualFold(parsed.Scheme, "ethereum") || parsed.Fragment != "" || parsed.Opaque == "" {
+		return nil, errInvalidPaymentRequest
+	}
+
+	pathParts := strings.Split(parsed.Opaque, "/")
+	if len(pathParts) > 2 {
+		return nil, errInvalidPaymentRequest
+	}
+	targetMatch := paymentRequestTargetRE.FindStringSubmatch(pathParts[0])
+	if targetMatch == nil || !IsValidEthAddress(targetMatch[1]) {
+		return nil, errInvalidPaymentRequest
+	}
+	if targetMatch[2] != "" && normalizeNumber(targetMatch[2]) != coin.ChainIDstr() {
+		return nil, ErrPaymentRequestAccountMismatch
+	}
+
+	parameters, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return nil, errInvalidPaymentRequest
+	}
+	if len(pathParts) == 2 {
+		if pathParts[1] != "transfer" {
+			return nil, errInvalidPaymentRequest
+		}
+		return coin.parseERC20Transfer(targetMatch[1], parameters)
+	}
+	for key := range parameters {
+		if key != "value" {
+			return nil, errInvalidPaymentRequest
+		}
+	}
+	values := parameters["value"]
+	if len(values) > 1 {
+		return nil, errInvalidPaymentRequest
+	}
+	request := &PaymentRequest{Recipient: targetMatch[1]}
+	if len(values) == 0 {
+		return request, nil
+	}
+	atomicAmount, ok := parsePaymentRequestAtomicAmount(values[0])
+	if !ok {
+		return nil, errInvalidPaymentRequest
+	}
+	if coin.erc20Token != nil {
+		return nil, ErrPaymentRequestAccountMismatch
+	}
+	request.Amount = formatPaymentRequestAmount(atomicAmount, coin.Decimals(false))
+	return request, nil
+}
+
+func (coin *Coin) parseERC20Transfer(target string, parameters url.Values) (*PaymentRequest, error) {
+	for key := range parameters {
+		if key != "address" && key != "uint256" {
+			return nil, errInvalidPaymentRequest
+		}
+	}
+	recipients := parameters["address"]
+	amounts := parameters["uint256"]
+	if len(recipients) != 1 || len(amounts) > 1 {
+		return nil, errInvalidPaymentRequest
+	}
+	if !IsValidEthAddress(recipients[0]) {
+		return nil, errInvalidPaymentRequest
+	}
+	if coin.erc20Token == nil || common.HexToAddress(target) != coin.erc20Token.ContractAddress() {
+		return nil, ErrPaymentRequestAccountMismatch
+	}
+
+	request := &PaymentRequest{Recipient: recipients[0]}
+	if len(amounts) == 0 {
+		return request, nil
+	}
+	atomicAmount, ok := parsePaymentRequestAtomicAmount(amounts[0])
+	if !ok {
+		return nil, errInvalidPaymentRequest
+	}
+	request.Amount = formatPaymentRequestAmount(atomicAmount, coin.Decimals(false))
+	return request, nil
+}
+
+func normalizeNumber(number string) string {
+	normalized := strings.TrimLeft(number, "0")
+	if normalized == "" {
+		return "0"
+	}
+	return normalized
+}
+
+func parsePaymentRequestAtomicAmount(value string) (*big.Int, bool) {
+	match := paymentRequestAmountRE.FindStringSubmatch(value)
+	if match == nil {
+		return nil, false
+	}
+	fraction := match[2]
+	exponent := uint64(0)
+	if match[3] != "" {
+		var err error
+		exponent, err = strconv.ParseUint(match[3], 10, 64)
+		if err != nil {
+			return nil, false
+		}
+	}
+	if exponent < uint64(len(fraction)) {
+		return nil, false
+	}
+
+	significantDigits := strings.TrimLeft(match[1]+fraction, "0")
+	if significantDigits == "" {
+		return new(big.Int), true
+	}
+	trailingZeros := exponent - uint64(len(fraction))
+	if trailingZeros > 78 || len(significantDigits) > 78-int(trailingZeros) {
+		return nil, false
+	}
+	atomicAmount, ok := new(big.Int).SetString(
+		significantDigits+strings.Repeat("0", int(trailingZeros)),
+		10,
+	)
+	if !ok || atomicAmount.BitLen() > 256 {
+		return nil, false
+	}
+	return atomicAmount, true
+}
+
+func formatPaymentRequestAmount(atomicAmount *big.Int, decimals uint) string {
+	amount := atomicAmount.String()
+	if decimals == 0 {
+		return amount
+	}
+	if uint(len(amount)) <= decimals {
+		amount = strings.Repeat("0", int(decimals)-len(amount)+1) + amount
+	}
+	split := len(amount) - int(decimals)
+	fraction := strings.TrimRight(amount[split:], "0")
+	if fraction == "" {
+		return amount[:split]
+	}
+	return amount[:split] + "." + fraction
+}

--- a/backend/coins/eth/payment_request_test.go
+++ b/backend/coins/eth/payment_request_test.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package eth
+
+import (
+	"testing"
+
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth/erc20"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+// testNativeRecipient comes from the native payment example in ERC-681:
+// https://eips.ethereum.org/EIPS/eip-681#semantics
+const testNativeRecipient = "0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359"
+
+func TestParsePaymentRequestAddress(t *testing.T) {
+	accountCoin := newPaymentRequestTestCoin(nil)
+
+	request, err := accountCoin.ParsePaymentRequest(
+		"ethereum:" + testNativeRecipient,
+	)
+	require.NoError(t, err)
+	require.Equal(t, &PaymentRequest{
+		Recipient: testNativeRecipient,
+	}, request)
+
+	tokenCoin := newPaymentRequestTestCoin(erc20.NewToken(
+		"0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7",
+		6,
+	))
+	request, err = tokenCoin.ParsePaymentRequest(
+		"ethereum:" + testNativeRecipient,
+	)
+	require.NoError(t, err)
+	require.Equal(t, &PaymentRequest{
+		Recipient: testNativeRecipient,
+	}, request)
+}
+
+func TestParsePaymentRequestNativeValue(t *testing.T) {
+	accountCoin := newPaymentRequestTestCoin(nil)
+
+	request, err := accountCoin.ParsePaymentRequest(
+		"ethereum:pay-" + testNativeRecipient + "@01?value=2.014e18",
+	)
+	require.NoError(t, err)
+	require.Equal(t, &PaymentRequest{
+		Recipient: testNativeRecipient,
+		Amount:    "2.014",
+	}, request)
+}
+
+func TestParsePaymentRequestUint256Bounds(t *testing.T) {
+	accountCoin := newPaymentRequestTestCoin(nil)
+
+	request, err := accountCoin.ParsePaymentRequest(
+		"ethereum:" + testNativeRecipient +
+			"?value=115792089237316195423570985008687907853269984665640564039457584007913129639935",
+	)
+	require.NoError(t, err)
+	require.Equal(t,
+		"115792089237316195423570985008687907853269984665640564039457.584007913129639935",
+		request.Amount,
+	)
+
+	request, err = accountCoin.ParsePaymentRequest(
+		"ethereum:" + testNativeRecipient +
+			"?value=115792089237316195423570985008687907853269984665640564039457584007913129639936",
+	)
+	require.ErrorIs(t, err, errInvalidPaymentRequest)
+	require.Nil(t, request)
+}
+
+func TestParsePaymentRequestERC20Transfer(t *testing.T) {
+	accountCoin := newPaymentRequestTestCoin(erc20.NewToken(
+		"0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7",
+		6,
+	))
+
+	request, err := accountCoin.ParsePaymentRequest(
+		"ethereum:0x89205A3A3B2A69DE6DBF7F01ED13B2108B2C43E7@1/transfer" +
+			"?address=0x8e23ee67d1332ad560396262c48ffbb01f93d052&uint256=1.2e6",
+	)
+	require.NoError(t, err)
+	require.Equal(t, &PaymentRequest{
+		Recipient: "0x8e23ee67d1332ad560396262c48ffbb01f93d052",
+		Amount:    "1.2",
+	}, request)
+
+	request, err = accountCoin.ParsePaymentRequest(
+		"ethereum:0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7/transfer" +
+			"?address=0x8e23ee67d1332ad560396262c48ffbb01f93d052",
+	)
+	require.NoError(t, err)
+	require.Equal(t, &PaymentRequest{
+		Recipient: "0x8e23ee67d1332ad560396262c48ffbb01f93d052",
+	}, request)
+}
+
+func TestParsePaymentRequestAccountMismatch(t *testing.T) {
+	tokenCoin := newPaymentRequestTestCoin(erc20.NewToken(
+		"0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7",
+		6,
+	))
+	nativeCoin := newPaymentRequestTestCoin(nil)
+
+	for _, test := range []struct {
+		name        string
+		accountCoin *Coin
+		uri         string
+	}{
+		{
+			name:        "different chain",
+			accountCoin: nativeCoin,
+			uri:         "ethereum:" + testNativeRecipient + "@11155111?value=1e18",
+		},
+		{
+			name:        "different token contract",
+			accountCoin: tokenCoin,
+			uri: "ethereum:0x0000000000000000000000000000000000000001/transfer" +
+				"?address=0x8e23ee67d1332ad560396262c48ffbb01f93d052&uint256=1",
+		},
+		{
+			name:        "token transfer from native account",
+			accountCoin: nativeCoin,
+			uri: "ethereum:0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7/transfer" +
+				"?address=0x8e23ee67d1332ad560396262c48ffbb01f93d052&uint256=1",
+		},
+		{
+			name:        "native value from token account",
+			accountCoin: tokenCoin,
+			uri:         "ethereum:" + testNativeRecipient + "?value=1e18",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request, err := test.accountCoin.ParsePaymentRequest(test.uri)
+			require.ErrorIs(t, err, ErrPaymentRequestAccountMismatch)
+			require.Nil(t, request)
+		})
+	}
+}
+
+func TestParsePaymentRequestRejectsInvalidRequests(t *testing.T) {
+	accountCoin := newPaymentRequestTestCoin(nil)
+
+	for _, uri := range []string{
+		"https://example.com/payment",
+		"ethereum:0x1234?value=1",
+		"ethereum:0xFb6916095ca1df60bb79Ce92ce3ea74c37c5d359",
+		"ethereum:0xFb6916095ca1df60bb79Ce92ce3ea74c37c5d359/transfer" +
+			"?address=0x8e23ee67d1332ad560396262c48ffbb01f93d052&uint256=1",
+		"ethereum:" + testNativeRecipient + "?value=1.2",
+		"ethereum:" + testNativeRecipient + "?value=1e18446744073709551615",
+		"ethereum:" + testNativeRecipient + "?gas=21000",
+		"ethereum:" + testNativeRecipient + "?value=1&value=2",
+		"ethereum:" + testNativeRecipient + "/approve",
+		"ethereum:" + testNativeRecipient + "?value=1#fragment",
+	} {
+		t.Run(uri, func(t *testing.T) {
+			request, err := accountCoin.ParsePaymentRequest(uri)
+			require.ErrorIs(t, err, errInvalidPaymentRequest)
+			require.Nil(t, request)
+		})
+	}
+}
+
+func TestParsePaymentRequestRejectsInvalidERC20Recipient(t *testing.T) {
+	accountCoin := newPaymentRequestTestCoin(erc20.NewToken(
+		"0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7",
+		6,
+	))
+
+	request, err := accountCoin.ParsePaymentRequest(
+		"ethereum:0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7/transfer" +
+			"?address=not-an-address&uint256=1",
+	)
+	require.ErrorIs(t, err, errInvalidPaymentRequest)
+	require.Nil(t, request)
+}
+
+func newPaymentRequestTestCoin(token *erc20.Token) *Coin {
+	return NewCoin(
+		nil,
+		coin.CodeETH,
+		"Ethereum",
+		"ETH",
+		"ETH",
+		params.MainnetChainConfig,
+		"",
+		nil,
+		token,
+	)
+}

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -227,6 +227,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/keystore/{rootFingerprint}/features", handlers.getKeystoreFeatures).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/keystore-name", handlers.getKeystoreName).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/accounts", handlers.getAccounts).Methods("GET")
+	getAPIRouterNoError(apiRouter)("/account/{code}/parse-ethereum-payment-request", handlers.postParseEthereumPaymentRequest).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/swap/accounts", handlers.getSwapAccounts).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/swap/status", handlers.getSwapStatus).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/accounts/balance-summary", handlers.getAccountsBalanceSummary).Methods("GET")
@@ -906,6 +907,42 @@ func (handlers *Handlers) lookupEthAccountCode(r *http.Request) interface{} {
 		Code:           code,
 		Name:           name,
 		DisplayAddress: backendutil.FormatAddress(coinpkg.CodeETH, args.Address),
+	}
+}
+
+func (handlers *Handlers) postParseEthereumPaymentRequest(r *http.Request) interface{} {
+	var request struct {
+		URI string `json:"uri"`
+	}
+	type response struct {
+		Success   bool   `json:"success"`
+		Recipient string `json:"recipient,omitempty"`
+		Amount    string `json:"amount,omitempty"`
+		ErrorCode string `json:"errorCode,omitempty"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		return response{Success: false}
+	}
+	account, err := handlers.backend.GetAccountFromCode(accountsTypes.Code(mux.Vars(r)["code"]))
+	if err != nil {
+		return response{Success: false}
+	}
+	accountCoin, ok := account.Coin().(*eth.Coin)
+	if !ok {
+		return response{Success: false}
+	}
+	paymentRequest, err := accountCoin.ParsePaymentRequest(request.URI)
+	if err != nil {
+		if errCode, ok := errp.Cause(err).(errp.ErrorCode); ok {
+			return response{Success: false, ErrorCode: string(errCode)}
+		}
+		return response{Success: false}
+	}
+	return response{
+		Success:   true,
+		Recipient: paymentRequest.Recipient,
+		Amount:    paymentRequest.Amount,
 	}
 }
 

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -64,6 +64,22 @@ export const getAccounts = (): Promise<TAccount[]> => {
   return apiGet('accounts');
 };
 
+type TEthereumPaymentRequest = {
+  success: true;
+  recipient: string;
+  amount?: string;
+} | {
+  success: false;
+  errorCode?: 'accountMismatch';
+};
+
+export const parseEthereumPaymentRequest = (
+  code: AccountCode,
+  uri: string,
+): Promise<TEthereumPaymentRequest> => {
+  return apiPost(`account/${code}/parse-ethereum-payment-request`, { uri });
+};
+
 export type CoinFormattedAmount = {
   coinCode: CoinCode;
   coinName: string;

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -2214,6 +2214,7 @@
       "invalidAddress": "invalid address",
       "invalidAmount": "invalid amount",
       "invalidData": "invalid data",
+      "paymentRequestAccountMismatch": "This payment request is for a different asset. Open the matching account and try again.",
       "syncInProgress": "The account is still syncing. Please wait until syncing is complete and try again."
     },
     "fee": {

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -353,20 +353,41 @@ export const Send = ({
 
 
   const parseQRResult = async (uri: string) => {
-    let qrAddress;
+    let qrAddress = uri;
     let qrAmount = '';
+    let url: URL | undefined;
     try {
-      const url = new URL(uri);
-      if (url.protocol !== 'bitcoin:' && url.protocol !== 'litecoin:' && url.protocol !== 'ethereum:') {
-        alertUser(t('invalidFormat'));
-        return;
-      }
-      qrAddress = url.pathname;
-      if (isBitcoinBased(account.coinCode)) {
-        qrAmount = url.searchParams.get('amount') || '';
-      }
+      url = new URL(uri);
     } catch {
-      qrAddress = uri;
+      url = undefined;
+    }
+    if (url) {
+      if (url.protocol === 'ethereum:') {
+        let paymentRequest;
+        try {
+          paymentRequest = await accountApi.parseEthereumPaymentRequest(account.code, uri);
+        } catch (error) {
+          alertUser(t('unknownError', { errorMessage: String(error) }));
+          return;
+        }
+        if (!paymentRequest.success) {
+          alertUser(t(paymentRequest.errorCode === 'accountMismatch'
+            ? 'send.error.paymentRequestAccountMismatch'
+            : 'invalidFormat'));
+          return;
+        }
+        qrAddress = paymentRequest.recipient;
+        qrAmount = paymentRequest.amount || '';
+      } else {
+        if (url.protocol !== 'bitcoin:' && url.protocol !== 'litecoin:') {
+          alertUser(t('invalidFormat'));
+          return;
+        }
+        qrAddress = url.pathname;
+        if (isBitcoinBased(account.coinCode)) {
+          qrAmount = url.searchParams.get('amount') || '';
+        }
+      }
     }
     qrAddress = qrAddress.replace(/\s/g, '');
 
@@ -390,8 +411,10 @@ export const Send = ({
     setRecipientDisplayAddress('');
     setSelectedReceiverAccount(null);
     setSendAll(false);
-    setFiatAmount('');
-    convertToFiat(qrAmount);
+    if (qrAmount) {
+      setFiatAmount('');
+    }
+    convertToFiat(qrAmount || amount);
     setUpdateFiat(true);
   };
 


### PR DESCRIPTION
Correctly parse native ETH and ERC20 payment requests scanned from QR codes. Use the request recipient and replace the entered amount only when the request includes one.


Before asking for reviews, here is a check list of the most common things you might need to consider:
- [x] updating the Changelog
- [x] writing unit tests
- [x] checking if your changes affect other coins or tokens in unintended ways
- [x] testing on multiple environments (Qt, Android, ...)
- [x] having an AI review your changes
