### PR TITLE
eth: simplify and harden ERC-681 parsing

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -41,7 +41,6 @@ import (
 )
 
 func isMixedCase(s string) bool {
-	s = strings.TrimPrefix(strings.TrimPrefix(s, "0x"), "0X")
 	return strings.ToLower(s) != s && strings.ToUpper(s) != s
 }
 
@@ -50,8 +49,9 @@ func IsValidEthAddress(addr string) bool {
 	if !ethcommon.IsHexAddress(addr) {
 		return false
 	}
+	unprefixedAddr := strings.TrimPrefix(strings.TrimPrefix(addr, "0x"), "0X")
 	// Validate checksum if the address is mixed case, see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
-	if isMixedCase(addr) && addr != ethcommon.HexToAddress(addr).Hex() {
+	if isMixedCase(unprefixedAddr) && "0x"+unprefixedAddr != ethcommon.HexToAddress(addr).Hex() {
 		return false
 	}
 	return true
@@ -550,10 +550,8 @@ func (account *Account) newTx(args *accounts.TxProposalArgs) (*TxProposal, error
 		}
 		value = parsedAmount.BigInt()
 	}
-	if account.coin.erc20Token != nil {
-		if value.BitLen() > 256 {
-			return nil, errp.WithStack(errors.ErrInvalidAmount)
-		}
+	if account.coin.erc20Token != nil && value.BitLen() > 256 {
+		return nil, errp.WithStack(errors.ErrInvalidAmount)
 	}
 
 	var message ethereum.CallMsg

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -202,6 +202,17 @@ func TestTxProposal(t *testing.T) {
 	})
 }
 
