### PR TITLE
Fix syncInProgress error

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -69,7 +69,7 @@ type Backend interface {
 	Coin(coinpkg.Code) (coinpkg.Coin, error)
 	Testing() bool
 	Accounts() backend.AccountsList
-	PrepareSwap(buyAccountCode, sellAccountCode accountsTypes.Code, routeID, sellAmount string) (*backend.SwapPreparation, error)
+	PrepareSwap(ctx context.Context, buyAccountCode, sellAccountCode accountsTypes.Code, routeID, sellAmount string) (*backend.SwapPreparation, error)
 	SwapAccounts() (backend.SwapAccounts, error)
 	SwapStatus() backend.SwapStatus
 	AccountsByKeystore() (backend.KeystoresAccountsListMap, error)
@@ -2029,6 +2029,7 @@ func (handlers *Handlers) postConnectKeystore(r *http.Request) interface{} {
 func (handlers *Handlers) postSwapSign(r *http.Request) interface{} {
 	type result struct {
 		Success           bool                     `json:"success"`
+		ErrorCode         string                   `json:"errorCode,omitempty"`
 		ErrorMessage      string                   `json:"errorMessage,omitempty"`
 		ExpectedBuyAmount string                   `json:"expectedBuyAmount,omitempty"`
 		SwapID            string                   `json:"swapId,omitempty"`
@@ -2058,13 +2059,18 @@ func (handlers *Handlers) postSwapSign(r *http.Request) interface{} {
 		return result{Success: false, ErrorMessage: "sellAmount is required."}
 	}
 	swapResult, err := handlers.backend.PrepareSwap(
+		r.Context(),
 		request.BuyAccountCode,
 		request.SellAccountCode,
 		request.RouteID,
 		request.SellAmount,
 	)
 	if err != nil {
-		return result{Success: false, ErrorMessage: err.Error()}
+		response := result{Success: false, ErrorMessage: err.Error()}
+		if errp.Cause(err) == accounts.ErrSyncInProgress {
+			response.ErrorCode = accounts.ErrSyncInProgress.Error()
+		}
+		return response
 	}
 
 	return result{

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -69,7 +69,6 @@ type Backend interface {
 	Coin(coinpkg.Code) (coinpkg.Coin, error)
 	Testing() bool
 	Accounts() backend.AccountsList
-	EnsureSwapAccountsReady(ctx context.Context, buyAccountCode, sellAccountCode accountsTypes.Code) error
 	PrepareSwap(ctx context.Context, buyAccountCode, sellAccountCode accountsTypes.Code, routeID, sellAmount string) (*backend.SwapPreparation, error)
 	SwapAccounts() (backend.SwapAccounts, error)
 	SwapStatus() backend.SwapStatus
@@ -231,7 +230,6 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/accounts", handlers.getAccounts).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/account/{code}/parse-ethereum-payment-request", handlers.postParseEthereumPaymentRequest).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/swap/accounts", handlers.getSwapAccounts).Methods("GET")
-	getAPIRouterNoError(apiRouter)("/swap/ready", handlers.postSwapReady).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/swap/status", handlers.getSwapStatus).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/accounts/balance-summary", handlers.getAccountsBalanceSummary).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/set-account-active", handlers.postSetAccountActive).Methods("POST")
@@ -2081,37 +2079,6 @@ func (handlers *Handlers) postSwapSign(r *http.Request) interface{} {
 		SwapID:            swapResult.SwapID,
 		TxInput:           &swapResult.TxInput,
 	}
-}
-
-func (handlers *Handlers) postSwapReady(r *http.Request) interface{} {
-	type result struct {
-		Success      bool   `json:"success"`
-		ErrorCode    string `json:"errorCode,omitempty"`
-		ErrorMessage string `json:"errorMessage,omitempty"`
-	}
-	var request struct {
-		BuyAccountCode  accountsTypes.Code `json:"buyAccountCode"`
-		SellAccountCode accountsTypes.Code `json:"sellAccountCode"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-		return result{Success: false, ErrorMessage: "Request body is required and must be a valid JSON object."}
-	}
-	if request.BuyAccountCode == "" {
-		return result{Success: false, ErrorMessage: "buyAccountCode is required."}
-	}
-	if request.SellAccountCode == "" {
-		return result{Success: false, ErrorMessage: "sellAccountCode is required."}
-	}
-	if err := handlers.backend.EnsureSwapAccountsReady(
-		r.Context(), request.BuyAccountCode, request.SellAccountCode,
-	); err != nil {
-		response := result{Success: false, ErrorMessage: err.Error()}
-		if errp.Cause(err) == accounts.ErrSyncInProgress {
-			response.ErrorCode = accounts.ErrSyncInProgress.Error()
-		}
-		return response
-	}
-	return result{Success: true}
 }
 
 func (handlers *Handlers) postSwapkitQuote(r *http.Request) interface{} {

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -69,6 +69,7 @@ type Backend interface {
 	Coin(coinpkg.Code) (coinpkg.Coin, error)
 	Testing() bool
 	Accounts() backend.AccountsList
+	EnsureSwapAccountsReady(ctx context.Context, buyAccountCode, sellAccountCode accountsTypes.Code) error
 	PrepareSwap(ctx context.Context, buyAccountCode, sellAccountCode accountsTypes.Code, routeID, sellAmount string) (*backend.SwapPreparation, error)
 	SwapAccounts() (backend.SwapAccounts, error)
 	SwapStatus() backend.SwapStatus
@@ -230,6 +231,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/accounts", handlers.getAccounts).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/account/{code}/parse-ethereum-payment-request", handlers.postParseEthereumPaymentRequest).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/swap/accounts", handlers.getSwapAccounts).Methods("GET")
+	getAPIRouterNoError(apiRouter)("/swap/ready", handlers.postSwapReady).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/swap/status", handlers.getSwapStatus).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/accounts/balance-summary", handlers.getAccountsBalanceSummary).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/set-account-active", handlers.postSetAccountActive).Methods("POST")
@@ -2079,6 +2081,37 @@ func (handlers *Handlers) postSwapSign(r *http.Request) interface{} {
 		SwapID:            swapResult.SwapID,
 		TxInput:           &swapResult.TxInput,
 	}
+}
+
+func (handlers *Handlers) postSwapReady(r *http.Request) interface{} {
+	type result struct {
+		Success      bool   `json:"success"`
+		ErrorCode    string `json:"errorCode,omitempty"`
+		ErrorMessage string `json:"errorMessage,omitempty"`
+	}
+	var request struct {
+		BuyAccountCode  accountsTypes.Code `json:"buyAccountCode"`
+		SellAccountCode accountsTypes.Code `json:"sellAccountCode"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		return result{Success: false, ErrorMessage: "Request body is required and must be a valid JSON object."}
+	}
+	if request.BuyAccountCode == "" {
+		return result{Success: false, ErrorMessage: "buyAccountCode is required."}
+	}
+	if request.SellAccountCode == "" {
+		return result{Success: false, ErrorMessage: "sellAccountCode is required."}
+	}
+	if err := handlers.backend.EnsureSwapAccountsReady(
+		r.Context(), request.BuyAccountCode, request.SellAccountCode,
+	); err != nil {
+		response := result{Success: false, ErrorMessage: err.Error()}
+		if errp.Cause(err) == accounts.ErrSyncInProgress {
+			response.ErrorCode = accounts.ErrSyncInProgress.Error()
+		}
+		return response
+	}
+	return result{Success: true}
 }
 
 func (handlers *Handlers) postSwapkitQuote(r *http.Request) interface{} {

--- a/backend/swap.go
+++ b/backend/swap.go
@@ -317,32 +317,9 @@ func (backend *Backend) PrepareSwap(
 	buyAccountCode, sellAccountCode accountsTypes.Code,
 	routeID, sellAmount string,
 ) (*SwapPreparation, error) {
-	// Account reinitialization is synchronous and has no context-aware API.
-	if err := backend.activateSwapBuyAccount(buyAccountCode); err != nil { //nolint:contextcheck
-		return nil, err
-	}
-
-	sellAccount, err := backend.GetAccountFromCode(sellAccountCode)
+	sellAccount, buyAccount, err := backend.swapAccountsReady(ctx, buyAccountCode, sellAccountCode)
 	if err != nil {
 		return nil, err
-	}
-	buyAccount, err := backend.GetAccountFromCode(buyAccountCode)
-	if err != nil {
-		return nil, err
-	}
-	if err := validateSwapAccountSupported(sellAccount); err != nil {
-		return nil, err
-	}
-	if err := validateSwapAccountSupported(buyAccount); err != nil {
-		return nil, err
-	}
-
-	syncCtx, cancelSync := context.WithTimeout(ctx, swapAccountSyncTimeout)
-	defer cancelSync()
-	for _, account := range []accounts.Interface{sellAccount, buyAccount} {
-		if err := waitForSwapAccountSync(syncCtx, account); err != nil {
-			return nil, err
-		}
 	}
 
 	// Grab an unused address; since we build the tx ourselves, we don't need an used
@@ -397,6 +374,50 @@ func (backend *Backend) PrepareSwap(
 		SwapID:            swapResponse.SwapID,
 		TxInput:           txInput,
 	}, nil
+}
+
+// EnsureSwapAccountsReady activates the destination account if necessary and waits until both
+// accounts can be used to prepare a swap.
+func (backend *Backend) EnsureSwapAccountsReady(
+	ctx context.Context,
+	buyAccountCode, sellAccountCode accountsTypes.Code,
+) error {
+	_, _, err := backend.swapAccountsReady(ctx, buyAccountCode, sellAccountCode)
+	return err
+}
+
+func (backend *Backend) swapAccountsReady(
+	ctx context.Context,
+	buyAccountCode, sellAccountCode accountsTypes.Code,
+) (accounts.Interface, accounts.Interface, error) {
+	// Account reinitialization is synchronous and has no context-aware API.
+	if err := backend.activateSwapBuyAccount(buyAccountCode); err != nil { //nolint:contextcheck
+		return nil, nil, err
+	}
+
+	sellAccount, err := backend.GetAccountFromCode(sellAccountCode)
+	if err != nil {
+		return nil, nil, err
+	}
+	buyAccount, err := backend.GetAccountFromCode(buyAccountCode)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := validateSwapAccountSupported(sellAccount); err != nil {
+		return nil, nil, err
+	}
+	if err := validateSwapAccountSupported(buyAccount); err != nil {
+		return nil, nil, err
+	}
+
+	syncCtx, cancelSync := context.WithTimeout(ctx, swapAccountSyncTimeout)
+	defer cancelSync()
+	for _, account := range []accounts.Interface{sellAccount, buyAccount} {
+		if err := waitForSwapAccountSync(syncCtx, account); err != nil {
+			return nil, nil, err
+		}
+	}
+	return sellAccount, buyAccount, nil
 }
 
 // waitForSwapAccountSync waits until an account is ready for address derivation and transaction

--- a/backend/swap.go
+++ b/backend/swap.go
@@ -317,9 +317,32 @@ func (backend *Backend) PrepareSwap(
 	buyAccountCode, sellAccountCode accountsTypes.Code,
 	routeID, sellAmount string,
 ) (*SwapPreparation, error) {
-	sellAccount, buyAccount, err := backend.swapAccountsReady(ctx, buyAccountCode, sellAccountCode)
+	// Account reinitialization is synchronous and has no context-aware API.
+	if err := backend.activateSwapBuyAccount(buyAccountCode); err != nil { //nolint:contextcheck
+		return nil, err
+	}
+
+	sellAccount, err := backend.GetAccountFromCode(sellAccountCode)
 	if err != nil {
 		return nil, err
+	}
+	buyAccount, err := backend.GetAccountFromCode(buyAccountCode)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateSwapAccountSupported(sellAccount); err != nil {
+		return nil, err
+	}
+	if err := validateSwapAccountSupported(buyAccount); err != nil {
+		return nil, err
+	}
+
+	syncCtx, cancelSync := context.WithTimeout(ctx, swapAccountSyncTimeout)
+	defer cancelSync()
+	for _, account := range []accounts.Interface{sellAccount, buyAccount} {
+		if err := waitForSwapAccountSync(syncCtx, account); err != nil {
+			return nil, err
+		}
 	}
 
 	// Grab an unused address; since we build the tx ourselves, we don't need an used
@@ -374,50 +397,6 @@ func (backend *Backend) PrepareSwap(
 		SwapID:            swapResponse.SwapID,
 		TxInput:           txInput,
 	}, nil
-}
-
-// EnsureSwapAccountsReady activates the destination account if necessary and waits until both
-// accounts can be used to prepare a swap.
-func (backend *Backend) EnsureSwapAccountsReady(
-	ctx context.Context,
-	buyAccountCode, sellAccountCode accountsTypes.Code,
-) error {
-	_, _, err := backend.swapAccountsReady(ctx, buyAccountCode, sellAccountCode)
-	return err
-}
-
-func (backend *Backend) swapAccountsReady(
-	ctx context.Context,
-	buyAccountCode, sellAccountCode accountsTypes.Code,
-) (accounts.Interface, accounts.Interface, error) {
-	// Account reinitialization is synchronous and has no context-aware API.
-	if err := backend.activateSwapBuyAccount(buyAccountCode); err != nil { //nolint:contextcheck
-		return nil, nil, err
-	}
-
-	sellAccount, err := backend.GetAccountFromCode(sellAccountCode)
-	if err != nil {
-		return nil, nil, err
-	}
-	buyAccount, err := backend.GetAccountFromCode(buyAccountCode)
-	if err != nil {
-		return nil, nil, err
-	}
-	if err := validateSwapAccountSupported(sellAccount); err != nil {
-		return nil, nil, err
-	}
-	if err := validateSwapAccountSupported(buyAccount); err != nil {
-		return nil, nil, err
-	}
-
-	syncCtx, cancelSync := context.WithTimeout(ctx, swapAccountSyncTimeout)
-	defer cancelSync()
-	for _, account := range []accounts.Interface{sellAccount, buyAccount} {
-		if err := waitForSwapAccountSync(syncCtx, account); err != nil {
-			return nil, nil, err
-		}
-	}
-	return sellAccount, buyAccount, nil
 }
 
 // waitForSwapAccountSync waits until an account is ready for address derivation and transaction

--- a/backend/swap.go
+++ b/backend/swap.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	accountsTypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
@@ -18,7 +19,10 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/market/swapkit"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/paymentrequest"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
 )
+
+const swapAccountSyncTimeout = 2 * time.Minute
 
 // SwapAccount contains the backend-native data needed to serialize swap accounts.
 type SwapAccount struct {
@@ -309,10 +313,12 @@ func (backend *Backend) accountHasNonZeroBalance(accountCode accountsTypes.Code)
 // PrepareSwap prepares a real SwapKit swap and returns a tx input that can be proposed and sent
 // through the existing account tx flow.
 func (backend *Backend) PrepareSwap(
+	ctx context.Context,
 	buyAccountCode, sellAccountCode accountsTypes.Code,
 	routeID, sellAmount string,
 ) (*SwapPreparation, error) {
-	if err := backend.activateSwapBuyAccount(buyAccountCode); err != nil {
+	// Account reinitialization is synchronous and has no context-aware API.
+	if err := backend.activateSwapBuyAccount(buyAccountCode); err != nil { //nolint:contextcheck
 		return nil, err
 	}
 
@@ -329,6 +335,14 @@ func (backend *Backend) PrepareSwap(
 	}
 	if err := validateSwapAccountSupported(buyAccount); err != nil {
 		return nil, err
+	}
+
+	syncCtx, cancelSync := context.WithTimeout(ctx, swapAccountSyncTimeout)
+	defer cancelSync()
+	for _, account := range []accounts.Interface{sellAccount, buyAccount} {
+		if err := waitForSwapAccountSync(syncCtx, account); err != nil {
+			return nil, err
+		}
 	}
 
 	// Grab an unused address; since we build the tx ourselves, we don't need an used
@@ -349,7 +363,7 @@ func (backend *Backend) PrepareSwap(
 	}
 
 	swapResponse, swapError := swapkit.NewSwap(
-		context.Background(),
+		ctx,
 		backend.httpClient,
 		string(sellAccount.Coin().Code()),
 		string(buyAccount.Coin().Code()),
@@ -383,6 +397,46 @@ func (backend *Backend) PrepareSwap(
 		SwapID:            swapResponse.SwapID,
 		TxInput:           txInput,
 	}, nil
+}
+
+// waitForSwapAccountSync waits until an account is ready for address derivation and transaction
+// preparation. Activating a swap destination currently reinitializes all accounts, so both the
+// source and destination can briefly be unsynced after activateSwapBuyAccount returns.
+func waitForSwapAccountSync(ctx context.Context, account accounts.Interface) error {
+	statusChanged := make(chan struct{}, 1)
+	unobserve := account.Observe(func(event observable.Event) {
+		if event.Subject != string(accountsTypes.EventStatusChanged) {
+			return
+		}
+		select {
+		case statusChanged <- struct{}{}:
+		default:
+		}
+	})
+	defer unobserve()
+
+	for {
+		// Check after subscribing so a sync completion cannot be missed between the initial state
+		// check and observer registration.
+		if account.Synced() {
+			return nil
+		}
+		if err := account.Offline(); err != nil {
+			return errp.Wrap(err, "account synchronization failed")
+		}
+		if account.FatalError() {
+			return errp.New("account synchronization failed")
+		}
+
+		select {
+		case <-ctx.Done():
+			if context.Cause(ctx) == context.DeadlineExceeded {
+				return errp.WithMessage(accounts.ErrSyncInProgress, "timed out waiting for account synchronization")
+			}
+			return context.Cause(ctx)
+		case <-statusChanged:
+		}
+	}
 }
 
 func validateSwapAccountSupported(account accounts.Interface) error {

--- a/backend/swap_test.go
+++ b/backend/swap_test.go
@@ -3,7 +3,9 @@
 package backend
 
 import (
+	"context"
 	"slices"
+	"sync/atomic"
 	"testing"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
@@ -13,10 +15,87 @@ import (
 	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	coinMocks "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin/mocks"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/paymentrequest"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/socksproxy"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWaitForSwapAccountSync(t *testing.T) {
+	t.Run("returns immediately when synced", func(t *testing.T) {
+		account := &accountsMocks.InterfaceMock{
+			ObserveFunc: func(func(observable.Event)) func() { return func() {} },
+			SyncedFunc:  func() bool { return true },
+		}
+
+		require.NoError(t, waitForSwapAccountSync(context.Background(), account))
+	})
+
+	t.Run("does not miss sync during observer registration", func(t *testing.T) {
+		var synced atomic.Bool
+		account := &accountsMocks.InterfaceMock{
+			ObserveFunc: func(func(observable.Event)) func() {
+				synced.Store(true)
+				return func() {}
+			},
+			SyncedFunc: synced.Load,
+		}
+
+		require.NoError(t, waitForSwapAccountSync(context.Background(), account))
+	})
+
+	t.Run("waits for status change", func(t *testing.T) {
+		var synced atomic.Bool
+		observerRegistered := make(chan func(observable.Event), 1)
+		account := &accountsMocks.InterfaceMock{
+			ObserveFunc: func(observer func(observable.Event)) func() {
+				observerRegistered <- observer
+				return func() {}
+			},
+			SyncedFunc:     synced.Load,
+			OfflineFunc:    func() error { return nil },
+			FatalErrorFunc: func() bool { return false },
+		}
+
+		result := make(chan error, 1)
+		go func() {
+			result <- waitForSwapAccountSync(context.Background(), account)
+		}()
+
+		observer := <-observerRegistered
+		synced.Store(true)
+		observer(observable.Event{Subject: string(accountsTypes.EventStatusChanged)})
+		require.NoError(t, <-result)
+	})
+
+	t.Run("stops when canceled", func(t *testing.T) {
+		account := &accountsMocks.InterfaceMock{
+			ObserveFunc:    func(func(observable.Event)) func() { return func() {} },
+			SyncedFunc:     func() bool { return false },
+			OfflineFunc:    func() error { return nil },
+			FatalErrorFunc: func() bool { return false },
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		require.ErrorIs(t, waitForSwapAccountSync(ctx, account), context.Canceled)
+	})
+
+	t.Run("maps timeout to sync in progress", func(t *testing.T) {
+		account := &accountsMocks.InterfaceMock{
+			ObserveFunc:    func(func(observable.Event)) func() { return func() {} },
+			SyncedFunc:     func() bool { return false },
+			OfflineFunc:    func() error { return nil },
+			FatalErrorFunc: func() bool { return false },
+		}
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cancel(context.DeadlineExceeded)
+
+		err := waitForSwapAccountSync(ctx, account)
+		require.Equal(t, accounts.ErrSyncInProgress, errp.Cause(err))
+	})
+}
 
 func TestSwapBuyAccountsRequireConnectedKeystore(t *testing.T) {
 	b := newBackend(t, testnetDisabled, regtestDisabled)

--- a/frontends/web/src/api/swap.ts
+++ b/frontends/web/src/api/swap.ts
@@ -101,21 +101,6 @@ export const getSwapStatus = (): Promise<TSwapStatusResponse> => {
   return apiGet('swap/status');
 };
 
-export type TSwapReadyResponse = {
-  success: true;
-} | {
-  success: false;
-  errorCode?: 'syncInProgress';
-  errorMessage: string;
-};
-
-export const ensureSwapAccountsReady = (
-  buyAccountCode: AccountCode,
-  sellAccountCode: AccountCode,
-): Promise<TSwapReadyResponse> => {
-  return apiPost('swap/ready', { buyAccountCode, sellAccountCode });
-};
-
 export const signSwap = (
   data: TSwapSignRequest,
 ): Promise<TSwapSignResponse> => {

--- a/frontends/web/src/api/swap.ts
+++ b/frontends/web/src/api/swap.ts
@@ -88,6 +88,7 @@ export type TSwapSignResponse = {
   txInput: TTxInput;
 } | {
   success: false;
+  errorCode?: 'syncInProgress';
   errorMessage: string;
 };
 

--- a/frontends/web/src/api/swap.ts
+++ b/frontends/web/src/api/swap.ts
@@ -101,6 +101,21 @@ export const getSwapStatus = (): Promise<TSwapStatusResponse> => {
   return apiGet('swap/status');
 };
 
+export type TSwapReadyResponse = {
+  success: true;
+} | {
+  success: false;
+  errorCode?: 'syncInProgress';
+  errorMessage: string;
+};
+
+export const ensureSwapAccountsReady = (
+  buyAccountCode: AccountCode,
+  sellAccountCode: AccountCode,
+): Promise<TSwapReadyResponse> => {
+  return apiPost('swap/ready', { buyAccountCode, sellAccountCode });
+};
+
 export const signSwap = (
   data: TSwapSignRequest,
 ): Promise<TSwapSignResponse> => {

--- a/frontends/web/src/routes/market/swap/components/input-with-account-selector.tsx
+++ b/frontends/web/src/routes/market/swap/components/input-with-account-selector.tsx
@@ -15,6 +15,7 @@ import style from './input-with-account-selector.module.css';
 type Props<T extends TAccountBase> = {
   accountCode: AccountCode;
   accounts: T[];
+  disabled?: boolean;
   id: string;
   isAccountDisabled?: (account: T) => boolean;
   onChangeAccountCode: (accountCode: AccountCode) => void;
@@ -28,6 +29,7 @@ type Props<T extends TAccountBase> = {
 export const InputWithAccountSelector = <T extends TAccountBase, >({
   accountCode,
   accounts,
+  disabled = false,
   id,
   isAccountDisabled,
   onChangeAccountCode,
@@ -98,6 +100,7 @@ export const InputWithAccountSelector = <T extends TAccountBase, >({
         {hasAccounts && (
           <GroupedAccountSelector
             accounts={accounts}
+            disabled={disabled}
             selected={accountCode}
             onChange={(accountCode => {
               const account = findAccount(accounts, accountCode);
@@ -115,7 +118,7 @@ export const InputWithAccountSelector = <T extends TAccountBase, >({
           <NumberInput
             transparent
             align="right"
-            disabled={!selectedAccount || readOnlyAmount}
+            disabled={disabled || !selectedAccount || readOnlyAmount}
             id={id}
             className={style.inputComponent}
             classNameInputField={style.inputField}

--- a/frontends/web/src/routes/market/swap/components/swap-service-selector.test.tsx
+++ b/frontends/web/src/routes/market/swap/components/swap-service-selector.test.tsx
@@ -91,6 +91,25 @@ describe('routes/market/swap/components/swap-service-selector', () => {
     expect(await screen.findByRole('option', { name: /THORChain/ })).toBeInTheDocument();
   });
 
+  it('disables route selection while preparing a swap', () => {
+    render(
+      <SwapServiceSelector
+        buyUnit="ETH"
+        disabled
+        isLoading={false}
+        onChangeRouteId={vi.fn()}
+        routes={[{
+          expectedBuyAmount: '1.23',
+          providers: ['THORCHAIN'],
+          routeId: 'route-1',
+        }]}
+        selectedRouteId="route-1"
+      />,
+    );
+
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
   it('emits route id when selecting another grouped route', async () => {
     const user = userEvent.setup();
     const onChangeRouteId = vi.fn();

--- a/frontends/web/src/routes/market/swap/components/swap-service-selector.tsx
+++ b/frontends/web/src/routes/market/swap/components/swap-service-selector.tsx
@@ -122,6 +122,7 @@ const DropdownIndicator = (props: DropdownIndicatorProps<TOption>) => (
 
 type Props = {
   buyUnit: CoinUnit | undefined;
+  disabled?: boolean;
   error?: string;
   isLoading: boolean;
   onChangeRouteId: (routeId: string) => void;
@@ -131,6 +132,7 @@ type Props = {
 
 export const SwapServiceSelector = ({
   buyUnit,
+  disabled = false,
   error,
   isLoading,
   onChangeRouteId,
@@ -203,7 +205,7 @@ export const SwapServiceSelector = ({
           SingleValue: CustomSingleValue,
         }}
         placeholder={placeholderText}
-        isDisabled={!options.length || isLoading}
+        isDisabled={disabled || !options.length || isLoading}
         isSearchable={false}
         options={options}
         value={selectedOption}

--- a/frontends/web/src/routes/market/swap/swap.test.tsx
+++ b/frontends/web/src/routes/market/swap/swap.test.tsx
@@ -48,11 +48,13 @@ vi.mock('./components/swap-result', () => ({
 }));
 vi.mock('./components/input-with-account-selector', () => ({
   InputWithAccountSelector: ({
+    disabled,
     id,
     onChangeValue,
     readOnlyAmount,
     value,
   }: {
+    disabled?: boolean;
     id: string;
     onChangeValue?: (value: string) => void;
     readOnlyAmount?: boolean;
@@ -64,6 +66,7 @@ vi.mock('./components/input-with-account-selector', () => ({
         <input
           id={id}
           aria-label={id}
+          disabled={disabled}
           value={value || ''}
           onChange={event => onChangeValue?.(event.target.value)}
         />
@@ -92,6 +95,7 @@ vi.mock('@/api/swap', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/api/swap')>();
   return {
     ...actual,
+    ensureSwapAccountsReady: vi.fn(),
     getSwapAccounts: vi.fn(),
     getSwapQuote: vi.fn(),
     signSwap: vi.fn(),
@@ -203,6 +207,7 @@ describe('routes/market/swap', () => {
 
     vi.mocked(accountApi.getBalance).mockResolvedValue({ success: false });
     vi.mocked(coinsApi.parseExternalBtcAmount).mockResolvedValue({ success: false, amount: '' });
+    vi.mocked(swapApi.ensureSwapAccountsReady).mockResolvedValue({ success: true });
     vi.mocked(swapApi.getSwapAccounts).mockResolvedValue({
       success: true,
       sellAccounts: [swapSellAccount],
@@ -457,7 +462,7 @@ describe('routes/market/swap', () => {
     const user = userEvent.setup();
 
     vi.mocked(accountApi.hasSwapPaymentRequest).mockResolvedValue({ success: true });
-    vi.mocked(swapApi.signSwap).mockImplementation(() => new Promise(() => {}));
+    vi.mocked(swapApi.ensureSwapAccountsReady).mockImplementation(() => new Promise(() => {}));
 
     render(
       <BackButtonProvider>
@@ -489,5 +494,88 @@ describe('routes/market/swap', () => {
     expect(await screen.findByRole('button', {
       name: 'Syncing the account, please wait…',
     })).toBeDisabled();
+    expect(screen.getByLabelText('swapSendAmount')).toBeDisabled();
+    expect(swapApi.signSwap).not.toHaveBeenCalled();
+  });
+
+  it('keeps the form locked after account synchronization', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(accountApi.hasSwapPaymentRequest).mockResolvedValue({ success: true });
+    vi.mocked(swapApi.signSwap).mockImplementation(() => new Promise(() => {}));
+
+    render(
+      <BackButtonProvider>
+        <RatesContext.Provider
+          value={{
+            activeCurrencies: [],
+            addToActiveCurrencies: vi.fn(),
+            btcUnit: 'default',
+            defaultCurrency: 'USD',
+            removeFromActiveCurrencies: vi.fn(),
+            rotateBtcUnit: vi.fn(),
+            rotateDefaultCurrency: vi.fn(),
+            updateDefaultCurrency: vi.fn(),
+          }}>
+          <MemoryRouter>
+            <Swap accounts={[sellAccount, buyAccount]} />
+          </MemoryRouter>
+        </RatesContext.Provider>
+      </BackButtonProvider>
+    );
+
+    await user.click(await screen.findByTestId('agree-swap-terms'));
+    const sellAmountInput = await screen.findByLabelText('swapSendAmount');
+    await user.type(sellAmountInput, '1');
+    expect(await screen.findByText('THORChain + Mayachain')).toBeInTheDocument();
+
+    await user.click(await screen.findByRole('button', { name: 'Swap' }));
+
+    expect(await screen.findByRole('button', { name: 'loading…' })).toBeDisabled();
+    expect(sellAmountInput).toBeDisabled();
+    expect(swapApi.signSwap).toHaveBeenCalledWith({
+      buyAccountCode: 'eth-account',
+      routeId: 'route-1',
+      sellAccountCode: 'btc-account',
+      sellAmount: '1',
+    });
+  });
+
+  it('refreshes an aging quote after account synchronization', async () => {
+    const user = userEvent.setup();
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+
+    vi.mocked(accountApi.hasSwapPaymentRequest).mockResolvedValue({ success: true });
+
+    render(
+      <BackButtonProvider>
+        <RatesContext.Provider
+          value={{
+            activeCurrencies: [],
+            addToActiveCurrencies: vi.fn(),
+            btcUnit: 'default',
+            defaultCurrency: 'USD',
+            removeFromActiveCurrencies: vi.fn(),
+            rotateBtcUnit: vi.fn(),
+            rotateDefaultCurrency: vi.fn(),
+            updateDefaultCurrency: vi.fn(),
+          }}>
+          <MemoryRouter>
+            <Swap accounts={[sellAccount, buyAccount]} />
+          </MemoryRouter>
+        </RatesContext.Provider>
+      </BackButtonProvider>
+    );
+
+    await user.click(await screen.findByTestId('agree-swap-terms'));
+    await user.type(await screen.findByLabelText('swapSendAmount'), '1');
+    expect(await screen.findByText('THORChain + Mayachain')).toBeInTheDocument();
+
+    dateNow.mockReturnValue(47_000);
+    await user.click(await screen.findByRole('button', { name: 'Swap' }));
+
+    await waitFor(() => expect(swapApi.getSwapQuote).toHaveBeenCalledTimes(2));
+    expect(swapApi.signSwap).not.toHaveBeenCalled();
+    dateNow.mockRestore();
   });
 });

--- a/frontends/web/src/routes/market/swap/swap.test.tsx
+++ b/frontends/web/src/routes/market/swap/swap.test.tsx
@@ -210,6 +210,7 @@ describe('routes/market/swap', () => {
       defaultSellAccountCode: swapSellAccount.code,
       defaultBuyAccountCode: swapBuyAccount.code,
     });
+    vi.mocked(swapApi.getSwapQuote).mockReset();
     vi.mocked(swapApi.getSwapQuote).mockResolvedValue({
       success: true,
       quote: {
@@ -450,5 +451,43 @@ describe('routes/market/swap', () => {
 
     expect(swapButton).toBeDisabled();
     expect(screen.queryByText('THORChain + Mayachain')).not.toBeInTheDocument();
+  });
+
+  it('shows account syncing while preparing the swap', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(accountApi.hasSwapPaymentRequest).mockResolvedValue({ success: true });
+    vi.mocked(swapApi.signSwap).mockImplementation(() => new Promise(() => {}));
+
+    render(
+      <BackButtonProvider>
+        <RatesContext.Provider
+          value={{
+            activeCurrencies: [],
+            addToActiveCurrencies: vi.fn(),
+            btcUnit: 'default',
+            defaultCurrency: 'USD',
+            removeFromActiveCurrencies: vi.fn(),
+            rotateBtcUnit: vi.fn(),
+            rotateDefaultCurrency: vi.fn(),
+            updateDefaultCurrency: vi.fn(),
+          }}>
+          <MemoryRouter>
+            <Swap accounts={[sellAccount, buyAccount]} />
+          </MemoryRouter>
+        </RatesContext.Provider>
+      </BackButtonProvider>
+    );
+
+    await user.click(await screen.findByTestId('agree-swap-terms'));
+    await user.type(await screen.findByLabelText('swapSendAmount'), '1');
+
+    expect(await screen.findByText('THORChain + Mayachain')).toBeInTheDocument();
+    const swapButton = await screen.findByRole('button', { name: 'Swap' });
+    await user.click(swapButton);
+
+    expect(await screen.findByRole('button', {
+      name: 'Syncing the account, please wait…',
+    })).toBeDisabled();
   });
 });

--- a/frontends/web/src/routes/market/swap/swap.test.tsx
+++ b/frontends/web/src/routes/market/swap/swap.test.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '../../../../__mocks__/i18n';
+import type { TAmountWithConversions } from '@/api/account';
 import type { TConfig } from '@/api/config';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -12,9 +13,6 @@ import '@/i18n/i18n';
 
 vi.mock('@/components/alert/Alert', () => ({
   alertUser: vi.fn(),
-}));
-vi.mock('@/components/dialog/firmware-upgrade-required-dialog', () => ({
-  FirmwareUpgradeRequiredDialog: () => null,
 }));
 vi.mock('@/components/layout', () => ({
   GuideWrapper: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -41,7 +39,13 @@ vi.mock('@/components/spinner/SpinnerAnimation', () => ({
   SpinnerRingAnimated: () => null,
 }));
 vi.mock('./components/swap-confirm', () => ({
-  ConfirmSwap: () => null,
+  ConfirmSwap: ({ expectedOutput }: { expectedOutput: TAmountWithConversions }) => (
+    <div data-testid="confirm-expected-output">
+      {expectedOutput.amount}
+      {' '}
+      {expectedOutput.unit}
+    </div>
+  ),
 }));
 vi.mock('./components/swap-result', () => ({
   SwapResult: () => null,
@@ -95,7 +99,6 @@ vi.mock('@/api/swap', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/api/swap')>();
   return {
     ...actual,
-    ensureSwapAccountsReady: vi.fn(),
     getSwapAccounts: vi.fn(),
     getSwapQuote: vi.fn(),
     signSwap: vi.fn(),
@@ -207,7 +210,6 @@ describe('routes/market/swap', () => {
 
     vi.mocked(accountApi.getBalance).mockResolvedValue({ success: false });
     vi.mocked(coinsApi.parseExternalBtcAmount).mockResolvedValue({ success: false, amount: '' });
-    vi.mocked(swapApi.ensureSwapAccountsReady).mockResolvedValue({ success: true });
     vi.mocked(swapApi.getSwapAccounts).mockResolvedValue({
       success: true,
       sellAccounts: [swapSellAccount],
@@ -461,8 +463,7 @@ describe('routes/market/swap', () => {
   it('shows account syncing while preparing the swap', async () => {
     const user = userEvent.setup();
 
-    vi.mocked(accountApi.hasSwapPaymentRequest).mockResolvedValue({ success: true });
-    vi.mocked(swapApi.ensureSwapAccountsReady).mockImplementation(() => new Promise(() => {}));
+    vi.mocked(swapApi.signSwap).mockImplementation(() => new Promise(() => {}));
 
     render(
       <BackButtonProvider>
@@ -495,44 +496,7 @@ describe('routes/market/swap', () => {
       name: 'Syncing the account, please wait…',
     })).toBeDisabled();
     expect(screen.getByLabelText('swapSendAmount')).toBeDisabled();
-    expect(swapApi.signSwap).not.toHaveBeenCalled();
-  });
-
-  it('keeps the form locked after account synchronization', async () => {
-    const user = userEvent.setup();
-
-    vi.mocked(accountApi.hasSwapPaymentRequest).mockResolvedValue({ success: true });
-    vi.mocked(swapApi.signSwap).mockImplementation(() => new Promise(() => {}));
-
-    render(
-      <BackButtonProvider>
-        <RatesContext.Provider
-          value={{
-            activeCurrencies: [],
-            addToActiveCurrencies: vi.fn(),
-            btcUnit: 'default',
-            defaultCurrency: 'USD',
-            removeFromActiveCurrencies: vi.fn(),
-            rotateBtcUnit: vi.fn(),
-            rotateDefaultCurrency: vi.fn(),
-            updateDefaultCurrency: vi.fn(),
-          }}>
-          <MemoryRouter>
-            <Swap accounts={[sellAccount, buyAccount]} />
-          </MemoryRouter>
-        </RatesContext.Provider>
-      </BackButtonProvider>
-    );
-
-    await user.click(await screen.findByTestId('agree-swap-terms'));
-    const sellAmountInput = await screen.findByLabelText('swapSendAmount');
-    await user.type(sellAmountInput, '1');
-    expect(await screen.findByText('THORChain + Mayachain')).toBeInTheDocument();
-
-    await user.click(await screen.findByRole('button', { name: 'Swap' }));
-
-    expect(await screen.findByRole('button', { name: 'loading…' })).toBeDisabled();
-    expect(sellAmountInput).toBeDisabled();
+    expect(swapApi.signSwap).toHaveBeenCalledTimes(1);
     expect(swapApi.signSwap).toHaveBeenCalledWith({
       buyAccountCode: 'eth-account',
       routeId: 'route-1',
@@ -541,11 +505,55 @@ describe('routes/market/swap', () => {
     });
   });
 
-  it('refreshes an aging quote after account synchronization', async () => {
+  it('uses the refreshed swap amount in the confirmation', async () => {
     const user = userEvent.setup();
-    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(1_000);
 
-    vi.mocked(accountApi.hasSwapPaymentRequest).mockResolvedValue({ success: true });
+    vi.mocked(swapApi.getSwapAccounts).mockResolvedValue({
+      success: true,
+      sellAccounts: [swapBuyAccount],
+      buyAccounts: [swapSellAccount],
+      defaultSellAccountCode: swapBuyAccount.code,
+      defaultBuyAccountCode: swapSellAccount.code,
+    });
+    vi.mocked(swapApi.getSwapQuote).mockResolvedValue({
+      success: true,
+      quote: {
+        routes: [{
+          expectedBuyAmount: '0.001',
+          providers: ['thorchain'],
+          routeId: 'route-1',
+        }],
+      },
+    });
+    vi.mocked(coinsApi.parseExternalBtcAmount)
+      .mockResolvedValueOnce({ success: true, amount: '100000' })
+      .mockResolvedValueOnce({ success: true, amount: '250000' });
+    vi.mocked(swapApi.signSwap).mockResolvedValue({
+      success: true,
+      expectedBuyAmount: '0.0025',
+      swapId: 'swap-id',
+      txInput: {
+        address: '0xrecipient',
+        amount: '1',
+        paymentRequest: null,
+        selectedUTXOs: [],
+        sendAll: 'no',
+        useHighestFee: true,
+      },
+    });
+    const ethAmount: TAmountWithConversions = {
+      amount: '1',
+      estimated: false,
+      unit: 'ETH',
+    };
+    vi.mocked(accountApi.proposeTx).mockResolvedValue({
+      success: true,
+      amount: ethAmount,
+      fee: ethAmount,
+      recipientDisplayAddress: '0xrecipient',
+      total: ethAmount,
+    });
+    vi.mocked(accountApi.sendTx).mockImplementation(() => new Promise(() => {}));
 
     render(
       <BackButtonProvider>
@@ -553,7 +561,7 @@ describe('routes/market/swap', () => {
           value={{
             activeCurrencies: [],
             addToActiveCurrencies: vi.fn(),
-            btcUnit: 'default',
+            btcUnit: 'sat',
             defaultCurrency: 'USD',
             removeFromActiveCurrencies: vi.fn(),
             rotateBtcUnit: vi.fn(),
@@ -569,13 +577,12 @@ describe('routes/market/swap', () => {
 
     await user.click(await screen.findByTestId('agree-swap-terms'));
     await user.type(await screen.findByLabelText('swapSendAmount'), '1');
-    expect(await screen.findByText('THORChain + Mayachain')).toBeInTheDocument();
+    expect(await screen.findByText('THORChain')).toBeInTheDocument();
 
-    dateNow.mockReturnValue(47_000);
     await user.click(await screen.findByRole('button', { name: 'Swap' }));
 
-    await waitFor(() => expect(swapApi.getSwapQuote).toHaveBeenCalledTimes(2));
-    expect(swapApi.signSwap).not.toHaveBeenCalled();
-    dateNow.mockRestore();
+    expect(await screen.findByTestId('confirm-expected-output')).toHaveTextContent('250000 sat');
+    expect(coinsApi.parseExternalBtcAmount).toHaveBeenLastCalledWith('0.0025');
+    expect(swapApi.signSwap).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -418,7 +418,9 @@ export const Swap = ({
         sellAmount,
       });
       if (!response.success) {
-        alertUser(response.errorMessage || t('genericError'));
+        alertUser(response.errorCode
+          ? t(`send.error.${response.errorCode}`)
+          : response.errorMessage || t('genericError'));
         return;
       }
 
@@ -659,7 +661,7 @@ export const Swap = ({
                       <SpinnerRingAnimated />
                     </span>
                   )}
-                  {isConfirmInFlight ? t('loading') : t('generic.swap')}
+                  {isConfirmInFlight ? t('account.syncing') : t('generic.swap')}
                 </span>
               </Button>
               <DesktopBackButton>

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/api/account';
 import { convertToCurrency, parseExternalBtcAmount } from '@/api/coins';
 import {
+  ensureSwapAccountsReady,
   getSwapAccounts,
   getSwapQuote,
   signSwap,
@@ -54,6 +55,8 @@ type Props = {
 };
 
 const QUOTE_DEBOUNCE_MS = 300;
+// SwapKit quotes expire after one minute. Leave enough time to create the swap after readiness.
+const QUOTE_MAX_AGE_MS = 45_000;
 const INSUFFICIENT_FUNDS_ERROR: TSwapQuoteErrorCode = 'insufficientFunds';
 const NO_ROUTES_FOUND_ERROR: TSwapQuoteErrorCode = 'noRoutesFound';
 const UNEXPECTED_ERROR: TSwapQuoteErrorCode = 'unexpectedError';
@@ -126,8 +129,11 @@ export const Swap = ({
   const [isFetchingRoutes, setIsFetchingRoutes] = useState<boolean>(false);
   const [quoteErrorCode, setQuoteErrorCode] = useState<TSwapQuoteErrorCode | undefined>();
   const [routeError, setRouteError] = useState<string | undefined>();
+  const [quoteRefreshCounter, setQuoteRefreshCounter] = useState(0);
+  const quoteUpdatedAtRef = useRef<number>();
   // Drives the button disabled/loading state for the whole confirm flow.
   const [isConfirmInFlight, setIsConfirmInFlight] = useState(false);
+  const [isWaitingForAccounts, setIsWaitingForAccounts] = useState(false);
   // Prevents double-submit before the button disabled state has re-rendered.
   const confirmInFlightRef = useRef(false);
 
@@ -203,6 +209,7 @@ export const Swap = ({
   }, [buyAccount, sellAccountCode]);
 
   const clearQuoteState = useCallback(() => {
+    quoteUpdatedAtRef.current = undefined;
     setRoutes([]);
     setSelectedRouteId(undefined);
     setExpectedOutput('');
@@ -248,6 +255,7 @@ export const Swap = ({
     const amount = Number(sellAmount);
 
     setRoutes([]);
+    quoteUpdatedAtRef.current = undefined;
     setSelectedRouteId(undefined);
     setExpectedOutput('');
     setExpectedOutputUnit(undefined);
@@ -283,6 +291,7 @@ export const Swap = ({
         const nextRoutes = response.quote?.routes ?? [];
         const validationErrorCode = response.success ? undefined : response.validationErrorCode;
         if (nextRoutes.length > 0) {
+          quoteUpdatedAtRef.current = Date.now();
           setQuoteErrorCode(response.success ? undefined : validationErrorCode ?? response.errorCode);
           setRouteError(undefined);
           setRoutes(nextRoutes);
@@ -353,6 +362,7 @@ export const Swap = ({
     buyAccountCode,
     clearQuoteState,
     resetQuoteStateWithError,
+    quoteRefreshCounter,
     sellAccount?.coinCode,
     sellAccountCode,
     sellAmount,
@@ -410,6 +420,22 @@ export const Swap = ({
 
       setResult(undefined);
       setConfirmDetails(undefined);
+
+      setIsWaitingForAccounts(true);
+      const readiness = await ensureSwapAccountsReady(buyAccountCode, sellAccountCode);
+      setIsWaitingForAccounts(false);
+      if (!readiness.success) {
+        alertUser(readiness.errorCode
+          ? t(`send.error.${readiness.errorCode}`)
+          : readiness.errorMessage || t('genericError'));
+        return;
+      }
+
+      const quoteUpdatedAt = quoteUpdatedAtRef.current;
+      if (!quoteUpdatedAt || Date.now() - quoteUpdatedAt >= QUOTE_MAX_AGE_MS) {
+        setQuoteRefreshCounter(current => current + 1);
+        return;
+      }
 
       const response = await signSwap({
         buyAccountCode,
@@ -472,6 +498,7 @@ export const Swap = ({
     } finally {
       confirmInFlightRef.current = false;
       setIsConfirmInFlight(false);
+      setIsWaitingForAccounts(false);
       setIsConfirming(false);
     }
   };
@@ -589,6 +616,7 @@ export const Swap = ({
               ) : (
                 <InputWithAccountSelector
                   accounts={sellAccounts}
+                  disabled={isConfirmInFlight}
                   id="swapSendAmount"
                   accountCode={sellAccountCode}
                   isAccountDisabled={account => isSameCoinAccount(account, buyAccount)}
@@ -610,7 +638,7 @@ export const Swap = ({
               </Message>
               <div className={style.flipContainer}>
                 <Button
-                  disabled={!canFlip}
+                  disabled={!canFlip || isConfirmInFlight}
                   transparent
                   className={style.flipAccountsButton}
                   onClick={handleFlipAccounts}
@@ -631,6 +659,7 @@ export const Swap = ({
               ) : (
                 <InputWithAccountSelector
                   accounts={buyAccounts}
+                  disabled={isConfirmInFlight}
                   id="swapGetAmount"
                   accountCode={buyAccountCode}
                   isAccountDisabled={account => isSameCoinAccount(account, sellAccount)}
@@ -643,6 +672,7 @@ export const Swap = ({
               )}
               <SwapServiceSelector
                 buyUnit={buyAccount?.coinUnit}
+                disabled={isConfirmInFlight}
                 error={routeError}
                 isLoading={isFetchingRoutes}
                 onChangeRouteId={setSelectedRouteId}
@@ -661,7 +691,9 @@ export const Swap = ({
                       <SpinnerRingAnimated />
                     </span>
                   )}
-                  {isConfirmInFlight ? t('account.syncing') : t('generic.swap')}
+                  {isConfirmInFlight
+                    ? t(isWaitingForAccounts ? 'account.syncing' : 'loading')
+                    : t('generic.swap')}
                 </span>
               </Button>
               <DesktopBackButton>

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -16,7 +16,6 @@ import {
 } from '@/api/account';
 import { convertToCurrency, parseExternalBtcAmount } from '@/api/coins';
 import {
-  ensureSwapAccountsReady,
   getSwapAccounts,
   getSwapQuote,
   signSwap,
@@ -55,8 +54,6 @@ type Props = {
 };
 
 const QUOTE_DEBOUNCE_MS = 300;
-// SwapKit quotes expire after one minute. Leave enough time to create the swap after readiness.
-const QUOTE_MAX_AGE_MS = 45_000;
 const INSUFFICIENT_FUNDS_ERROR: TSwapQuoteErrorCode = 'insufficientFunds';
 const NO_ROUTES_FOUND_ERROR: TSwapQuoteErrorCode = 'noRoutesFound';
 const UNEXPECTED_ERROR: TSwapQuoteErrorCode = 'unexpectedError';
@@ -113,7 +110,6 @@ export const Swap = ({
   // Receive
   const [buyAccountCode, setBuyAccountCode] = useState<AccountCode | undefined>();
   const [expectedOutput, setExpectedOutput] = useState<string>('');
-  const [expectedOutputUnit, setExpectedOutputUnit] = useState<CoinUnit | undefined>();
 
   // Shows the fullscreen device-confirmation step after the tx proposal is ready.
   const [isConfirming, setIsConfirming] = useState<boolean>(false);
@@ -124,16 +120,14 @@ export const Swap = ({
   }>();
   const [result, setResult] = useState<TSendTx | undefined>();
   const [canFlip, setCanFlip] = useState<boolean>(false);
+
   const [routes, setRoutes] = useState<TSwapQuoteRoute[]>([]);
   const [selectedRouteId, setSelectedRouteId] = useState<string | undefined>();
   const [isFetchingRoutes, setIsFetchingRoutes] = useState<boolean>(false);
   const [quoteErrorCode, setQuoteErrorCode] = useState<TSwapQuoteErrorCode | undefined>();
   const [routeError, setRouteError] = useState<string | undefined>();
-  const [quoteRefreshCounter, setQuoteRefreshCounter] = useState(0);
-  const quoteUpdatedAtRef = useRef<number>();
   // Drives the button disabled/loading state for the whole confirm flow.
   const [isConfirmInFlight, setIsConfirmInFlight] = useState(false);
-  const [isWaitingForAccounts, setIsWaitingForAccounts] = useState(false);
   // Prevents double-submit before the button disabled state has re-rendered.
   const confirmInFlightRef = useRef(false);
 
@@ -209,11 +203,9 @@ export const Swap = ({
   }, [buyAccount, sellAccountCode]);
 
   const clearQuoteState = useCallback(() => {
-    quoteUpdatedAtRef.current = undefined;
     setRoutes([]);
     setSelectedRouteId(undefined);
     setExpectedOutput('');
-    setExpectedOutputUnit(undefined);
     setQuoteErrorCode(undefined);
     setRouteError(undefined);
   }, []);
@@ -255,10 +247,8 @@ export const Swap = ({
     const amount = Number(sellAmount);
 
     setRoutes([]);
-    quoteUpdatedAtRef.current = undefined;
     setSelectedRouteId(undefined);
     setExpectedOutput('');
-    setExpectedOutputUnit(undefined);
 
     if (
       !sellCoinCode
@@ -291,7 +281,6 @@ export const Swap = ({
         const nextRoutes = response.quote?.routes ?? [];
         const validationErrorCode = response.success ? undefined : response.validationErrorCode;
         if (nextRoutes.length > 0) {
-          quoteUpdatedAtRef.current = Date.now();
           setQuoteErrorCode(response.success ? undefined : validationErrorCode ?? response.errorCode);
           setRouteError(undefined);
           setRoutes(nextRoutes);
@@ -362,7 +351,6 @@ export const Swap = ({
     buyAccountCode,
     clearQuoteState,
     resetQuoteStateWithError,
-    quoteRefreshCounter,
     sellAccount?.coinCode,
     sellAccountCode,
     sellAmount,
@@ -375,7 +363,6 @@ export const Swap = ({
     const updateExpectedOutput = async () => {
       if (!selectedRoute || !buyAccount) {
         setExpectedOutput('');
-        setExpectedOutputUnit(undefined);
         return;
       }
 
@@ -389,13 +376,11 @@ export const Swap = ({
         return;
       }
       setExpectedOutput(displayAmount.amount);
-      setExpectedOutputUnit(displayAmount.unit);
     };
 
     updateExpectedOutput().catch(() => {
       if (!canceled) {
         setExpectedOutput(selectedRoute?.expectedBuyAmount || '');
-        setExpectedOutputUnit(buyAccount?.coinUnit);
       }
     });
 
@@ -421,22 +406,6 @@ export const Swap = ({
       setResult(undefined);
       setConfirmDetails(undefined);
 
-      setIsWaitingForAccounts(true);
-      const readiness = await ensureSwapAccountsReady(buyAccountCode, sellAccountCode);
-      setIsWaitingForAccounts(false);
-      if (!readiness.success) {
-        alertUser(readiness.errorCode
-          ? t(`send.error.${readiness.errorCode}`)
-          : readiness.errorMessage || t('genericError'));
-        return;
-      }
-
-      const quoteUpdatedAt = quoteUpdatedAtRef.current;
-      if (!quoteUpdatedAt || Date.now() - quoteUpdatedAt >= QUOTE_MAX_AGE_MS) {
-        setQuoteRefreshCounter(current => current + 1);
-        return;
-      }
-
       const response = await signSwap({
         buyAccountCode,
         routeId: selectedRouteId,
@@ -460,6 +429,13 @@ export const Swap = ({
         return;
       }
 
+      const refreshedExpectedOutput = await getSwapDisplayAmount(
+        response.expectedBuyAmount,
+        buyAccount.coinCode,
+        buyAccount.coinUnit,
+        btcUnit,
+      );
+
       let expectedOutputConversions: TAmountWithConversions['conversions'];
       const fiatConversions = await Promise.all(
         activeCurrencies.map(async fiatUnit => {
@@ -479,9 +455,9 @@ export const Swap = ({
 
       setConfirmDetails({
         expectedOutput: {
-          amount: expectedOutput,
+          amount: refreshedExpectedOutput.amount,
           conversions: expectedOutputConversions,
-          unit: expectedOutputUnit || buyAccount.coinUnit,
+          unit: refreshedExpectedOutput.unit,
           estimated: false,
         },
         feeAmount: proposal.fee,
@@ -498,7 +474,6 @@ export const Swap = ({
     } finally {
       confirmInFlightRef.current = false;
       setIsConfirmInFlight(false);
-      setIsWaitingForAccounts(false);
       setIsConfirming(false);
     }
   };
@@ -691,9 +666,7 @@ export const Swap = ({
                       <SpinnerRingAnimated />
                     </span>
                   )}
-                  {isConfirmInFlight
-                    ? t(isWaitingForAccounts ? 'account.syncing' : 'loading')
-                    : t('generic.swap')}
+                  {isConfirmInFlight ? t('account.syncing') : t('generic.swap')}
                 </span>
               </Button>
               <DesktopBackButton>


### PR DESCRIPTION
This PR resolves the syncInProgress error pop-up that appears when you try to swap to a destination account that has not been activated yet.

To reproduce try swapping BTC to a non-activated account on mainnet, you should get the syncInProgress error. Then disable the account again via settings, switch to this branch, restart webdev and servewaller-mainnet and try again. Now it should show that the account is being activated and then the swap proceeds.