### PR TITLE
lightning: make LNURL payments idempotent

### DIFF
--- a/backend/lightning/payments.go
+++ b/backend/lightning/payments.go
@@ -670,23 +670,30 @@ func (lightning *Lightning) PreparePayment(request preparePaymentRequest) (*paym
 		if err != nil {
 			return fee, err
 		}
-		idempotencyKey := request.IdempotencyKey
-		if idempotencyKey == "" {
-			generatedKey, err := uuid.NewRandom()
-			if err != nil {
-				return nil, errp.Wrap(err, "generate idempotency key")
-			}
-			idempotencyKey = generatedKey.String()
-		}
-		fee.IdempotencyKey = idempotencyKey
-		return fee, nil
+		return paymentFeeWithIdempotencyKey(fee, request.IdempotencyKey)
 	case paymentInputTypeBolt11:
 		return lightning.prepareBolt11Payment(request.PaymentInput, request.AmountSat)
 	case paymentInputTypeLNURLPay:
-		return lightning.prepareLNURLPay(request.PaymentInput, request.AmountSat)
+		fee, err := lightning.prepareLNURLPay(request.PaymentInput, request.AmountSat)
+		if err != nil {
+			return fee, err
+		}
+		return paymentFeeWithIdempotencyKey(fee, request.IdempotencyKey)
 	default:
 		return nil, errp.New("Payment type not supported")
 	}
