### PR TITLE
backend: refresh update checks hourly

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -95,6 +95,7 @@ type Backend interface {
 	SystemOpen(string) error
 	ReconfigureHistoryExchangeRates()
 	GetUpdate() backend.UpdateState
+	CheckUpdate(context.Context) backend.UpdateState
 	Banners() *banners.Banners
 	Lightning() *lightning.Lightning
 	Environment() backend.Environment
@@ -620,7 +621,10 @@ func (handlers *Handlers) postOpen(r *http.Request) interface{} {
 	return response{Success: true}
 }
 
-func (handlers *Handlers) getUpdate(*http.Request) interface{} {
+func (handlers *Handlers) getUpdate(r *http.Request) interface{} {
+	if r.URL.Query().Get("about") == "1" {
+		return handlers.backend.CheckUpdate(r.Context())
+	}
 	return handlers.backend.GetUpdate()
 }
 

--- a/backend/update.go
+++ b/backend/update.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/versioninfo"
@@ -21,10 +23,10 @@ import (
 
 const (
 	updateFileURL       = "https://bitboxapp.shiftcrypto.io/desktop.json"
-	updateCheckInterval = 24 * time.Hour
+	updateCheckInterval = time.Hour
 )
 
-type updateCheckFunc func(context.Context) (*UpdateFile, error)
+type updateCheckFunc func(context.Context, url.Values) (*UpdateFile, error)
 
 type updateChecker struct {
 	observable.Implementation
@@ -33,6 +35,7 @@ type updateChecker struct {
 
 	latest     *UpdateFile
 	revision   uint64
+	checkLock  locker.Locker
 	latestLock locker.Locker
 	cancel     context.CancelFunc
 }
@@ -57,21 +60,26 @@ type UpdateState struct {
 
 func newUpdateChecker(proxy *socksproxy.SocksProxy, userAgent string) *updateChecker {
 	return &updateChecker{
-		check: func(ctx context.Context) (*UpdateFile, error) {
-			return checkForUpdate(ctx, proxy, userAgent)
+		check: func(ctx context.Context, query url.Values) (*UpdateFile, error) {
+			return checkForUpdate(ctx, proxy, userAgent, query)
 		},
 	}
 }
 
 // checkForUpdate checks whether a newer version of this application has been released.
 // It returns the retrieved update file if a newer version has been released and nil otherwise.
-func checkForUpdate(ctx context.Context, proxy *socksproxy.SocksProxy, userAgent string) (*UpdateFile, error) {
+func checkForUpdate(
+	ctx context.Context,
+	proxy *socksproxy.SocksProxy,
+	userAgent string,
+	query url.Values,
+) (*UpdateFile, error) {
 	client, err := proxy.GetHTTPClient()
 	if err != nil {
 		return nil, errp.WithStack(err)
 	}
 
-	request, err := newUpdateRequest(ctx, userAgent)
+	request, err := newUpdateRequest(ctx, userAgent, query)
 	if err != nil {
 		return nil, errp.WithStack(err)
 	}
@@ -99,11 +107,12 @@ func checkForUpdate(ctx context.Context, proxy *socksproxy.SocksProxy, userAgent
 	return &updateFile, nil
 }
 
-func newUpdateRequest(ctx context.Context, userAgent string) (*http.Request, error) {
+func newUpdateRequest(ctx context.Context, userAgent string, query url.Values) (*http.Request, error) {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, updateFileURL, nil)
 	if err != nil {
 		return nil, err
 	}
+	request.URL.RawQuery = query.Encode()
 	request.Header.Set("User-Agent", userAgent)
 	return request, nil
 }
@@ -133,8 +142,10 @@ func (checker *updateChecker) stop() {
 
 // run checks immediately and waits for the interval after each attempt before retrying.
 func (checker *updateChecker) run(ctx context.Context, interval time.Duration) {
-	for {
-		checker.checkAndSet(ctx)
+	for count := uint64(0); ; count++ {
+		query := url.Values{}
+		query.Set("c", strconv.FormatUint(count, 10))
+		checker.checkAndSet(ctx, query)
 
 		timer := time.NewTimer(interval)
 		select {
@@ -146,19 +157,24 @@ func (checker *updateChecker) run(ctx context.Context, interval time.Duration) {
 	}
 }
 
-func (checker *updateChecker) checkAndSet(ctx context.Context) {
-	updateFile, err := checker.check(ctx)
+func (checker *updateChecker) checkAndSet(ctx context.Context, query url.Values) UpdateState {
+	defer checker.checkLock.Lock()()
 	if ctx.Err() != nil {
-		return
+		return checker.get()
+	}
+
+	updateFile, err := checker.check(ctx, query)
+	if ctx.Err() != nil {
+		return checker.get()
 	}
 	if err != nil {
 		logging.Get().WithGroup("update").WithError(err).Warn("Check for update failed.")
-		return
+		return checker.get()
 	}
-	checker.set(updateFile)
+	return checker.set(updateFile)
 }
 
-func (checker *updateChecker) set(updateFile *UpdateFile) {
+func (checker *updateChecker) set(updateFile *UpdateFile) UpdateState {
 	unlock := checker.latestLock.Lock()
 	checker.latest = updateFile
 	checker.revision++
@@ -173,6 +189,7 @@ func (checker *updateChecker) set(updateFile *UpdateFile) {
 		Action:  action.Replace,
 		Object:  state,
 	})
+	return state
 }
 
 func (checker *updateChecker) get() UpdateState {
@@ -186,4 +203,11 @@ func (checker *updateChecker) get() UpdateState {
 // GetUpdate returns the result of the latest successful update check.
 func (backend *Backend) GetUpdate() UpdateState {
 	return backend.updateChecker.get()
+}
+
+// CheckUpdate refreshes and returns the update state after an explicit check from the About page.
+func (backend *Backend) CheckUpdate(ctx context.Context) UpdateState {
+	query := url.Values{}
+	query.Set("about", "1")
+	return backend.updateChecker.checkAndSet(ctx, query)
 }

--- a/backend/update_test.go
+++ b/backend/update_test.go
@@ -5,6 +5,7 @@ package backend
 import (
 	"context"
 	"errors"
+	"net/url"
 	"testing"
 	"time"
 
@@ -16,13 +17,17 @@ import (
 
 func TestUpdateCheckerRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	calls := make(chan int, 2)
+	type call struct {
+		count int
+		query url.Values
+	}
+	calls := make(chan call, 2)
 	releaseSecondCheck := make(chan struct{})
 	callCount := 0
 	checker := &updateChecker{
-		check: func(context.Context) (*UpdateFile, error) {
+		check: func(_ context.Context, query url.Values) (*UpdateFile, error) {
 			callCount++
-			calls <- callCount
+			calls <- call{count: callCount, query: query}
 			if callCount == 2 {
 				<-releaseSecondCheck
 			}
@@ -35,21 +40,29 @@ func TestUpdateCheckerRun(t *testing.T) {
 		close(done)
 	}()
 
-	waitForCall := func() int {
+	waitForCall := func() call {
 		select {
 		case call := <-calls:
 			return call
 		case <-time.After(time.Second):
 			require.FailNow(t, "timed out waiting for update check")
-			return 0
+			return call{}
 		}
 	}
-	require.Equal(t, 1, waitForCall())
-	require.Equal(t, 2, waitForCall())
+	firstCall := waitForCall()
+	require.Equal(t, 1, firstCall.count)
+	require.Equal(t, "c=0", firstCall.query.Encode())
+	secondCall := waitForCall()
+	require.Equal(t, 2, secondCall.count)
+	require.Equal(t, "c=1", secondCall.query.Encode())
 	cancel()
 	close(releaseSecondCheck)
 	<-done
 	require.Equal(t, 2, callCount)
+}
+
+func TestUpdateCheckInterval(t *testing.T) {
+	require.Equal(t, time.Hour, updateCheckInterval)
 }
 
 func TestUpdateCheckerCheckAndSet(t *testing.T) {
@@ -57,7 +70,7 @@ func TestUpdateCheckerCheckAndSet(t *testing.T) {
 		events := make(chan observable.Event, 1)
 		update := &UpdateFile{Description: "update available"}
 		checker := &updateChecker{
-			check: func(context.Context) (*UpdateFile, error) {
+			check: func(context.Context, url.Values) (*UpdateFile, error) {
 				return update, nil
 			},
 		}
@@ -65,7 +78,7 @@ func TestUpdateCheckerCheckAndSet(t *testing.T) {
 			events <- event
 		})
 
-		checker.checkAndSet(context.Background())
+		checker.checkAndSet(context.Background(), nil)
 
 		state := checker.get()
 		require.Equal(t, uint64(1), state.Revision)
@@ -79,7 +92,7 @@ func TestUpdateCheckerCheckAndSet(t *testing.T) {
 	t.Run("no update clears cached update", func(t *testing.T) {
 		events := make(chan observable.Event, 1)
 		checker := &updateChecker{
-			check: func(context.Context) (*UpdateFile, error) {
+			check: func(context.Context, url.Values) (*UpdateFile, error) {
 				return nil, nil
 			},
 			latest:   &UpdateFile{Description: "old update"},
@@ -89,7 +102,7 @@ func TestUpdateCheckerCheckAndSet(t *testing.T) {
 			events <- event
 		})
 
-		checker.checkAndSet(context.Background())
+		checker.checkAndSet(context.Background(), nil)
 
 		state := checker.get()
 		require.Equal(t, uint64(5), state.Revision)
@@ -101,7 +114,7 @@ func TestUpdateCheckerCheckAndSet(t *testing.T) {
 		update := &UpdateFile{Description: "cached update"}
 		events := make(chan observable.Event, 1)
 		checker := &updateChecker{
-			check: func(context.Context) (*UpdateFile, error) {
+			check: func(context.Context, url.Values) (*UpdateFile, error) {
 				return nil, errors.New("offline")
 			},
 			latest:   update,
@@ -111,7 +124,7 @@ func TestUpdateCheckerCheckAndSet(t *testing.T) {
 			events <- event
 		})
 
-		checker.checkAndSet(context.Background())
+		checker.checkAndSet(context.Background(), nil)
 
 		state := checker.get()
 		require.Equal(t, uint64(4), state.Revision)
@@ -124,12 +137,33 @@ func TestUpdateCheckerCheckAndSet(t *testing.T) {
 	})
 }
 
+func TestCheckUpdate(t *testing.T) {
+	var query url.Values
+	update := &UpdateFile{Description: "update available"}
+	backend := &Backend{
+		updateChecker: &updateChecker{
+			check: func(_ context.Context, checkQuery url.Values) (*UpdateFile, error) {
+				query = checkQuery
+				return update, nil
+			},
+		},
+	}
+
+	state := backend.CheckUpdate(context.Background())
+
+	require.Equal(t, "about=1", query.Encode())
+	require.Equal(t, uint64(1), state.Revision)
+	require.Same(t, update, state.Update)
+}
+
 func TestNewUpdateRequestSetsUserAgent(t *testing.T) {
 	backend := &Backend{environment: environment{}}
 
-	request, err := newUpdateRequest(context.Background(), backend.userAgent())
+	query := url.Values{}
+	query.Set("c", "0")
+	request, err := newUpdateRequest(context.Background(), backend.userAgent(), query)
 
 	require.NoError(t, err)
-	require.Equal(t, updateFileURL, request.URL.String())
+	require.Equal(t, updateFileURL+"?c=0", request.URL.String())
 	require.Equal(t, "BitBoxApp/"+versioninfo.Version.String()+" (linux)", request.Header.Get("User-Agent"))
 }

--- a/frontends/web/src/api/version.ts
+++ b/frontends/web/src/api/version.ts
@@ -25,6 +25,10 @@ export const getUpdate = (): Promise<TUpdateState> => {
   return apiGet('update');
 };
 
+export const checkUpdate = (): Promise<TUpdateState> => {
+  return apiGet('update?about=1');
+};
+
 export const subscribeUpdate = (
   cb: TSubscriptionCallback<TUpdateState>
 ) => (

--- a/frontends/web/src/routes/settings/components/about/app-version-setting.test.tsx
+++ b/frontends/web/src/routes/settings/components/about/app-version-setting.test.tsx
@@ -8,7 +8,7 @@ import type { TUpdateFile, TUpdateState } from '@/api/version';
 import { AppVersion } from './app-version-setting';
 
 const versionApiMocks = vi.hoisted(() => ({
-  getUpdate: vi.fn(),
+  checkUpdate: vi.fn(),
   getVersion: vi.fn(),
   subscribeUpdate: vi.fn(),
 }));
@@ -53,20 +53,21 @@ describe('routes/settings/components/about/app-version-setting', () => {
     vi.clearAllMocks();
     notifyUpdate = undefined;
     versionApiMocks.getVersion.mockResolvedValue('4.51.3');
-    versionApiMocks.getUpdate.mockResolvedValue(noUpdateState);
+    versionApiMocks.checkUpdate.mockResolvedValue(noUpdateState);
     versionApiMocks.subscribeUpdate.mockImplementation((cb: typeof notifyUpdate) => {
       notifyUpdate = cb;
       return () => {};
     });
   });
 
-  it('renders a cached update', async () => {
-    versionApiMocks.getUpdate.mockResolvedValue(updateState);
+  it('checks for and renders an update', async () => {
+    versionApiMocks.checkUpdate.mockResolvedValue(updateState);
 
     render(<AppVersion />);
 
     expect(await screen.findByText('settings.info.out-of-date')).toBeInTheDocument();
     expect(await screen.findByText('4.51.3')).toBeInTheDocument();
+    expect(versionApiMocks.checkUpdate).toHaveBeenCalledOnce();
     expect(versionApiMocks.subscribeUpdate).toHaveBeenCalledOnce();
   });
 

--- a/frontends/web/src/routes/settings/components/about/app-version-setting.tsx
+++ b/frontends/web/src/routes/settings/components/about/app-version-setting.tsx
@@ -2,7 +2,7 @@
 
 import { useLoad, useSync } from '@/hooks/api';
 import { useTranslation } from 'react-i18next';
-import { getUpdate, getVersion, subscribeUpdate } from '@/api/version';
+import { checkUpdate, getVersion, subscribeUpdate } from '@/api/version';
 import { open } from '@/api/system';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
 import { StyledSkeleton } from '@/routes/settings/bb02-settings';
@@ -13,7 +13,7 @@ export const AppVersion = () => {
   const { t } = useTranslation();
 
   const version = useLoad(getVersion);
-  const updateState = useSync(getUpdate, subscribeUpdate, state => state.revision);
+  const updateState = useSync(checkUpdate, subscribeUpdate, state => state.revision);
   const update = updateState?.update;
 
   const secondaryText = !!update ? t('settings.info.out-of-date') : t('settings.info.up-to-date');


### PR DESCRIPTION
Run automatic update checks hourly and append an incrementing c query
parameter, starting with c=0 at startup.

Refresh the update state when the About page opens and tag that check
with about=1. Serialize overlapping checks so an older response cannot
overwrite a newer result.