+func TestIsValidEthAddress(t *testing.T) {
+	for _, address := range []string{
+		"0xa29163852021BF4C139D03Dff59ae763AC73e84e",
+		"0Xa29163852021BF4C139D03Dff59ae763AC73e84e",
+		"a29163852021BF4C139D03Dff59ae763AC73e84e",
+	} {
+		require.True(t, IsValidEthAddress(address), address)
+	}
+	require.False(t, IsValidEthAddress("0xA29163852021BF4C139D03Dff59ae763AC73e84e"))
+}
+
 func TestERC20TxProposalRejectsAmountOverflow(t *testing.T) {
 	acct := newAccount(t)
 	defer acct.Close()

--- a/backend/coins/eth/coin.go
+++ b/backend/coins/eth/coin.go
@@ -146,8 +146,10 @@ func (coin *Coin) unitFactor(isFee bool) *big.Int {
 // FormatAmount implements coin.Coin.
 func (coin *Coin) FormatAmount(amount coinpkg.Amount, isFee bool) string {
 	factor := coin.unitFactor(isFee)
-	s := new(big.Rat).SetFrac(amount.BigInt(), factor).FloatString(18)
-	s = strings.TrimRight(strings.TrimRight(s, "0"), ".")
+	s := new(big.Rat).SetFrac(amount.BigInt(), factor).FloatString(int(coin.Decimals(isFee)))
+	if strings.ContainsRune(s, '.') {
+		s = strings.TrimRight(strings.TrimRight(s, "0"), ".")
+	}
 	// For USDC/USDT, display 2 decimals when there's only 1
 	if coin.unit == "USDC" || coin.unit == "USDT" {
 		parts := strings.Split(s, ".")

--- a/backend/coins/eth/coin_test.go
+++ b/backend/coins/eth/coin_test.go
@@ -107,6 +107,14 @@ func (s *testSuite) TestFormatAmount() {
 		"0.123456789012345678",
 		s.ERC20Coin.FormatAmount(coin.NewAmountFromInt64(123456789012345678), true),
 	)
+	s.ERC20Coin.erc20Token = erc20.NewToken("0x0000000000000000000000000000000000000001", 0)
+	s.Require().Equal("0", s.ERC20Coin.FormatAmount(coin.NewAmountFromInt64(0), false))
+	s.Require().Equal("10", s.ERC20Coin.FormatAmount(coin.NewAmountFromInt64(10), false))
+	s.ERC20Coin.erc20Token = erc20.NewToken("0x0000000000000000000000000000000000000001", 24)
+	s.Require().Equal(
+		"0.000000000000000000000001",
+		s.ERC20Coin.FormatAmount(coin.NewAmountFromInt64(1), false),
+	)
 
 	stablecoinTests := []struct {
 		amount   int64

--- a/backend/coins/eth/payment_request.go
+++ b/backend/coins/eth/payment_request.go
@@ -147,12 +147,16 @@ func parsePaymentRequestAtomicAmount(value string) (coinpkg.Amount, bool) {
 		return coinpkg.NewAmountFromInt64(0), true
 	}
 	trailingZeros := exponent - uint64(len(fraction))
-	// Bound the exponent before passing the untrusted value to the amount parser. A non-zero
-	// uint256 cannot have more than 77 trailing decimal zeros.
-	if trailingZeros > 77 {
+	// Bound the input before passing the untrusted value to the amount parser. A non-zero uint256
+	// has at most 78 decimal digits and cannot have more than 77 trailing decimal zeros.
+	if trailingZeros > 77 || len(significantDigits) > 78-int(trailingZeros) {
 		return coinpkg.Amount{}, false
 	}
-	atomicAmount, err := coinpkg.NewAmountFromString(value, big.NewInt(1))
+	boundedAmountString := significantDigits
+	if trailingZeros > 0 {
+		boundedAmountString += "e" + strconv.FormatUint(trailingZeros, 10)
+	}
+	atomicAmount, err := coinpkg.NewAmountFromString(boundedAmountString, big.NewInt(1))
 	if err != nil || atomicAmount.BigInt().BitLen() > 256 {
 		return coinpkg.Amount{}, false
 	}

--- a/backend/coins/eth/payment_request.go
+++ b/backend/coins/eth/payment_request.go
@@ -9,13 +9,15 @@ import (
 	"strconv"
 	"strings"
 
+	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/ethereum/go-ethereum/common"
 )
 
 var (
 	errInvalidPaymentRequest = errp.New("invalid Ethereum payment request")
-	// ERC-681 (EIP-681) URL grammar: https://eips.ethereum.org/EIPS/eip-681
+	// Supported hexadecimal-address subset of the ERC-681 (EIP-681) URL grammar:
+	// https://eips.ethereum.org/EIPS/eip-681
 	paymentRequestTargetRE = regexp.MustCompile(`^(?:pay-)?(0x[0-9a-fA-F]{40})(?:@(\d+))?$`)
 	paymentRequestAmountRE = regexp.MustCompile(`^(\d+)(?:\.(\d+))?(?:[eE](\d+))?$`)
 )
@@ -30,7 +32,7 @@ type PaymentRequest struct {
 	Amount    string
 }
 
-// ParsePaymentRequest parses an ERC-681 payment request for this coin.
+// ParsePaymentRequest parses a supported native or ERC20 ERC-681 payment request for this coin.
 func (coin *Coin) ParsePaymentRequest(input string) (*PaymentRequest, error) {
 	parsed, err := url.Parse(strings.TrimSpace(input))
 	if err != nil || !strings.EqualFold(parsed.Scheme, "ethereum") || parsed.Fragment != "" || parsed.Opaque == "" {
@@ -79,7 +81,7 @@ func (coin *Coin) ParsePaymentRequest(input string) (*PaymentRequest, error) {
 	if coin.erc20Token != nil {
 		return nil, ErrPaymentRequestAccountMismatch
 	}
-	request.Amount = formatPaymentRequestAmount(atomicAmount, coin.Decimals(false))
+	request.Amount = coin.FormatAmount(atomicAmount, false)
 	return request, nil
 }
 
@@ -109,7 +111,7 @@ func (coin *Coin) parseERC20Transfer(target string, parameters url.Values) (*Pay
 	if !ok {
 		return nil, errInvalidPaymentRequest
 	}
-	request.Amount = formatPaymentRequestAmount(atomicAmount, coin.Decimals(false))
+	request.Amount = coin.FormatAmount(atomicAmount, false)
 	return request, nil
 }
 
@@ -121,10 +123,11 @@ func normalizeNumber(number string) string {
 	return normalized
 }
 
-func parsePaymentRequestAtomicAmount(value string) (*big.Int, bool) {
+func parsePaymentRequestAtomicAmount(value string) (coinpkg.Amount, bool) {
+	// The generic amount parser accepts more than ERC-681's decimal syntax, so constrain it first.
 	match := paymentRequestAmountRE.FindStringSubmatch(value)
 	if match == nil {
-		return nil, false
+		return coinpkg.Amount{}, false
 	}
 	fraction := match[2]
 	exponent := uint64(0)
@@ -132,43 +135,26 @@ func parsePaymentRequestAtomicAmount(value string) (*big.Int, bool) {
 		var err error
 		exponent, err = strconv.ParseUint(match[3], 10, 64)
 		if err != nil {
-			return nil, false
+			return coinpkg.Amount{}, false
 		}
 	}
 	if exponent < uint64(len(fraction)) {
-		return nil, false
+		return coinpkg.Amount{}, false
 	}
 
 	significantDigits := strings.TrimLeft(match[1]+fraction, "0")
 	if significantDigits == "" {
-		return new(big.Int), true
+		return coinpkg.NewAmountFromInt64(0), true
 	}
 	trailingZeros := exponent - uint64(len(fraction))
-	if trailingZeros > 78 || len(significantDigits) > 78-int(trailingZeros) {
-		return nil, false
+	// Bound the exponent before passing the untrusted value to the amount parser. A non-zero
+	// uint256 cannot have more than 77 trailing decimal zeros.
+	if trailingZeros > 77 {
+		return coinpkg.Amount{}, false
 	}
-	atomicAmount, ok := new(big.Int).SetString(
-		significantDigits+strings.Repeat("0", int(trailingZeros)),
-		10,
-	)
-	if !ok || atomicAmount.BitLen() > 256 {
-		return nil, false
+	atomicAmount, err := coinpkg.NewAmountFromString(value, big.NewInt(1))
+	if err != nil || atomicAmount.BigInt().BitLen() > 256 {
+		return coinpkg.Amount{}, false
 	}
 	return atomicAmount, true
-}
-
-func formatPaymentRequestAmount(atomicAmount *big.Int, decimals uint) string {
-	amount := atomicAmount.String()
-	if decimals == 0 {
-		return amount
-	}
-	if uint(len(amount)) <= decimals {
-		amount = strings.Repeat("0", int(decimals)-len(amount)+1) + amount
-	}
-	split := len(amount) - int(decimals)
-	fraction := strings.TrimRight(amount[split:], "0")
-	if fraction == "" {
-		return amount[:split]
-	}
-	return amount[:split] + "." + fraction
 }

--- a/backend/coins/eth/payment_request_test.go
+++ b/backend/coins/eth/payment_request_test.go
@@ -3,6 +3,7 @@
 package eth
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
@@ -71,6 +72,22 @@ func TestParsePaymentRequestUint256Bounds(t *testing.T) {
 	)
 	require.ErrorIs(t, err, errInvalidPaymentRequest)
 	require.Nil(t, request)
+}
+
+func TestParsePaymentRequestAtomicAmount(t *testing.T) {
+	for value, expected := range map[string]string{
+		"0e18446744073709551615": "0",
+		"0.0001e81":              "1" + strings.Repeat("0", 77),
+		"1e77":                   "1" + strings.Repeat("0", 77),
+	} {
+		amount, ok := parsePaymentRequestAtomicAmount(value)
+		require.True(t, ok, value)
+		require.Equal(t, expected, amount.BigInt().String(), value)
+	}
+	for _, value := range []string{"1e78", "1.20e1"} {
+		_, ok := parsePaymentRequestAtomicAmount(value)
+		require.False(t, ok, value)
+	}
 }
 
 func TestParsePaymentRequestERC20Transfer(t *testing.T) {

--- a/backend/coins/eth/payment_request_test.go
+++ b/backend/coins/eth/payment_request_test.go
@@ -84,7 +84,11 @@ func TestParsePaymentRequestAtomicAmount(t *testing.T) {
 		require.True(t, ok, value)
 		require.Equal(t, expected, amount.BigInt().String(), value)
 	}
-	for _, value := range []string{"1e78", "1.20e1"} {
+	for _, value := range []string{
+		"1e78",
+		"1.20e1",
+		strings.Repeat("9", 79),
+	} {
 		_, ok := parsePaymentRequestAtomicAmount(value)
 		require.False(t, ok, value)
 	}

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -2213,7 +2213,7 @@
       "invalidAddress": "invalid address",
       "invalidAmount": "invalid amount",
       "invalidData": "invalid data",
-      "paymentRequestAccountMismatch": "This payment request is for a different asset. Open the matching account and try again.",
+      "paymentRequestAccountMismatch": "This payment request is for a different network or asset. Open the matching account and try again.",
       "syncInProgress": "The account is still syncing. Please wait until syncing is complete and try again."
     },
     "fee": {


### PR DESCRIPTION
Follow-up to #4347.

## Summary

- replace manual scientific-notation expansion with the shared exact amount parser
- reject impossible exponents and mantissas before invoking the generic parser
- reuse the canonical coin formatter and make it honor each token decimal count
- normalize address prefixes before mixed-case checksum validation
- clarify the supported ERC-681 subset and network-or-asset mismatch message
- add coverage for amount boundaries, unusual decimal counts, and address prefixes

The formatter generalization is kept in a separate commit.

## Validation

- go test -mod=vendor ./...
- make weblint
- git diff --check