### PR TITLE
frontend: add safety margin on mobile full screen confirmation

### DIFF
--- a/frontends/web/src/components/view/view.module.css
+++ b/frontends/web/src/components/view/view.module.css
@@ -75,6 +75,10 @@
     text-align: left;
 }
 @media (max-width: 768px) {
+    .fullscreen.withMobileSafetyMargin {
+        padding-left: calc(var(--space-quarter) + env(safe-area-inset-left, 0px));
+        padding-right: calc(var(--space-quarter) + env(safe-area-inset-right, 0px));
+    }
     .inner {
         flex-grow: 1;
         display: flex;

--- a/frontends/web/src/components/view/view.tsx
+++ b/frontends/web/src/components/view/view.tsx
@@ -21,6 +21,7 @@ type TViewProps = {
   verticallyCentered?: boolean;
   width?: string;
   withBottomBar?: boolean;
+  withMobileSafetyMargin?: boolean;
 };
 
 /**
@@ -35,6 +36,7 @@ type TViewProps = {
  * @param verticallyCentered centers all text content in the view, has no effect in dialog mode
  * @param width can be used to overwrite the default width of the inner area
  * @param withBottomBar enables a footer with some logo and language switch
+ * @param withMobileSafetyMargin adds a small horizontal inset on mobile
  */
 export const View = ({
   dialog = false,
@@ -48,6 +50,7 @@ export const View = ({
   verticallyCentered = false,
   width,
   withBottomBar,
+  withMobileSafetyMargin = false,
 }: TViewProps) => {
   const { isDarkMode } = useDarkmode();
   const containerClasses = `
@@ -55,6 +58,7 @@ export const View = ({
     ${scrollableContent && style.scrollableContent || ''}
     ${verticallyCentered && style.verticallyCentered || ''}
     ${dialog && style.dialog || ''}
+    ${withMobileSafetyMargin && style.withMobileSafetyMargin || ''}
   `;
   let classNames = style.inner;
   if (fitContent || scrollableContent) {

--- a/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
@@ -78,7 +78,7 @@ export const ConfirmSend = ({
   }
 
   return (
-    <View fullscreen width="840px">
+    <View fullscreen width="840px" withMobileSafetyMargin>
       <UseDisableBackButton />
       <ViewHeader title={<div className={style.title}>{t('send.confirm.title')}</div>} />
       <ViewContent>

--- a/frontends/web/src/routes/account/sign-message/sign-message-views.tsx
+++ b/frontends/web/src/routes/account/sign-message/sign-message-views.tsx
@@ -156,7 +156,7 @@ export const SignMessageConfirmView = ({ controller }: TProps) => {
   }
 
   return (
-    <View fullscreen>
+    <View fullscreen withMobileSafetyMargin>
       <UseDisableBackButton />
       <ViewHeader title={<div className={style.confirmViewTitle}>{t('signMessage.signMessage')}</div>} />
       <ViewContent>

--- a/frontends/web/src/routes/device/bitbox02/bip85.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bip85.tsx
@@ -196,7 +196,8 @@ export const Bip85 = ({
         key="bip85-progress"
         fullscreen
         textCenter
-        verticallyCentered>
+        verticallyCentered
+        withMobileSafetyMargin>
         <UseDisableBackButton />
         <ViewHeader title={t('deviceSettings.expert.bip85.title')} />
         <ViewContent minHeight="280px">

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -93,7 +93,8 @@ export const Passphrase = ({ deviceID }: TProps) => {
           fullscreen
           minHeight={CONTENT_MIN_HEIGHT}
           textCenter
-          verticallyCentered>
+          verticallyCentered
+          withMobileSafetyMargin>
           <ViewHeader
             title={t(isEnabled
               ? 'passphrase.progressDisable.title'

--- a/frontends/web/src/routes/device/bitbox02/recovery-words.tsx
+++ b/frontends/web/src/routes/device/bitbox02/recovery-words.tsx
@@ -45,7 +45,8 @@ export const RecoveryWords = ({ deviceID }: TProps) => {
           key="progress"
           fullscreen
           minHeight={CONTENT_MIN_HEIGHT}
-          verticallyCentered>
+          verticallyCentered
+          withMobileSafetyMargin>
           <ViewHeader small title={t('backup.showMnemonic.title')} />
           <ViewContent>
             <Message type="warning">

--- a/frontends/web/src/routes/device/bitbox02/setup/pairing.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/pairing.tsx
@@ -63,7 +63,7 @@ export const Pairing = ({
           </p>
         )}
       </ViewHeader>
-      <ViewContent fullWidth>
+      <ViewContent>
         { (attestation === false && !pairingFailed) && (
           <Message type="warning" className="m-bottom-half">
             {t('bitbox02Wizard.attestationFailed')}

--- a/frontends/web/src/routes/device/bitbox02/setup/wait.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/wait.tsx
@@ -17,7 +17,8 @@ export const Wait = ({ title, text }: Props) => {
       fullscreen
       width="720px"
       verticallyCentered
-      textCenter>
+      textCenter
+      withMobileSafetyMargin>
       <UseDisableBackButton />
       <ViewHeader title={title}>
         <p>{text ? text : t('bitbox02Interact.followInstructions')}</p>

--- a/frontends/web/src/routes/lightning/activate.tsx
+++ b/frontends/web/src/routes/lightning/activate.tsx
@@ -193,7 +193,8 @@ export const LightningActivate = () => {
           key="step-create"
           fullscreen
           textCenter
-          verticallyCentered>
+          verticallyCentered
+          withMobileSafetyMargin>
           <UseDisableBackButton />
           <ViewHeader title={t('lightning.activate.wait.title')}>
             <p>{t('lightning.activate.wait.confirm')}</p>

--- a/frontends/web/src/routes/market/bitrefill-confirm.tsx
+++ b/frontends/web/src/routes/market/bitrefill-confirm.tsx
@@ -34,7 +34,7 @@ export const ConfirmBitrefill = ({
   }
 
   return (
-    <View fullscreen width="840px">
+    <View fullscreen width="840px" withMobileSafetyMargin>
       <UseDisableBackButton />
       <ViewHeader title={<div className={style.title}>{t('send.confirm.title')}</div>} />
       <ViewContent>

--- a/frontends/web/src/routes/market/swap/components/swap-confirm.tsx
+++ b/frontends/web/src/routes/market/swap/components/swap-confirm.tsx
@@ -32,7 +32,7 @@ export const ConfirmSwap = ({
   }
 
   return (
-    <View fullscreen width="540px" verticallyCentered>
+    <View fullscreen width="540px" verticallyCentered withMobileSafetyMargin>
       <UseDisableBackButton />
       <ViewHeader title={
         t('swap.confirmOnBitBox')


### PR DESCRIPTION
Before:
<img width="388" height="834" alt="Screenshot 2026-08-31 at 16 43 11" src="https://github.com/user-attachments/assets/bfb468a4-65b5-4159-acce-a5094690c021" />


After:
<img width="389" height="817" alt="Screenshot 2026-08-31 at 16 40 05" src="https://github.com/user-attachments/assets/d50b3d9f-ac6e-441d-8947-f3507f20e383" />
