### PR TITLE
fix(lightning): handle initialization failures

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -317,8 +317,9 @@ func (backend *Backend) formattedCoinBalance(
 }
 
 // getCoinsTotalBalance returns the total balances grouped by coins.
-func (backend *Backend) coinsTotalBalance() ([]coinFormattedAmount, error) {
+func (backend *Backend) coinsTotalBalance() ([]coinFormattedAmount, []coinpkg.Code, error) {
 	coinFormattedAmounts := []coinFormattedAmount{}
+	unavailableCoinCodes := []coinpkg.Code{}
 	var sortedCoins []coinpkg.Code
 	totalCoinsBalances := make(map[coinpkg.Code]*big.Int)
 
@@ -331,12 +332,12 @@ func (backend *Backend) coinsTotalBalance() ([]coinFormattedAmount, error) {
 		}
 		err := account.Initialize()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		coinCode := account.Coin().Code()
 		b, err := account.Balance()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		amount := b.Available()
 
@@ -348,15 +349,24 @@ func (backend *Backend) coinsTotalBalance() ([]coinFormattedAmount, error) {
 		}
 	}
 
-	lightningBalance, err := backend.lightningFormattedBalance()
-	if err != nil {
-		return nil, err
+	var lightningBalance *coinFormattedAmount
+	if backend.hasLightningAccount() {
+		if !backend.lightning.Ready() {
+			unavailableCoinCodes = append(unavailableCoinCodes, coinCodeLightning)
+		} else {
+			var err error
+			lightningBalance, err = backend.lightningFormattedBalance()
+			if err != nil {
+				backend.log.WithError(err).Warn("Could not include Lightning balance in portfolio summary")
+				unavailableCoinCodes = append(unavailableCoinCodes, coinCodeLightning)
+			}
+		}
 	}
 
 	for _, coinCode := range sortedCoins {
 		coin, err := backend.Coin(coinCode)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		coinFormattedAmounts = append(coinFormattedAmounts, backend.formattedCoinBalance(
 			coinCode,
@@ -365,7 +375,7 @@ func (backend *Backend) coinsTotalBalance() ([]coinFormattedAmount, error) {
 			totalCoinsBalances[coinCode],
 		))
 	}
-	return insertLightningFormattedBalance(coinFormattedAmounts, lightningBalance), nil
+	return insertLightningFormattedBalance(coinFormattedAmounts, lightningBalance), unavailableCoinCodes, nil
 }
 
 // AmountsByCoin maps the total amount of each coin.
@@ -473,8 +483,9 @@ func (backend *Backend) convertBtcAmountToFiat(amount coinpkg.Amount, fiat strin
 
 // AccountsBalanceSummary holds the total balance for each coin and of each keystore.
 type AccountsBalanceSummary struct {
-	KeystoresBalance  map[string]KeystoreBalance `json:"keystoresBalance"`
-	CoinsTotalBalance []coinFormattedAmount      `json:"coinsTotalBalance"`
+	KeystoresBalance     map[string]KeystoreBalance `json:"keystoresBalance"`
+	CoinsTotalBalance    []coinFormattedAmount      `json:"coinsTotalBalance"`
+	UnavailableCoinCodes []coinpkg.Code             `json:"unavailableCoinCodes"`
 }
 
 // AccountsBalanceSummary returns the total balance for each coin and of each keystore.
@@ -483,14 +494,15 @@ func (backend *Backend) AccountsBalanceSummary() (*AccountsBalanceSummary, error
 	if err != nil {
 		return nil, err
 	}
-	coinsTotalBalance, err := backend.coinsTotalBalance()
+	coinsTotalBalance, unavailableCoinCodes, err := backend.coinsTotalBalance()
 	if err != nil {
 		return nil, err
 	}
 
 	return &AccountsBalanceSummary{
-		KeystoresBalance:  keystoresBalance,
-		CoinsTotalBalance: coinsTotalBalance,
+		KeystoresBalance:     keystoresBalance,
+		CoinsTotalBalance:    coinsTotalBalance,
+		UnavailableCoinCodes: unavailableCoinCodes,
 	}, nil
 }
 

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -1501,8 +1501,9 @@ func TestCoinsTotalBalance(t *testing.T) {
 	b.ratesUpdater = rates.MockRateUpdater()
 	defer b.ratesUpdater.Stop()
 
-	coinsTotalBalance, err := b.coinsTotalBalance()
+	coinsTotalBalance, unavailableCoinCodes, err := b.coinsTotalBalance()
 	require.NoError(t, err)
+	require.Empty(t, unavailableCoinCodes)
 	require.Equal(t, coinpkg.CodeBTC, coinsTotalBalance[0].CoinCode)
 	require.Equal(t, "2.00000000", coinsTotalBalance[0].FormattedAmount.Amount)
 	require.Equal(t, coinpkg.CodeLTC, coinsTotalBalance[1].CoinCode)

--- a/backend/chart.go
+++ b/backend/chart.go
@@ -31,7 +31,7 @@ func (backend *Backend) allCoinCodes() []string {
 // chartCoinCodes returns the coin codes needed to load chart rate history.
 func (backend *Backend) chartCoinCodes() []string {
 	coinCodes := backend.allCoinCodes()
-	if !backend.hasLightningAccount() || slices.Contains(coinCodes, string(coin.CodeBTC)) {
+	if !backend.lightning.Ready() || slices.Contains(coinCodes, string(coin.CodeBTC)) {
 		return coinCodes
 	}
 	// Lightning transactions require BTC coin code
@@ -71,6 +71,8 @@ type Chart struct {
 	IsUpToDate bool `json:"chartIsUpToDate"`
 	// Latest rate timestamp available among all enabled coins.
 	LastTimestamp int64 `json:"lastTimestamp"`
+	// Coins omitted from the chart and total because their balances are unavailable.
+	UnavailableCoinCodes []coin.Code `json:"unavailableCoinCodes"`
 }
 
 func (backend *Backend) addChartData(
@@ -201,6 +203,7 @@ func (backend *Backend) ChartData() (*Chart, error) {
 	// Total number of transactions across all active accounts.
 	totalNumberOfTransactions := 0
 	transactionHistoryMissing := false
+	unavailableCoinCodes := []coin.Code{}
 	for _, account := range backend.Accounts() {
 		if account.Config().Config.Inactive {
 			continue
@@ -258,46 +261,52 @@ func (backend *Backend) ChartData() (*Chart, error) {
 	}
 
 	if backend.hasLightningAccount() {
-		var err error
-		lightningBalance, err := backend.lightning.Balance()
-		if err != nil {
-			return nil, err
-		}
-		lightningBalanceAmount, err := backend.convertBtcAmountToFiat(lightningBalance.Available(), fiat)
-		if err != nil {
-			return nil, err
-		}
-		currentTotal.Add(currentTotal, lightningBalanceAmount)
-
-		lightningTxs, err := backend.lightning.Transactions()
-		if err != nil {
-			backend.log.WithError(err).WithField("coin", coinCodeLightning).Info("ChartDataMissing/list-payments")
-			chartDataMissing = true
-			transactionHistoryMissing = true
-			lightningTxs = nil
-		}
-		totalNumberOfTransactions += len(lightningTxs)
-
-		if !chartDataMissing {
-			btcCoin, err := backend.Coin(coin.CodeBTC)
-			if err != nil {
-				return nil, err
+		if !backend.lightning.Ready() {
+			unavailableCoinCodes = append(unavailableCoinCodes, coinCodeLightning)
+		} else {
+			lightningBalance, err := backend.lightning.Balance()
+			if err == nil {
+				var lightningBalanceAmount *big.Rat
+				lightningBalanceAmount, err = backend.convertBtcAmountToFiat(lightningBalance.Available(), fiat)
+				if err == nil {
+					currentTotal.Add(currentTotal, lightningBalanceAmount)
+				}
 			}
-			lightningChartDataMissing, err := backend.addTxsToChart(
-				coin.CodeBTC,
-				coinCodeLightning,
-				fiat,
-				coin.DecimalsExp(btcCoin, false),
-				lightningTxs,
-				until,
-				chartEntriesDaily,
-				chartEntriesHourly,
-			)
 			if err != nil {
-				return nil, err
-			}
-			if lightningChartDataMissing {
-				chartDataMissing = true
+				backend.log.WithError(err).Warn("Could not include Lightning balance in portfolio chart")
+				unavailableCoinCodes = append(unavailableCoinCodes, coinCodeLightning)
+			} else {
+				lightningTxs, err := backend.lightning.Transactions()
+				if err != nil {
+					backend.log.WithError(err).WithField("coin", coinCodeLightning).Info("ChartDataMissing/list-payments")
+					chartDataMissing = true
+					transactionHistoryMissing = true
+					lightningTxs = nil
+				}
+				totalNumberOfTransactions += len(lightningTxs)
+
+				if !chartDataMissing {
+					btcCoin, err := backend.Coin(coin.CodeBTC)
+					if err != nil {
+						return nil, err
+					}
+					lightningChartDataMissing, err := backend.addTxsToChart(
+						coin.CodeBTC,
+						coinCodeLightning,
+						fiat,
+						coin.DecimalsExp(btcCoin, false),
+						lightningTxs,
+						until,
+						chartEntriesDaily,
+						chartEntriesHourly,
+					)
+					if err != nil {
+						return nil, err
+					}
+					if lightningChartDataMissing {
+						chartDataMissing = true
+					}
+				}
 			}
 		}
 	}
@@ -364,13 +373,14 @@ func (backend *Backend) ChartData() (*Chart, error) {
 		formattedChartTotal = coin.FormatAsCurrency(currentTotal, fiat)
 	}
 	return &Chart{
-		DataMissing:    chartDataMissing,
-		DataDaily:      toSortedSlice(chartEntriesDaily, fiat),
-		DataHourly:     toSortedSlice(chartEntriesHourly, fiat),
-		Fiat:           fiat,
-		Total:          chartTotal,
-		FormattedTotal: formattedChartTotal,
-		IsUpToDate:     isUpToDate,
-		LastTimestamp:  lastTimestamp,
+		DataMissing:          chartDataMissing,
+		DataDaily:            toSortedSlice(chartEntriesDaily, fiat),
+		DataHourly:           toSortedSlice(chartEntriesHourly, fiat),
+		Fiat:                 fiat,
+		Total:                chartTotal,
+		FormattedTotal:       formattedChartTotal,
+		IsUpToDate:           isUpToDate,
+		LastTimestamp:        lastTimestamp,
+		UnavailableCoinCodes: unavailableCoinCodes,
 	}, nil
 }

--- a/backend/chart_test.go
+++ b/backend/chart_test.go
@@ -5,12 +5,11 @@ package backend
 import (
 	"testing"
 
-	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
 	"github.com/stretchr/testify/require"
 )
 
-func TestChartCoinCodesIncludesBitcoinForLightning(t *testing.T) {
+func TestChartCoinCodesExcludesBitcoinForUnavailableLightning(t *testing.T) {
 	b := newBackend(t, testnetDisabled, regtestDisabled)
 	defer b.Close()
 
@@ -20,6 +19,5 @@ func TestChartCoinCodesIncludesBitcoinForLightning(t *testing.T) {
 		Code:            "v0-deadbeef-ln-0",
 		Number:          0,
 	}))
-
-	require.Equal(t, []string{string(coinpkg.CodeBTC)}, b.chartCoinCodes())
+	require.Empty(t, b.chartCoinCodes())
 }

--- a/backend/lightning/connection.go
+++ b/backend/lightning/connection.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package lightning
+
+import (
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable/action"
+)
+
+// ConnectionState describes the Lightning SDK connection lifecycle.
+type ConnectionState string
+
+const (
+	// ConnectionInactive means that no Lightning account is configured.
+	ConnectionInactive ConnectionState = "inactive"
+	// ConnectionConnecting means that the SDK connection is being initialized.
+	ConnectionConnecting ConnectionState = "connecting"
+	// ConnectionReady means that the SDK connection is ready for requests.
+	ConnectionReady ConnectionState = "ready"
+	// ConnectionFailed means that SDK connection initialization failed.
+	ConnectionFailed ConnectionState = "failed"
+)
+
+// ConnectionErrorInitializationFailed is returned when the Lightning SDK could not initialize.
+const ConnectionErrorInitializationFailed = "initializationFailed"
+
+// ConnectionStatus is the current Lightning SDK connection status.
+type ConnectionStatus struct {
+	State     ConnectionState `json:"state"`
+	ErrorCode string          `json:"errorCode,omitempty"`
+}
+
+// Status returns the current Lightning SDK connection status.
+func (lightning *Lightning) Status() ConnectionStatus {
+	lightning.connectionStatusLock.RLock()
+	defer lightning.connectionStatusLock.RUnlock()
+	return lightning.connectionStatus
+}
+
+func (lightning *Lightning) setConnectionStatus(state ConnectionState, errorCode string) {
+	status := ConnectionStatus{
+		State:     state,
+		ErrorCode: errorCode,
+	}
+
+	lightning.connectionStatusLock.Lock()
+	if lightning.connectionStatus == status {
+		lightning.connectionStatusLock.Unlock()
+		return
+	}
+	lightning.connectionStatus = status
+	lightning.connectionStatusLock.Unlock()
+
+	lightning.Notify(observable.Event{
+		Subject: "lightning/status",
+		Action:  action.Replace,
+		Object:  status,
+	})
+}
+
+// Reconnect retries Lightning SDK connection initialization in the background.
+func (lightning *Lightning) Reconnect() error {
+	if lightning.Account() == nil {
+		return errp.New("Lightning account not configured")
+	}
+	if lightning.Ready() || lightning.Status().State == ConnectionConnecting {
+		return nil
+	}
+
+	lightning.setConnectionStatus(ConnectionConnecting, "")
+	go lightning.Connect()
+	return nil
+}

--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -38,6 +38,8 @@ func NewHandlers(
 	handleNoError("/address/generate", lightning.PostGenerateAddress).Methods("POST")
 	handleNoError("/address/register", lightning.PostRegisterAddress).Methods("POST")
 	handleNoError("/ready", lightning.GetReady).Methods("GET")
+	handleNoError("/reconnect", lightning.PostReconnect).Methods("POST")
+	handleNoError("/status", lightning.GetStatus).Methods("GET")
 	handleNoError("/activate", lightning.PostActivate).Methods("POST")
 	handleNoError("/deactivate", lightning.PostDeactivate).Methods("POST")
 	handleNoError("/balance", lightning.GetBalance).Methods("GET")
@@ -205,6 +207,19 @@ func (lightning *Lightning) PostRegisterAddress(r *http.Request) interface{} {
 // GetReady handles the GET request to retrieve whether the lightning SDK is ready.
 func (lightning *Lightning) GetReady(_ *http.Request) interface{} {
 	return responseDto{Success: true, Data: lightning.Ready()}
+}
+
+// GetStatus handles the GET request to retrieve the Lightning SDK connection status.
+func (lightning *Lightning) GetStatus(_ *http.Request) interface{} {
+	return responseDto{Success: true, Data: lightning.Status()}
+}
+
+// PostReconnect handles a request to retry Lightning SDK connection initialization.
+func (lightning *Lightning) PostReconnect(_ *http.Request) interface{} {
+	if err := lightning.Reconnect(); err != nil {
+		return errorResponse(err)
+	}
+	return responseDto{Success: true}
 }
 
 // PostActivate handles the POST request to activate lightning.

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -83,6 +83,10 @@ type Lightning struct {
 	ratesUpdater *rates.RateUpdater
 	btcCoin      coin.Coin
 
+	connectionLock       sync.Mutex
+	connectionStatus     ConnectionStatus
+	connectionStatusLock sync.RWMutex
+
 	// Serializes lazy lightning address registration.
 	lightningAddressLock sync.Mutex
 }
@@ -96,6 +100,10 @@ func NewLightning(config *config.Config,
 	httpClient *http.Client,
 	ratesUpdater *rates.RateUpdater,
 	btcCoin coin.Coin) *Lightning {
+	connectionState := ConnectionInactive
+	if len(config.LightningConfig().Accounts) > 0 {
+		connectionState = ConnectionConnecting
+	}
 	return &Lightning{
 		backendConfig:      config,
 		cacheDirectoryPath: cacheDirectoryPath,
@@ -108,6 +116,9 @@ func NewLightning(config *config.Config,
 		httpClient:         httpClient,
 		ratesUpdater:       ratesUpdater,
 		btcCoin:            btcCoin,
+		connectionStatus: ConnectionStatus{
+			State: connectionState,
+		},
 	}
 }
 
@@ -349,10 +360,28 @@ func accountBreezFolder(accountCode types.Code) string {
 }
 
 // connect initializes the connection configuration and calls connect to create a Breez SDK instance.
-func (lightning *Lightning) connect() error {
-	account := lightning.Account()
+func (lightning *Lightning) connect() (connectErr error) {
+	lightning.connectionLock.Lock()
+	defer lightning.connectionLock.Unlock()
 
-	if account != nil && lightning.sdkService == nil {
+	account := lightning.Account()
+	if account == nil {
+		lightning.setConnectionStatus(ConnectionInactive, "")
+		return nil
+	}
+	if lightning.sdkService != nil {
+		lightning.setConnectionStatus(ConnectionReady, "")
+		return nil
+	}
+
+	lightning.setConnectionStatus(ConnectionConnecting, "")
+	defer func() {
+		if connectErr != nil {
+			lightning.setConnectionStatus(ConnectionFailed, ConnectionErrorInitializationFailed)
+		}
+	}()
+
+	if lightning.sdkService == nil {
 		initializeLogging(lightning.log)
 
 		workingDir := path.Join(lightning.cacheDirectoryPath, accountBreezFolder(account.Code))
@@ -421,6 +450,7 @@ func (lightning *Lightning) connect() error {
 		}
 
 		lightning.sdkService = sdk
+		lightning.setConnectionStatus(ConnectionReady, "")
 		lightning.notifyReady()
 		lightning.NotifyBalanceReload()
 		if _, err := lightning.ensureLightningAddress(); err != nil {
@@ -566,6 +596,11 @@ func (lightning *Lightning) SetAccount(account *config.LightningAccountConfig) e
 		Subject: "lightning/account",
 		Action:  action.Reload,
 	})
+	if account == nil {
+		lightning.setConnectionStatus(ConnectionInactive, "")
+	} else {
+		lightning.setConnectionStatus(ConnectionConnecting, "")
+	}
 	lightning.notifyReady()
 
 	return nil

--- a/backend/lightning/lightning_test.go
+++ b/backend/lightning/lightning_test.go
@@ -158,6 +158,29 @@ func TestReady(t *testing.T) {
 	require.False(t, lightning.Ready())
 }
 
+func TestConnectionStatusFailedInitialization(t *testing.T) {
+	lightning := newTestLightning(t, &testEnvironment{
+		canEncrypt: true,
+		loadErr:    errors.New("secure storage unavailable"),
+	})
+	require.Equal(t, ConnectionStatus{State: ConnectionInactive}, lightning.Status())
+
+	require.NoError(t, lightning.SetAccount(&config.LightningAccountConfig{
+		Code: "v0-deadbeef-ln-0",
+		Seed: "v1:encrypted",
+	}))
+	require.Equal(t, ConnectionStatus{State: ConnectionConnecting}, lightning.Status())
+
+	lightning.Connect()
+	require.Equal(t, ConnectionStatus{
+		State:     ConnectionFailed,
+		ErrorCode: ConnectionErrorInitializationFailed,
+	}, lightning.Status())
+
+	require.NoError(t, lightning.SetAccount(nil))
+	require.Equal(t, ConnectionStatus{State: ConnectionInactive}, lightning.Status())
+}
+
 func TestAddressDomain(t *testing.T) {
 	require.Equal(t, "bitbox.cash", newTestLightning(t, nil).AddressDomain())
 }

--- a/backend/lightning_test.go
+++ b/backend/lightning_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/rates"
 	"github.com/stretchr/testify/require"
 )
@@ -43,6 +44,24 @@ func TestLightningFormattedBalanceWithoutAccount(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Nil(t, balance)
+}
+
+func TestPortfolioDataWithUnavailableLightning(t *testing.T) {
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	require.NoError(t, b.lightning.SetAccount(&config.LightningAccountConfig{
+		Code: "v0-deadbeef-ln-0",
+	}))
+
+	summary, err := b.AccountsBalanceSummary()
+	require.NoError(t, err)
+	require.Empty(t, summary.CoinsTotalBalance)
+	require.Equal(t, []coinpkg.Code{coinCodeLightning}, summary.UnavailableCoinCodes)
+
+	chart, err := b.ChartData()
+	require.NoError(t, err)
+	require.Equal(t, []coinpkg.Code{coinCodeLightning}, chart.UnavailableCoinCodes)
 }
 
 func TestInsertLightningFormattedBalance(t *testing.T) {

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -87,6 +87,7 @@ export type TKeystoresBalance = {
 export type TAccountsBalanceSummary = {
   keystoresBalance: TKeystoresBalance;
   coinsTotalBalance: CoinFormattedAmount[];
+  unavailableCoinCodes: CoinCode[];
 };
 
 export type TAccountsBalanceSummaryResponse = {
@@ -188,6 +189,7 @@ export type TChartData = {
   formattedChartTotal: string | null;
   chartIsUpToDate: boolean; // only valid if chartDataMissing is false
   lastTimestamp: number;
+  unavailableCoinCodes: CoinCode[];
 };
 
 export const getChartData = (): Promise<TChartDataResponse> => {

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -196,6 +196,13 @@ export type TSparkStatus = {
   status: TServiceStatus;
 };
 
+export type TLightningConnectionState = 'inactive' | 'connecting' | 'ready' | 'failed';
+
+export type TLightningConnectionStatus = {
+  state: TLightningConnectionState;
+  errorCode?: 'initializationFailed';
+};
+
 export enum TPaymentInputType {
   BITCOIN_ADDRESS = 'bitcoinAddress',
   BOLT11 = 'bolt11',
@@ -298,12 +305,20 @@ export const getLightningReady = async (): Promise<boolean> => {
   return getApiResponse<boolean>('lightning/ready', 'Error calling getLightningReady');
 };
 
+export const getLightningStatus = async (): Promise<TLightningConnectionStatus> => {
+  return getApiResponse<TLightningConnectionStatus>('lightning/status', 'Error calling getLightningStatus');
+};
+
 export const postActivate = async (): Promise<void> => {
   return postApiResponse<void, undefined>('lightning/activate', undefined, 'Error calling postActivate');
 };
 
 export const postDeactivate = async (): Promise<void> => {
   return postApiResponse<void, undefined>('lightning/deactivate', undefined, 'Error calling postDeactivate');
+};
+
+export const postReconnect = async (): Promise<void> => {
+  return postApiResponse<void, undefined>('lightning/reconnect', undefined, 'Error calling postReconnect');
 };
 
 export const getLightningBalance = async (): Promise<TLightningBalance> => {
@@ -411,6 +426,12 @@ export const subscribeLightningAddress = (cb: TSubscriptionCallback<string | nul
 
 export const subscribeLightningReady = (cb: TSubscriptionCallback<boolean>): TUnsubscribe => {
   return subscribeEndpoint('lightning/ready', cb);
+};
+
+export const subscribeLightningStatus = (
+  cb: TSubscriptionCallback<TLightningConnectionStatus>,
+): TUnsubscribe => {
+  return subscribeEndpoint('lightning/status', cb);
 };
 
 export const subscribeListPayments = (cb: TSubscriptionCallback<TLightningPayment[]>) => {

--- a/frontends/web/src/contexts/LightningContext.tsx
+++ b/frontends/web/src/contexts/LightningContext.tsx
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createContext } from 'react';
-import { TLightningAccount } from '@/api/lightning';
+import { TLightningAccount, TLightningConnectionStatus } from '@/api/lightning';
 
 type Props = {
   isLightningReady: boolean | undefined;
   lightningAccount: TLightningAccount | null | undefined;
+  lightningStatus: TLightningConnectionStatus | undefined;
 };
 
 export const LightningContext = createContext<Props>({} as Props);

--- a/frontends/web/src/contexts/LightningProvider.tsx
+++ b/frontends/web/src/contexts/LightningProvider.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode } from 'react';
 import { LightningContext } from './LightningContext';
-import { getLightningAccount, getLightningReady, subscribeLightningAccount, subscribeLightningReady } from '../api/lightning';
+import { getLightningAccount, getLightningStatus, subscribeLightningAccount, subscribeLightningStatus } from '../api/lightning';
 import { useSync } from '../hooks/api';
 import { isLightningFeatureAvailable } from '@/utils/env';
 
@@ -16,16 +16,20 @@ export const LightningProvider = ({ children }: TProps) => {
     lightningFeatureAvailable ? getLightningAccount : null,
     lightningFeatureAvailable ? subscribeLightningAccount : null,
   );
-  const isLightningReady = useSync(
-    lightningFeatureAvailable ? getLightningReady : null,
-    lightningFeatureAvailable ? subscribeLightningReady : null,
+  const lightningStatus = useSync(
+    lightningFeatureAvailable ? getLightningStatus : null,
+    lightningFeatureAvailable ? subscribeLightningStatus : null,
   );
+  const isLightningReady = lightningStatus === undefined
+    ? undefined
+    : lightningStatus.state === 'ready';
 
   return (
     <LightningContext.Provider
       value={{
         isLightningReady: lightningFeatureAvailable ? isLightningReady : false,
         lightningAccount: lightningFeatureAvailable ? lightningAccount : null,
+        lightningStatus: lightningFeatureAvailable ? lightningStatus : { state: 'inactive' },
       }}>
       {children}
     </LightningContext.Provider>

--- a/frontends/web/src/hooks/lightning.ts
+++ b/frontends/web/src/hooks/lightning.ts
@@ -4,6 +4,6 @@ import { useContext } from 'react';
 import { LightningContext } from '../contexts/LightningContext';
 
 export const useLightning = () => {
-  const { isLightningReady, lightningAccount } = useContext(LightningContext);
-  return { isLightningReady, lightningAccount };
+  const { isLightningReady, lightningAccount, lightningStatus } = useContext(LightningContext);
+  return { isLightningReady, lightningAccount, lightningStatus };
 };

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -50,6 +50,7 @@
   "accountSummary": {
     "availableBalance": "Available balance",
     "balance": "Balance",
+    "lightningUnavailable": "Lightning is unavailable. Portfolio totals currently exclude it.",
     "name": "Account name",
     "noAccount": "There are no accounts to show.",
     "portfolio": "Portfolio",
@@ -1717,6 +1718,9 @@
         "note": "Your coins will appear in your wallet once the transaction is confirmed."
       },
       "viewTransaction": "View transaction"
+    },
+    "connection": {
+      "initializationFailed": "Lightning could not be initialized. Check your connection and try again."
     },
     "deactivate": {
       "intro": {

--- a/frontends/web/src/routes/account/summary/accountssummary.test.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.test.tsx
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../../__mocks__/i18n';
+import type { ReactNode } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as accountApi from '@/api/account';
+import * as lightningApi from '@/api/lightning';
+import { AppContext } from '@/contexts/AppContext';
+import { RatesContext } from '@/contexts/RatesContext';
+import { AccountsSummary } from './accountssummary';
+
+vi.mock('@/components/guide/entry', () => ({ Entry: () => null }));
+vi.mock('@/components/guide/guide', () => ({ Guide: () => null }));
+vi.mock('@/components/banners/backup', () => ({ BackupReminder: () => null }));
+vi.mock('@/components/banners/offline-error', () => ({ OfflineError: () => null }));
+vi.mock('@/components/status/status', () => ({
+  Status: ({ children, hidden }: { children: ReactNode; hidden?: boolean }) => (
+    hidden ? null : <div role="alert">{children}</div>
+  ),
+}));
+
+const lightningHookState = vi.hoisted(() => ({
+  account: { code: 'v0-test-ln-0', num: 0, rootFingerprint: 'f23ab988' },
+  state: 'failed' as 'failed' | 'ready',
+}));
+
+vi.mock('@/hooks/lightning', () => ({
+  useLightning: () => ({
+    isLightningReady: lightningHookState.state === 'ready',
+    lightningAccount: lightningHookState.account,
+    lightningStatus: { state: lightningHookState.state },
+  }),
+}));
+vi.mock('./chart', () => ({
+  Chart: ({ data }: { data?: accountApi.TChartData }) => (
+    <div data-testid="chart-total">{data?.formattedChartTotal}</div>
+  ),
+}));
+vi.mock('./total-balance-for-all-keystores', () => ({
+  TotalBalanceForAllKeystores: ({ coinsBalances }: { coinsBalances?: accountApi.CoinFormattedAmount[] }) => (
+    <div data-testid="coin-balances">
+      {coinsBalances?.map(balance => balance.coinCode).join(',') ?? 'loading'}
+    </div>
+  ),
+}));
+vi.mock('./keystorebalance', () => ({
+  KeystoreBalance: () => null,
+}));
+
+const partialChartData: accountApi.TChartData = {
+  chartDataDaily: [],
+  chartDataHourly: [],
+  chartDataMissing: false,
+  chartFiat: 'USD',
+  chartIsUpToDate: true,
+  chartTotal: 60000,
+  formattedChartTotal: '60,000.00',
+  lastTimestamp: 0,
+  unavailableCoinCodes: ['lightning'],
+};
+
+const readyChartData: accountApi.TChartData = {
+  ...partialChartData,
+  chartTotal: 60025,
+  formattedChartTotal: '60,025.00',
+  unavailableCoinCodes: [],
+};
+
+const btcBalance: accountApi.CoinFormattedAmount = {
+  coinCode: 'btc',
+  coinName: 'Bitcoin',
+  formattedAmount: {
+    amount: '1.00000000',
+    conversions: { USD: '60000.00' },
+    estimated: false,
+    unit: 'BTC',
+  },
+};
+
+const lightningBalance: accountApi.CoinFormattedAmount = {
+  coinCode: 'lightning',
+  coinName: 'Lightning',
+  formattedAmount: {
+    amount: '2500',
+    conversions: { USD: '25.00' },
+    estimated: false,
+    unit: 'sat',
+  },
+};
+
+const btcAccount: accountApi.TAccount = {
+  active: true,
+  blockExplorerTxPrefix: 'https://example.com/tx/',
+  code: 'btc-account',
+  coinCode: 'btc',
+  coinName: 'Bitcoin',
+  coinUnit: 'BTC',
+  isToken: false,
+  keystore: {
+    connected: true,
+    lastConnected: '',
+    name: 'BitBox02',
+    rootFingerprint: 'f23ab988',
+    watchonly: false,
+  },
+  name: 'Bitcoin Account',
+};
+
+const accounts = [btcAccount];
+
+const partialBalanceSummary: accountApi.TAccountsBalanceSummary = {
+  coinsTotalBalance: [btcBalance],
+  keystoresBalance: {},
+  unavailableCoinCodes: ['lightning'],
+};
+
+const readyBalanceSummary: accountApi.TAccountsBalanceSummary = {
+  coinsTotalBalance: [btcBalance, lightningBalance],
+  keystoresBalance: {},
+  unavailableCoinCodes: [],
+};
+
+let chartDataResponse = partialChartData;
+let balanceSummaryResponse = partialBalanceSummary;
+
+const appContext = {
+  activeSidebar: false,
+  chartDisplay: 'year' as const,
+  firmwareUpdateDialogOpen: false,
+  guideExists: false,
+  guideShown: false,
+  hideAmounts: false,
+  isDevServers: false,
+  isTesting: false,
+  nativeLocale: 'en-US',
+  sessionConfig: {},
+  setActiveSidebar: vi.fn(),
+  setChartDisplay: vi.fn(),
+  setFirmwareUpdateDialogOpen: vi.fn(),
+  setGuideExists: vi.fn(),
+  setHideAmounts: vi.fn(),
+  setVendorIframeActive: vi.fn(),
+  toggleGuide: vi.fn(),
+  toggleHideAmounts: vi.fn(),
+  toggleSidebar: vi.fn(),
+  updateSessionConfig: vi.fn(),
+  vendorIframeActive: false,
+};
+
+const TestProviders = ({ children }: { children: ReactNode }) => (
+  <MemoryRouter>
+    <AppContext.Provider value={appContext}>
+      <RatesContext.Provider value={{
+        activeCurrencies: ['USD'],
+        addToActiveCurrencies: vi.fn(),
+        btcUnit: 'default',
+        defaultCurrency: 'USD',
+        removeFromActiveCurrencies: vi.fn(),
+        rotateBtcUnit: vi.fn(),
+        rotateDefaultCurrency: vi.fn(),
+        updateDefaultCurrency: vi.fn(),
+      }}>
+        {children}
+      </RatesContext.Provider>
+    </AppContext.Provider>
+  </MemoryRouter>
+);
+
+const AccountSummaryUnderTest = () => (
+  <TestProviders>
+    <AccountsSummary accounts={accounts} />
+  </TestProviders>
+);
+
+describe('AccountsSummary', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    lightningHookState.state = 'failed';
+    chartDataResponse = partialChartData;
+    balanceSummaryResponse = partialBalanceSummary;
+    vi.spyOn(accountApi, 'getChartData').mockImplementation(async () => ({
+      success: true,
+      data: chartDataResponse,
+    }));
+    vi.spyOn(accountApi, 'getAccountsBalanceSummary').mockImplementation(async () => ({
+      success: true,
+      accountsBalanceSummary: balanceSummaryResponse,
+    }));
+    vi.spyOn(accountApi, 'getStatus').mockResolvedValue({
+      disabled: true,
+      fatalError: false,
+      offlineError: null,
+      synced: false,
+    });
+    vi.spyOn(lightningApi, 'subscribeLightningBalance').mockReturnValue(vi.fn());
+  });
+
+  it('keeps available portfolio data when Lightning is unavailable', async () => {
+    render(<AccountSummaryUnderTest />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('accountSummary.lightningUnavailable');
+    });
+    expect(screen.getByTestId('chart-total')).toHaveTextContent('60,000.00');
+    expect(screen.getByTestId('coin-balances')).toHaveTextContent('btc');
+    expect(screen.getByTestId('coin-balances')).not.toHaveTextContent('lightning');
+  });
+
+  it('refreshes complete portfolio data when Lightning recovers', async () => {
+    const { rerender } = render(<AccountSummaryUnderTest />);
+
+    await screen.findByRole('alert');
+    const chartCallsBeforeRecovery = vi.mocked(accountApi.getChartData).mock.calls.length;
+    const summaryCallsBeforeRecovery = vi.mocked(accountApi.getAccountsBalanceSummary).mock.calls.length;
+
+    lightningHookState.state = 'ready';
+    chartDataResponse = readyChartData;
+    balanceSummaryResponse = readyBalanceSummary;
+    rerender(<AccountSummaryUnderTest />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      expect(screen.getByTestId('chart-total')).toHaveTextContent('60,025.00');
+      expect(screen.getByTestId('coin-balances')).toHaveTextContent('btc,lightning');
+    });
+    expect(accountApi.getChartData).toHaveBeenCalledTimes(chartCallsBeforeRecovery + 1);
+    expect(accountApi.getAccountsBalanceSummary).toHaveBeenCalledTimes(summaryCallsBeforeRecovery + 1);
+  });
+
+  it('does not show an unavailable warning when Lightning is ready', async () => {
+    lightningHookState.state = 'ready';
+    chartDataResponse = readyChartData;
+    balanceSummaryResponse = readyBalanceSummary;
+
+    render(<AccountSummaryUnderTest />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chart-total')).toHaveTextContent('60,025.00');
+      expect(screen.getByTestId('coin-balances')).toHaveTextContent('btc,lightning');
+    });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -24,6 +24,7 @@ import { RatesContext } from '@/contexts/RatesContext';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { BackupReminder } from '@/components/banners/backup';
 import { OfflineError } from '@/components/banners/offline-error';
+import { Status } from '@/components/status/status';
 import { isLightningFeatureAvailable } from '@/utils/env';
 import style from './accountssummary.module.css';
 
@@ -43,7 +44,7 @@ export const AccountsSummary = ({
   const mounted = useMountedRef();
   const { hideAmounts } = useContext(AppContext);
   const { defaultCurrency } = useContext(RatesContext);
-  const { lightningAccount } = useLightning();
+  const { lightningAccount, lightningStatus } = useLightning();
 
   const accountsByKeystore = getAccountsByKeystore(accounts);
   const hasActiveBitcoinAccount = accounts.some(account => account.active && isBitcoinOnly(account.coinCode));
@@ -64,6 +65,9 @@ export const AccountsSummary = ({
   const coinsTotalBalance = accountsBalanceSummary?.coinsTotalBalance.filter(balance => (
     balance.coinCode !== 'lightning' || isLightningFeatureAvailable()
   ));
+  const lightningUnavailable = chartData?.unavailableCoinCodes.includes('lightning')
+    || accountsBalanceSummary?.unavailableCoinCodes.includes('lightning')
+    || false;
 
   const getChartData = useCallback(async () => {
     // replace previous timer if present
@@ -159,7 +163,7 @@ export const AccountsSummary = ({
     // & whenever any of the dependencies change.
     getChartData();
     getAccountsBalanceSummary();
-  }, [getChartData, getAccountsBalanceSummary, defaultCurrency, lightningAccount]);
+  }, [getChartData, getAccountsBalanceSummary, defaultCurrency, lightningAccount, lightningStatus?.state]);
 
   useEffect(() => {
     return () => {
@@ -186,6 +190,13 @@ export const AccountsSummary = ({
         <Main>
           <ContentWrapper>
             <OfflineError error={offlineError} />
+            <Status
+              dismissibleKey=""
+              hidden={!lightningUnavailable}
+              type="warning"
+            >
+              {t('accountSummary.lightningUnavailable')}
+            </Status>
             {accountsByKeystore.map(({ keystore }) => (
               <BackupReminder
                 key={keystore.rootFingerprint}

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -34,6 +34,7 @@ const defaultData: Readonly<TChartData> = {
   formattedChartTotal: null,
   chartIsUpToDate: false,
   lastTimestamp: 0,
+  unavailableCoinCodes: [],
 };
 
 type FormattedData = {

--- a/frontends/web/src/routes/account/summary/total-balance-for-all-keystores.test.tsx
+++ b/frontends/web/src/routes/account/summary/total-balance-for-all-keystores.test.tsx
@@ -37,6 +37,7 @@ const chartData = (chartFiat: Fiat): TChartData => ({
   formattedChartTotal: '1',
   chartIsUpToDate: true,
   lastTimestamp: 0,
+  unavailableCoinCodes: [],
 });
 
 const btcBalance: CoinFormattedAmount = {

--- a/frontends/web/src/routes/lightning/lightning.module.css
+++ b/frontends/web/src/routes/lightning/lightning.module.css
@@ -2,6 +2,25 @@
     animation: fade-in 200ms ease-out;
 }
 
+.connectionState {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-half);
+    justify-content: center;
+    min-height: 200px;
+    text-align: center;
+}
+
+.connectionState img {
+    height: 36px;
+    width: 36px;
+}
+
+.connectionState p {
+    margin: 0;
+}
+
 @keyframes fade-in {
     from {
         opacity: 0;

--- a/frontends/web/src/routes/lightning/lightning.test.tsx
+++ b/frontends/web/src/routes/lightning/lightning.test.tsx
@@ -21,6 +21,7 @@ type TLightningState = {
     num: number;
     rootFingerprint: string;
   } | null | undefined;
+  lightningStatus: lightningApi.TLightningConnectionStatus | undefined;
 };
 
 const useLightningMock = vi.hoisted(() => vi.fn<() => TLightningState>());
@@ -101,12 +102,14 @@ describe('Lightning funding limit', () => {
     useLightningMock.mockReturnValue({
       isLightningReady: true,
       lightningAccount: { code: 'v0-test-ln-0', num: 0, rootFingerprint: 'f23ab988' },
+      lightningStatus: { state: 'ready' },
     });
     vi.spyOn(devicesApi, 'getDeviceList').mockResolvedValue({});
     vi.spyOn(lightningApi, 'getBlockExplorerTxPrefix').mockResolvedValue('https://example.com/tx/');
     vi.spyOn(lightningApi, 'getLightningBalance').mockResolvedValue(balance);
     vi.spyOn(lightningApi, 'getListPayments').mockResolvedValue([]);
     vi.spyOn(lightningApi, 'getSparkStatus').mockResolvedValue({ status: 'operational' });
+    vi.spyOn(lightningApi, 'postReconnect').mockResolvedValue();
     vi.spyOn(lightningApi, 'subscribeLightningBalance').mockReturnValue(vi.fn());
     vi.spyOn(lightningApi, 'subscribeListPayments').mockReturnValue(vi.fn());
   });
@@ -126,6 +129,7 @@ describe('Lightning funding limit', () => {
     useLightningMock.mockReturnValue({
       isLightningReady: undefined,
       lightningAccount: undefined,
+      lightningStatus: undefined,
     });
     const pendingRequest = new Promise<never>(() => {});
     vi.mocked(lightningApi.getBlockExplorerTxPrefix).mockReturnValue(pendingRequest);
@@ -172,5 +176,19 @@ describe('Lightning funding limit', () => {
 
     expect(screen.getByText('lightning.initializing')).toBeInTheDocument();
     expect(globalBannersElement.parentElement).toBe(container.querySelector('main'));
+  });
+
+  it('shows a retry action when Lightning initialization failed', async () => {
+    useLightningMock.mockReturnValue({
+      isLightningReady: false,
+      lightningAccount: { code: 'v0-test-ln-0', num: 0, rootFingerprint: 'f23ab988' },
+      lightningStatus: { state: 'failed', errorCode: 'initializationFailed' },
+    });
+
+    renderLightning();
+
+    expect(screen.getByText('lightning.connection.initializationFailed')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'generic.retry' }));
+    await waitFor(() => expect(lightningApi.postReconnect).toHaveBeenCalledOnce());
   });
 });

--- a/frontends/web/src/routes/lightning/lightning.tsx
+++ b/frontends/web/src/routes/lightning/lightning.tsx
@@ -9,6 +9,7 @@ import {
   getBlockExplorerTxPrefix,
   getLightningBalance,
   getListPayments,
+  postReconnect,
   subscribeLightningBalance,
   subscribeListPayments,
   getSparkStatus,
@@ -18,7 +19,7 @@ import { Balance } from '../../components/balance/balance';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { View, ViewContent, ViewHeader } from '../../components/view/view';
 import { GuideWrapper, GuidedContent, Header, Main } from '../../components/layout';
-import { Spinner } from '../../components/spinner/Spinner';
+import { SpinnerRingAnimated } from '../../components/spinner/SpinnerAnimation';
 import { ActionButtons } from './components/action-buttons';
 import { LightningGuide } from './guide';
 import { LightningTorProxyWarning } from '@/components/banners/lightning-tor-proxy-warning';
@@ -29,7 +30,7 @@ import { RatesContext } from '@/contexts/RatesContext';
 import { useLoad, useSync } from '@/hooks/api';
 import { useMountedRef } from '@/hooks/mount';
 import { useLightning } from '@/hooks/lightning';
-import { Link } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import {
   formatExcessLightningFundingLimit,
   formatLightningFundingLimit,
@@ -290,14 +291,16 @@ const LightningInner = ({
   );
 };
 
-export const Lightning = () => {
+type TLightningReadyProps = {
+  statusBanners: ReactNode;
+};
+
+const LightningReady = ({ statusBanners }: TLightningReadyProps) => {
   const { t } = useTranslation();
   const { btcUnit } = useContext(RatesContext);
   const { isLightningReady, lightningAccount } = useLightning();
   const balance = useSync(getLightningBalance, subscribeLightningBalance);
-  const [syncedAddressesCount] = useState<number>();
   const [payments, setPayments] = useState<TLightningPayment[]>();
-  const [sparkStatus, setSparkStatus] = useState<TSparkStatus>();
   const [error, setError] = useState<string>();
   const mounted = useMountedRef();
   const blockExplorerTxPrefix = useLoad(getBlockExplorerTxPrefix);
@@ -329,6 +332,61 @@ export const Lightning = () => {
     return subscribeListPayments(onStateChange);
   }, [btcUnit, isLightningReady, lightningAccount, onStateChange]);
 
+  const hasDataLoaded = balance !== undefined && payments !== undefined;
+
+  if (error) {
+    return (
+      <GuideWrapper>
+        <GuidedContent>
+          <Main>
+            <ContentWrapper>
+              {statusBanners}
+            </ContentWrapper>
+            <View textCenter verticallyCentered>
+              <ViewHeader title={t('unknownError', { errorMessage: error })} />
+            </View>
+          </Main>
+        </GuidedContent>
+        <LightningGuide />
+      </GuideWrapper>
+    );
+  }
+  const canSend = balance && balance.hasAvailable;
+
+  if (!hasDataLoaded) {
+    return (
+      <LightningPageLayout
+        accountDataLoaded={false}
+        balance={balance}
+        canSend={canSend}
+        statusBanners={statusBanners}
+      >
+        <TransactionHistorySkeleton />
+      </LightningPageLayout>
+    );
+  }
+
+  return (
+    <LightningPageLayout
+      accountDataLoaded
+      balance={balance}
+      canSend={canSend}
+      statusBanners={statusBanners}
+    >
+      <LightningInner
+        explorerURL={blockExplorerTxPrefix}
+        payments={payments}
+      />
+    </LightningPageLayout>
+  );
+};
+
+export const Lightning = () => {
+  const { t } = useTranslation();
+  const { lightningAccount, lightningStatus } = useLightning();
+  const [sparkStatus, setSparkStatus] = useState<TSparkStatus>();
+  const mounted = useMountedRef();
+
   const loadSparkStatus = useCallback(async () => {
     try {
       const status = await getSparkStatus();
@@ -351,8 +409,6 @@ export const Lightning = () => {
     return () => window.clearInterval(interval);
   }, [loadSparkStatus]);
 
-  const hasDataLoaded = balance !== undefined && payments !== undefined;
-
   const statusBanners = (
     <>
       <LightningTorProxyWarning dismissible />
@@ -370,77 +426,51 @@ export const Lightning = () => {
     </>
   );
 
-  if (error) {
+  if (lightningAccount === undefined || lightningStatus === undefined) {
     return (
-      <GuideWrapper>
-        <GuidedContent>
-          <Main>
-            <ContentWrapper>
-              {statusBanners}
-            </ContentWrapper>
-            <View textCenter verticallyCentered>
-              <ViewHeader title={t('unknownError', { errorMessage: error })} />
-            </View>
-          </Main>
-        </GuidedContent>
-        <LightningGuide />
-      </GuideWrapper>
-    );
-  }
-  if (
-    lightningAccount === undefined
-    || isLightningReady === undefined
-    || (lightningAccount && !isLightningReady)
-  ) {
-    return (
-      <LightningPageLayout
-        accountDataLoaded={false}
-        statusBanners={statusBanners}
-      >
-        <Spinner text={t('lightning.initializing')} />
+      <LightningPageLayout accountDataLoaded={false} statusBanners={statusBanners}>
+        <div className={style.connectionState}>
+          <SpinnerRingAnimated />
+          <p>{t('lightning.initializing')}</p>
+        </div>
       </LightningPageLayout>
     );
   }
 
-  const canSend = balance && balance.hasAvailable;
+  if (lightningAccount === null) {
+    return <Navigate replace to="/lightning/activate" />;
+  }
 
-  const initializingSpinnerText =
-    syncedAddressesCount !== undefined && syncedAddressesCount > 1
-      ? '\n' +
-        t('account.syncedAddressesCount', {
-          count: syncedAddressesCount.toString(),
-          defaultValue: 0
-        } as any)
-      : '';
-
-  if (!hasDataLoaded) {
+  if (lightningAccount && lightningStatus.state === 'failed') {
+    const reconnect = async () => {
+      try {
+        await postReconnect();
+      } catch (err) {
+        console.error(err);
+      }
+    };
     return (
-      <LightningPageLayout
-        accountDataLoaded={false}
-        balance={balance}
-        canSend={canSend}
-        statusBanners={statusBanners}
-      >
-        {initializingSpinnerText ? (
-          <Spinner text={initializingSpinnerText} />
-        ) : (
-          <TransactionHistorySkeleton />
-        )}
+      <LightningPageLayout accountDataLoaded={false} statusBanners={statusBanners}>
+        <div className={style.connectionState}>
+          <p>{t('lightning.connection.initializationFailed')}</p>
+          <Button primary onClick={reconnect}>
+            {t('generic.retry')}
+          </Button>
+        </div>
       </LightningPageLayout>
     );
   }
 
-  return (
-    <LightningPageLayout
-      accountDataLoaded
-      balance={balance}
-      canSend={canSend}
-      statusBanners={statusBanners}
-    >
-      <LightningInner
-        explorerURL={blockExplorerTxPrefix}
-        payments={payments}
-      />
-    </LightningPageLayout>
-  );
+  if (lightningAccount && lightningStatus.state !== 'ready') {
+    return (
+      <LightningPageLayout accountDataLoaded={false} statusBanners={statusBanners}>
+        <div className={style.connectionState}>
+          <SpinnerRingAnimated />
+          <p>{t('lightning.initializing')}</p>
+        </div>
+      </LightningPageLayout>
+    );
+  }
+
+  return <LightningReady statusBanners={statusBanners} />;
 };


### PR DESCRIPTION
1. Expose connection status and retry support so failed startup cannot leave Lightning and portfolio views loading forever.

2. Return partial portfolio data when Lightning is unavailable and

3. Keep the mobile bottom navigation visible during Lightning initialization failures.