+}
+
+func paymentFeeWithIdempotencyKey(fee *paymentFee, idempotencyKey string) (*paymentFee, error) {
+	if idempotencyKey == "" {
+		generatedKey, err := uuid.NewRandom()
+		if err != nil {
+			return nil, errp.Wrap(err, "generate idempotency key")
+		}
+		idempotencyKey = generatedKey.String()
+	}
+	fee.IdempotencyKey = idempotencyKey
+	return fee, nil
 }
 
 func (lightning *Lightning) prepareBolt11Payment(paymentInvoice string, amountSat *uint64) (*paymentFee, error) {
@@ -856,6 +863,9 @@ func (lightning *Lightning) sendLNURLPay(request sendPaymentRequest) error {
 	if request.AmountSat == nil || *request.AmountSat == 0 {
 		return errLightningInvalidAmount
 	}
+	if request.IdempotencyKey == "" {
+		return errp.WithMessage(errLightningInvalidPaymentInput, "idempotency key missing")
+	}
 
 	lightning.log.Info("Sending LNURL-Pay payment")
 
@@ -887,6 +897,7 @@ func (lightning *Lightning) sendLNURLPay(request sendPaymentRequest) error {
 
 	_, err = lightning.sdkService.LnurlPay(breez_sdk_spark.LnurlPayRequest{
 		PrepareResponse: prepareResponse,
+		IdempotencyKey:  &request.IdempotencyKey,
 	})
 	if err != nil {
 		lightning.log.WithError(err).Error("Send LNURL-Pay failed")

--- a/backend/lightning/payments_test.go
+++ b/backend/lightning/payments_test.go
@@ -1125,7 +1125,9 @@ type testPaymentSDK struct {
 	balanceSats           uint64
 	parseInput            func(string) (breez_sdk_spark.InputType, error)
 	prepareSend           func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error)
+	prepareLnurlPay       func(breez_sdk_spark.PrepareLnurlPayRequest) (breez_sdk_spark.PrepareLnurlPayResponse, error)
 	send                  func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error)
+	lnurlPay              func(breez_sdk_spark.LnurlPayRequest) (breez_sdk_spark.LnurlPayResponse, error)
 	listUnclaimedDeposits func(breez_sdk_spark.ListUnclaimedDepositsRequest) (breez_sdk_spark.ListUnclaimedDepositsResponse, error)
 	claimDeposit          func(breez_sdk_spark.ClaimDepositRequest) (breez_sdk_spark.ClaimDepositResponse, error)
 	refundDeposit         func(breez_sdk_spark.RefundDepositRequest) (breez_sdk_spark.RefundDepositResponse, error)
@@ -1148,10 +1150,22 @@ func (sdk *testPaymentSDK) PrepareSendPayment(
 	return sdk.prepareSend(request)
 }
 
+func (sdk *testPaymentSDK) PrepareLnurlPay(
+	request breez_sdk_spark.PrepareLnurlPayRequest,
+) (breez_sdk_spark.PrepareLnurlPayResponse, error) {
+	return sdk.prepareLnurlPay(request)
+}
+
 func (sdk *testPaymentSDK) SendPayment(
 	request breez_sdk_spark.SendPaymentRequest,
 ) (breez_sdk_spark.SendPaymentResponse, error) {
 	return sdk.send(request)
+}
+
+func (sdk *testPaymentSDK) LnurlPay(
+	request breez_sdk_spark.LnurlPayRequest,
+) (breez_sdk_spark.LnurlPayResponse, error) {
+	return sdk.lnurlPay(request)
 }
 
 func (sdk *testPaymentSDK) ListUnclaimedDeposits(
@@ -1502,6 +1516,127 @@ func testStandardBitcoinPrepareResponse(amountSat uint64, feeSat uint64) breez_s
 		Amount:    new(big.Int).SetUint64(amountSat),
 		FeePolicy: breez_sdk_spark.FeePolicyFeesExcluded,
 	}
+}
+
+func testLNURLPayRequestDetails() breez_sdk_spark.LnurlPayRequestDetails {
+	return breez_sdk_spark.LnurlPayRequestDetails{
+		Callback:    "https://example.com/lnurl-pay",
+		MinSendable: 1_000,
+		MaxSendable: 1_000_000,
+		MetadataStr: `[["text/plain","Coffee"]]`,
+		Domain:      "example.com",
+		Url:         "https://example.com/.well-known/lnurlp/alice",
+	}
+}
+
+func TestPrepareLNURLPayment(t *testing.T) {
+	t.Parallel()
+
+	payRequest := testLNURLPayRequestDetails()
+	sdk := &testPaymentSDK{balanceSats: 1_000}
+	sdk.parseInput = func(input string) (breez_sdk_spark.InputType, error) {
+		require.Equal(t, "lnurl-input", input)
+		return breez_sdk_spark.InputTypeLnurlPay{Field0: payRequest}, nil
+	}
+	sdk.prepareLnurlPay = func(request breez_sdk_spark.PrepareLnurlPayRequest) (breez_sdk_spark.PrepareLnurlPayResponse, error) {
+		require.Equal(t, payRequest, request.PayRequest)
+		require.Zero(t, request.Amount.Cmp(big.NewInt(123)))
+		return breez_sdk_spark.PrepareLnurlPayResponse{AmountSats: 123, FeeSats: 7}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(123)
+
+	fee, err := lightning.PreparePayment(preparePaymentRequest{
+		Type:         paymentInputTypeLNURLPay,
+		PaymentInput: "lnurl-input",
+		AmountSat:    &amountSat,
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, fee.IdempotencyKey)
+	idempotencyKey, err := uuid.Parse(fee.IdempotencyKey)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, idempotencyKey)
+	fee.IdempotencyKey = ""
+	require.Equal(t, &paymentFee{
+		AmountSat:     123,
+		FeeSat:        7,
+		TotalDebitSat: 130,
+	}, fee)
+
+	const existingIdempotencyKey = "00000000-0000-4000-8000-000000000001"
+	fee, err = lightning.PreparePayment(preparePaymentRequest{
+		Type:           paymentInputTypeLNURLPay,
+		PaymentInput:   "lnurl-input",
+		AmountSat:      &amountSat,
+		IdempotencyKey: existingIdempotencyKey,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, existingIdempotencyKey, fee.IdempotencyKey)
+}
+
+func TestSendLNURLPayment(t *testing.T) {
+	t.Parallel()
+
+	const idempotencyKey = "00000000-0000-4000-8000-000000000001"
+	payRequest := testLNURLPayRequestDetails()
+	prepareResponse := breez_sdk_spark.PrepareLnurlPayResponse{AmountSats: 123, FeeSats: 7}
+	sdk := &testPaymentSDK{balanceSats: 1_000}
+	sdk.parseInput = func(input string) (breez_sdk_spark.InputType, error) {
+		require.Equal(t, "lnurl-input", input)
+		return breez_sdk_spark.InputTypeLnurlPay{Field0: payRequest}, nil
+	}
+	sdk.prepareLnurlPay = func(request breez_sdk_spark.PrepareLnurlPayRequest) (breez_sdk_spark.PrepareLnurlPayResponse, error) {
+		return prepareResponse, nil
+	}
+	sdk.lnurlPay = func(request breez_sdk_spark.LnurlPayRequest) (breez_sdk_spark.LnurlPayResponse, error) {
+		require.Equal(t, prepareResponse, request.PrepareResponse)
+		require.NotNil(t, request.IdempotencyKey)
+		require.Equal(t, idempotencyKey, *request.IdempotencyKey)
+		return breez_sdk_spark.LnurlPayResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(123)
+
+	err := lightning.SendPayment(sendPaymentRequest{
+		Type:           paymentInputTypeLNURLPay,
+		PaymentInput:   "lnurl-input",
+		AmountSat:      &amountSat,
+		ApprovedFeeSat: 7,
+		IdempotencyKey: idempotencyKey,
+	})
+
+	require.NoError(t, err)
+}
+
+func TestSendLNURLPaymentRequiresIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 1_000}
+	sdk.parseInput = func(string) (breez_sdk_spark.InputType, error) {
+		t.Fatal("payment input must not be parsed without an idempotency key")
+		return nil, nil
+	}
+	sdk.prepareLnurlPay = func(breez_sdk_spark.PrepareLnurlPayRequest) (breez_sdk_spark.PrepareLnurlPayResponse, error) {
+		t.Fatal("payment must not be prepared without an idempotency key")
+		return breez_sdk_spark.PrepareLnurlPayResponse{}, nil
+	}
+	sdk.lnurlPay = func(breez_sdk_spark.LnurlPayRequest) (breez_sdk_spark.LnurlPayResponse, error) {
+		t.Fatal("payment must not be sent without an idempotency key")
+		return breez_sdk_spark.LnurlPayResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+	amountSat := uint64(123)
+
+	err := lightning.SendPayment(sendPaymentRequest{
+		Type:           paymentInputTypeLNURLPay,
+		PaymentInput:   "lnurl-input",
+		AmountSat:      &amountSat,
+		ApprovedFeeSat: 7,
+	})
+
+	require.ErrorIs(t, err, errLightningInvalidPaymentInput)
 }
 
 func TestPrepareBitcoinPayment(t *testing.T) {

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -166,6 +166,7 @@ export type TSendPaymentRequest = {
   paymentInput: string;
   amountSat: number;
   approvedFeeSat: number;
+  idempotencyKey: string;
 };
 
 export type TPreparePaymentRequest = {
@@ -181,6 +182,7 @@ export type TPreparePaymentRequest = {
   type: TPaymentInputType.LNURL_PAY;
   paymentInput: string;
   amountSat: number;
+  idempotencyKey?: string;
 };
 
 export type TPreparePaymentResponse = {

--- a/frontends/web/src/routes/lightning/send/hooks/use-payment-review.ts
+++ b/frontends/web/src/routes/lightning/send/hooks/use-payment-review.ts
@@ -121,6 +121,7 @@ export const usePaymentReview = ({
         type: TPaymentInputType.LNURL_PAY,
         paymentInput: paymentDetails.details.input,
         amountSat,
+        idempotencyKey: existingIdempotencyKey,
       };
       break;
     }
@@ -214,11 +215,15 @@ export const usePaymentReview = ({
             approvedFeeSat: fees.feeSat,
           };
         case TPaymentInputType.LNURL_PAY:
+          if (fees.idempotencyKey === undefined) {
+            throw new TSdkError('idempotency key missing', TLightningErrorCode.INVALID_PAYMENT_INPUT);
+          }
           return {
             type: TPaymentInputType.LNURL_PAY,
             paymentInput: paymentDetails.details.input,
             amountSat: currentAmountSat,
             approvedFeeSat: fees.feeSat,
+            idempotencyKey: fees.idempotencyKey,
           };
         }
       })();


### PR DESCRIPTION
Generate an idempotency key while preparing an LNURL payment and return it with the fee quote. Preserve the key when refreshing the quote and require the frontend to include it when sending.

Pass the key to the Breez SDK so retries after an ambiguous response cannot execute a second payment. Cover key generation, reuse, SDK propagation, and missing-key rejection.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
