### PR TITLE
backend: enable btcdirect support for usdt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add option to navigate to "Used addresses" in sign-message workflow
 - Floating mobile bottom navigation bar
 - Mobile: Move settings into bottom navigation
+- Enable Tether USDT for BTC Direct
 
 ## v4.51.4
 - Bundle BitBox02 and BitBox02 Nova firmware version v9.26.5

--- a/backend/market/btcdirect.go
+++ b/backend/market/btcdirect.go
@@ -57,7 +57,7 @@ func isRegionSupportedBtcDirect(region string) bool {
 // IsBtcDirectSupported is true if coin.Code is supported by BtcDirect.
 func IsBtcDirectSupported(coinCode coin.Code) bool {
 	supportedCoins := []coin.Code{
-		coin.CodeBTC, coin.CodeLTC, coin.CodeETH, "eth-erc20-usdc", "eth-erc20-link"}
+		coin.CodeBTC, coin.CodeLTC, coin.CodeETH, "eth-erc20-usdt", "eth-erc20-usdc", "eth-erc20-link"}
 
 	coinSupported := slices.Contains(supportedCoins, coinCode)
 


### PR DESCRIPTION
BTC Direct now supports Tether USDT again.
