### PR TITLE
lightning: move files outside of cache and handle clearing cache 

### DIFF
--- a/backend/arguments/arguments.go
+++ b/backend/arguments/arguments.go
@@ -18,8 +18,11 @@ type Arguments struct {
 	// bitbox02DirectoryPath stores the location where bitbox02 application data is stored.
 	bitbox02DirectoryPath string
 
-	// cacheDirectoryPath stores the location where application data is stored.
+	// cacheDirectoryPath stores the location where disposable application caches are stored.
 	cacheDirectoryPath string
+
+	// lightningDirectoryPath stores persistent Lightning application data.
+	lightningDirectoryPath string
 
 	// notesDirectoryPath is the location where transaction notes (labels) are stored.
 	notesDirectoryPath string
@@ -79,6 +82,11 @@ func NewArguments(
 		panic("Cannot create the cache directory.")
 	}
 
+	lightningDirectoryPath := path.Join(mainDirectoryPath, "lightning")
+	if err := utilconfig.EnsurePrivateDir(lightningDirectoryPath); err != nil {
+		panic("Cannot create the lightning directory.")
+	}
+
 	notesDirectoryPath := path.Join(mainDirectoryPath, "notes")
 	if err := utilconfig.EnsurePrivateDir(notesDirectoryPath); err != nil {
 		panic("Cannot create the notes directory.")
@@ -102,6 +110,7 @@ func NewArguments(
 		bitbox02DirectoryPath: bitbox02DirectoryPath,
 
 		cacheDirectoryPath:      cacheDirectoryPath,
+		lightningDirectoryPath:  lightningDirectoryPath,
 		notesDirectoryPath:      notesDirectoryPath,
 		appConfigFilename:       appConfigFilename,
 		accountsConfigFilename:  accountsConfigFilename,
@@ -148,6 +157,12 @@ func (arguments *Arguments) BitBox02DirectoryPath() string {
 // The above constructor ensures that the directory with the returned path exists.
 func (arguments *Arguments) CacheDirectoryPath() string {
 	return arguments.cacheDirectoryPath
+}
+
+// LightningDirectoryPath returns the path where persistent Lightning application data is stored.
+// The above constructor ensures that the directory with the returned path exists.
+func (arguments *Arguments) LightningDirectoryPath() string {
+	return arguments.lightningDirectoryPath
 }
 
 // NotesDirectoryPath returns the path to the notes directory of the backend.

--- a/backend/arguments/arguments_test.go
+++ b/backend/arguments/arguments_test.go
@@ -47,6 +47,22 @@ func TestNewArgumentsDoesNotPanicIfConfigFileRestrictionFails(t *testing.T) {
 	})
 }
 
+func TestNewArgumentsCreatesPrivateLightningDirectory(t *testing.T) {
+	mainDirectoryPath := t.TempDir()
+
+	logging.Set(&logging.Configuration{Output: "STDERR", Level: logrus.DebugLevel})
+	args := NewArguments(mainDirectoryPath, true, false, false, nil)
+
+	lightningDirectoryPath := filepath.Join(mainDirectoryPath, "lightning")
+	require.Equal(t, lightningDirectoryPath, args.LightningDirectoryPath())
+	require.DirExists(t, lightningDirectoryPath)
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(lightningDirectoryPath)
+		require.NoError(t, err)
+		require.Equal(t, config.PrivateDirMode, info.Mode().Perm())
+	}
+}
+
 func requirePrivateFileMode(t *testing.T, filename string) {
 	t.Helper()
 	info, err := os.Stat(filename)

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1189,6 +1189,13 @@ func (backend *Backend) ClearCache() error {
 
 	backend.ratesUpdater = backend.newRatesUpdater()
 	backend.initAccounts(true)
+	btcCoin, err := backend.Coin(coinpkg.CodeBTC)
+	if err != nil {
+		backend.log.WithError(err).Error("could not recreate Bitcoin coin after clearing cache")
+		errors = append(errors, err.Error())
+	} else {
+		backend.lightning.SetRuntimeDependencies(backend.ratesUpdater, btcCoin)
+	}
 	if backend.started {
 		backend.ratesUpdater.StartCurrentRates()
 	}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -373,7 +373,7 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 	}
 
 	backend.lightning = lightning.NewLightning(backend.config,
-		backend.arguments.CacheDirectoryPath(),
+		backend.arguments.LightningDirectoryPath(),
 		backend.environment,
 		backend.Keystore,
 		backend.GetAccountFromCode,

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -457,6 +457,9 @@ func TestDevicesRegisteredReturnsSnapshot(t *testing.T) {
 func TestClearCachePreservesUserData(t *testing.T) {
 	b := newBackend(t, false, false)
 	defer b.Close()
+	oldRatesUpdater := b.ratesUpdater
+	oldBTCCoin, err := b.Coin(coinpkg.CodeBTC)
+	require.NoError(t, err)
 
 	cacheFile := filepath.Join(b.arguments.CacheDirectoryPath(), "dummy-cache-file")
 	require.NoError(t, os.WriteFile(cacheFile, []byte("cache"), 0600))
@@ -471,7 +474,11 @@ func TestClearCachePreservesUserData(t *testing.T) {
 	require.FileExists(t, b.arguments.AccountsConfigFilename())
 
 	require.NoError(t, b.ClearCache())
+	newBTCCoin, err := b.Coin(coinpkg.CodeBTC)
+	require.NoError(t, err)
 
+	require.NotSame(t, oldRatesUpdater, b.ratesUpdater)
+	require.NotSame(t, oldBTCCoin, newBTCCoin)
 	require.NoFileExists(t, cacheFile)
 	require.DirExists(t, filepath.Join(b.arguments.CacheDirectoryPath(), "exchangerates"))
 	require.FileExists(t, lightningFile)

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -476,9 +476,12 @@ func TestClearCachePreservesUserData(t *testing.T) {
 	require.NoError(t, b.ClearCache())
 	newBTCCoin, err := b.Coin(coinpkg.CodeBTC)
 	require.NoError(t, err)
+	lightningRatesUpdater, lightningBTCCoin := b.lightning.TstRuntimeDependencies()
 
 	require.NotSame(t, oldRatesUpdater, b.ratesUpdater)
 	require.NotSame(t, oldBTCCoin, newBTCCoin)
+	require.Same(t, b.ratesUpdater, lightningRatesUpdater)
+	require.Same(t, newBTCCoin, lightningBTCCoin)
 	require.NoFileExists(t, cacheFile)
 	require.DirExists(t, filepath.Join(b.arguments.CacheDirectoryPath(), "exchangerates"))
 	require.FileExists(t, lightningFile)

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -461,6 +461,9 @@ func TestClearCachePreservesUserData(t *testing.T) {
 	cacheFile := filepath.Join(b.arguments.CacheDirectoryPath(), "dummy-cache-file")
 	require.NoError(t, os.WriteFile(cacheFile, []byte("cache"), 0600))
 
+	lightningFile := filepath.Join(b.arguments.LightningDirectoryPath(), "dummy-breez-database")
+	require.NoError(t, os.WriteFile(lightningFile, []byte("lightning"), 0600))
+
 	noteFile := filepath.Join(b.arguments.NotesDirectoryPath(), "dummy-note-file")
 	require.NoError(t, os.WriteFile(noteFile, []byte("note"), 0600))
 
@@ -471,6 +474,7 @@ func TestClearCachePreservesUserData(t *testing.T) {
 
 	require.NoFileExists(t, cacheFile)
 	require.DirExists(t, filepath.Join(b.arguments.CacheDirectoryPath(), "exchangerates"))
+	require.FileExists(t, lightningFile)
 	require.FileExists(t, noteFile)
 	require.FileExists(t, b.arguments.AppConfigFilename())
 	require.FileExists(t, b.arguments.AccountsConfigFilename())

--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -146,9 +146,10 @@ func (lightning *Lightning) GetAccount(_ *http.Request) interface{} {
 
 // GetBlockExplorerTxPrefix handles the GET request to retrieve the Bitcoin transaction explorer prefix.
 func (lightning *Lightning) GetBlockExplorerTxPrefix(_ *http.Request) interface{} {
+	_, btcCoin := lightning.runtimeDependencies()
 	return responseDto{
 		Success: true,
-		Data:    lightning.btcCoin.BlockExplorerTransactionURLPrefix(),
+		Data:    btcCoin.BlockExplorerTransactionURLPrefix(),
 	}
 }
 
@@ -239,19 +240,19 @@ func (lightning *Lightning) formattedBalance() (*formattedLightningBalance, erro
 		return nil, err
 	}
 
-	btcCoin := lightning.btcCoin
+	ratesUpdater, btcCoin := lightning.runtimeDependencies()
 
 	formattedAvailableAmount := coin.FormattedAmountWithConversions{
 		Amount:                 btcCoin.FormatAmount(balance.Available(), false),
 		Unit:                   btcCoin.GetFormatUnit(false),
-		Conversions:            coin.Conversions(balance.Available(), btcCoin, false, lightning.ratesUpdater),
-		UnformattedConversions: coin.UnformattedConversions(balance.Available(), btcCoin, false, lightning.ratesUpdater),
+		Conversions:            coin.Conversions(balance.Available(), btcCoin, false, ratesUpdater),
+		UnformattedConversions: coin.UnformattedConversions(balance.Available(), btcCoin, false, ratesUpdater),
 	}
 	formattedIncomingAmount := coin.FormattedAmountWithConversions{
 		Amount:                 btcCoin.FormatAmount(balance.Incoming(), false),
 		Unit:                   btcCoin.GetFormatUnit(false),
-		Conversions:            coin.Conversions(balance.Incoming(), btcCoin, false, lightning.ratesUpdater),
-		UnformattedConversions: coin.UnformattedConversions(balance.Incoming(), btcCoin, false, lightning.ratesUpdater),
+		Conversions:            coin.Conversions(balance.Incoming(), btcCoin, false, ratesUpdater),
+		UnformattedConversions: coin.UnformattedConversions(balance.Incoming(), btcCoin, false, ratesUpdater),
 	}
 
 	return &formattedLightningBalance{

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -69,12 +69,12 @@ type breezSDK interface {
 type Lightning struct {
 	observable.Implementation
 
-	backendConfig      *config.Config
-	cacheDirectoryPath string
-	environment        environment
-	getKeystore        func() keystore.Keystore
-	getAccount         func(types.Code) (accounts.Interface, error)
-	synced             bool
+	backendConfig          *config.Config
+	lightningDirectoryPath string
+	environment            environment
+	getKeystore            func() keystore.Keystore
+	getAccount             func(types.Code) (accounts.Interface, error)
+	synced                 bool
 
 	log          *logrus.Entry
 	sdkService   breezSDK
@@ -89,7 +89,7 @@ type Lightning struct {
 
 // NewLightning creates a new instance of the Lightning struct.
 func NewLightning(config *config.Config,
-	cacheDirectoryPath string,
+	lightningDirectoryPath string,
 	environment environment,
 	getKeystore func() keystore.Keystore,
 	getAccount func(types.Code) (accounts.Interface, error),
@@ -97,17 +97,17 @@ func NewLightning(config *config.Config,
 	ratesUpdater *rates.RateUpdater,
 	btcCoin coin.Coin) *Lightning {
 	return &Lightning{
-		backendConfig:      config,
-		cacheDirectoryPath: cacheDirectoryPath,
-		environment:        environment,
-		getKeystore:        getKeystore,
-		getAccount:         getAccount,
-		log:                logging.Get().WithGroup("lightning"),
-		synced:             false,
-		sparkStatus:        breez_sdk_spark.GetSparkStatus,
-		httpClient:         httpClient,
-		ratesUpdater:       ratesUpdater,
-		btcCoin:            btcCoin,
+		backendConfig:          config,
+		lightningDirectoryPath: lightningDirectoryPath,
+		environment:            environment,
+		getKeystore:            getKeystore,
+		getAccount:             getAccount,
+		log:                    logging.Get().WithGroup("lightning"),
+		synced:                 false,
+		sparkStatus:            breez_sdk_spark.GetSparkStatus,
+		httpClient:             httpClient,
+		ratesUpdater:           ratesUpdater,
+		btcCoin:                btcCoin,
 	}
 }
 
@@ -195,7 +195,7 @@ func (lightning *Lightning) Disconnect() {
 	}
 }
 
-// Deactivate changes the config to inactive, disconnects the instance and deletes the cache folder.
+// Deactivate changes the config to inactive, disconnects the instance and deletes its storage folder.
 func (lightning *Lightning) Deactivate() error {
 	account := lightning.Account()
 
@@ -208,7 +208,7 @@ func (lightning *Lightning) Deactivate() error {
 	}
 
 	lightning.Disconnect()
-	workingDir := path.Join(lightning.cacheDirectoryPath, accountBreezFolder(account.Code))
+	workingDir := path.Join(lightning.lightningDirectoryPath, accountBreezFolder(account.Code))
 	if err := os.RemoveAll(workingDir); err != nil {
 		lightning.log.WithError(err).Error("Error deleting working directory")
 	}
@@ -355,7 +355,7 @@ func (lightning *Lightning) connect() error {
 	if account != nil && lightning.sdkService == nil {
 		initializeLogging(lightning.log)
 
-		workingDir := path.Join(lightning.cacheDirectoryPath, accountBreezFolder(account.Code))
+		workingDir := path.Join(lightning.lightningDirectoryPath, accountBreezFolder(account.Code))
 
 		if err := os.MkdirAll(workingDir, 0700); err != nil {
 			lightning.log.WithError(err).Error("Error creating working directory")

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -127,6 +127,11 @@ func (lightning *Lightning) runtimeDependencies() (*rates.RateUpdater, coin.Coin
 	return lightning.ratesUpdater, lightning.btcCoin
 }
 
+// TstRuntimeDependencies must only be used in tests to inspect the current runtime dependencies.
+func (lightning *Lightning) TstRuntimeDependencies() (*rates.RateUpdater, coin.Coin) {
+	return lightning.runtimeDependencies()
+}
+
 // Activate first creates a mnemonic from the keystore entropy, persists it, and connects to the
 // instance.
 func (lightning *Lightning) Activate() error {

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -83,6 +83,8 @@ type Lightning struct {
 	ratesUpdater *rates.RateUpdater
 	btcCoin      coin.Coin
 
+	runtimeDependenciesLock sync.RWMutex
+
 	// Serializes lazy lightning address registration.
 	lightningAddressLock sync.Mutex
 }
@@ -109,6 +111,20 @@ func NewLightning(config *config.Config,
 		ratesUpdater:           ratesUpdater,
 		btcCoin:                btcCoin,
 	}
+}
+
+// SetRuntimeDependencies updates dependencies that are recreated when the backend cache is cleared.
+func (lightning *Lightning) SetRuntimeDependencies(ratesUpdater *rates.RateUpdater, btcCoin coin.Coin) {
+	lightning.runtimeDependenciesLock.Lock()
+	defer lightning.runtimeDependenciesLock.Unlock()
+	lightning.ratesUpdater = ratesUpdater
+	lightning.btcCoin = btcCoin
+}
+
+func (lightning *Lightning) runtimeDependencies() (*rates.RateUpdater, coin.Coin) {
+	lightning.runtimeDependenciesLock.RLock()
+	defer lightning.runtimeDependenciesLock.RUnlock()
+	return lightning.ratesUpdater, lightning.btcCoin
 }
 
 // Activate first creates a mnemonic from the keystore entropy, persists it, and connects to the

--- a/backend/lightning/lightning_test.go
+++ b/backend/lightning/lightning_test.go
@@ -158,6 +158,19 @@ func TestReady(t *testing.T) {
 	require.False(t, lightning.Ready())
 }
 
+func TestSetRuntimeDependencies(t *testing.T) {
+	lightning := makeTestLightning()
+	replacement := makeTestLightning()
+	defer lightning.ratesUpdater.Stop()
+	defer replacement.ratesUpdater.Stop()
+
+	lightning.SetRuntimeDependencies(replacement.ratesUpdater, replacement.btcCoin)
+	ratesUpdater, btcCoin := lightning.runtimeDependencies()
+
+	require.Same(t, replacement.ratesUpdater, ratesUpdater)
+	require.Same(t, replacement.btcCoin, btcCoin)
+}
+
 func TestAddressDomain(t *testing.T) {
 	require.Equal(t, "bitbox.cash", newTestLightning(t, nil).AddressDomain())
 }

--- a/backend/lightning/lightning_test.go
+++ b/backend/lightning/lightning_test.go
@@ -158,19 +158,6 @@ func TestReady(t *testing.T) {
 	require.False(t, lightning.Ready())
 }
 
-func TestSetRuntimeDependencies(t *testing.T) {
-	lightning := makeTestLightning()
-	replacement := makeTestLightning()
-	defer lightning.ratesUpdater.Stop()
-	defer replacement.ratesUpdater.Stop()
-
-	lightning.SetRuntimeDependencies(replacement.ratesUpdater, replacement.btcCoin)
-	ratesUpdater, btcCoin := lightning.runtimeDependencies()
-
-	require.Same(t, replacement.ratesUpdater, ratesUpdater)
-	require.Same(t, replacement.btcCoin, btcCoin)
-}
-
 func TestAddressDomain(t *testing.T) {
 	require.Equal(t, "bitbox.cash", newTestLightning(t, nil).AddressDomain())
 }

--- a/backend/lightning/lightning_test.go
+++ b/backend/lightning/lightning_test.go
@@ -81,7 +81,7 @@ func newTestLightningWithConfigFilename(
 
 	return NewLightning(
 		cfg,
-		test.TstTempDir("lightning-cache"),
+		test.TstTempDir("lightning-data"),
 		environment,
 		func() keystore.Keystore { return nil },
 		nil,

--- a/backend/lightning/payments.go
+++ b/backend/lightning/payments.go
@@ -376,16 +376,17 @@ func (lightning *Lightning) toLightningPayment(payment breez_sdk_spark.Payment) 
 		formatted := t.Format(time.RFC3339)
 		formattedTime = &formatted
 	}
+	ratesUpdater, btcCoin := lightning.runtimeDependencies()
 
 	result := lightningPayment{
 		ID:                   payment.Id,
 		Type:                 paymentType,
 		Status:               toLightningPaymentStatus(payment.Status),
 		Time:                 formattedTime,
-		Amount:               amount.FormatWithConversions(lightning.btcCoin, false, lightning.ratesUpdater),
-		AmountAtTime:         amount.FormatWithConversionsAtTime(lightning.btcCoin, timestamp, lightning.ratesUpdater),
-		DeductedAmountAtTime: deductedAmount.FormatWithConversionsAtTime(lightning.btcCoin, timestamp, lightning.ratesUpdater),
-		Fee:                  fee.FormatWithConversions(lightning.btcCoin, true, lightning.ratesUpdater),
+		Amount:               amount.FormatWithConversions(btcCoin, false, ratesUpdater),
+		AmountAtTime:         amount.FormatWithConversionsAtTime(btcCoin, timestamp, ratesUpdater),
+		DeductedAmountAtTime: deductedAmount.FormatWithConversionsAtTime(btcCoin, timestamp, ratesUpdater),
+		Fee:                  fee.FormatWithConversions(btcCoin, true, ratesUpdater),
 	}
 	// Claimed Bitcoin deposits appear in ListPayments, sometimes without payment details. Mark them
 	// as complete top-ups based on the payment method so the frontend can identify them reliably.
@@ -488,6 +489,7 @@ func bitcoinDepositPaymentID(deposit breez_sdk_spark.DepositInfo) string {
 
 func (lightning *Lightning) toBitcoinDepositPayment(deposit breez_sdk_spark.DepositInfo) lightningPayment {
 	amount := coin.NewAmountFromInt64(int64(deposit.AmountSats))
+	ratesUpdater, btcCoin := lightning.runtimeDependencies()
 	depositInfo := &bitcoinDeposit{
 		TxID:  deposit.Txid,
 		State: bitcoinDepositStateFromSDK(deposit),
@@ -502,10 +504,10 @@ func (lightning *Lightning) toBitcoinDepositPayment(deposit breez_sdk_spark.Depo
 		ID:                   bitcoinDepositPaymentID(deposit),
 		Type:                 accounts.TxTypeReceive,
 		Status:               accounts.TxStatusPending,
-		Amount:               amount.FormatWithConversions(lightning.btcCoin, false, lightning.ratesUpdater),
-		AmountAtTime:         amount.FormatWithConversionsAtTime(lightning.btcCoin, nil, lightning.ratesUpdater),
-		DeductedAmountAtTime: coin.NewAmountFromInt64(0).FormatWithConversionsAtTime(lightning.btcCoin, nil, lightning.ratesUpdater),
-		Fee:                  coin.NewAmountFromInt64(0).FormatWithConversions(lightning.btcCoin, true, lightning.ratesUpdater),
+		Amount:               amount.FormatWithConversions(btcCoin, false, ratesUpdater),
+		AmountAtTime:         amount.FormatWithConversionsAtTime(btcCoin, nil, ratesUpdater),
+		DeductedAmountAtTime: coin.NewAmountFromInt64(0).FormatWithConversionsAtTime(btcCoin, nil, ratesUpdater),
+		Fee:                  coin.NewAmountFromInt64(0).FormatWithConversions(btcCoin, true, ratesUpdater),
 		BitcoinDeposit:       depositInfo,
 	}
 }
@@ -920,7 +922,8 @@ func (lightning *Lightning) validateBitcoinPaymentAmountAgainstDustLimit(
 	destinationAddress string,
 	amountSat uint64,
 ) error {
-	btcCoin, ok := lightning.btcCoin.(bitcoinAddressToPkScripter)
+	_, lightningCoin := lightning.runtimeDependencies()
+	btcCoin, ok := lightningCoin.(bitcoinAddressToPkScripter)
 	if !ok {
 		return errp.New("Bitcoin coin does not support address-to-script conversion")
 	}
@@ -1023,7 +1026,8 @@ func (lightning *Lightning) onChainDestinationAddress(
 
 func (lightning *Lightning) formatSats(amountSat uint64, isFee bool) coin.FormattedAmountWithConversions {
 	amount := coin.NewAmount(new(big.Int).SetUint64(amountSat))
-	return amount.FormatWithConversions(lightning.btcCoin, isFee, lightning.ratesUpdater)
+	ratesUpdater, btcCoin := lightning.runtimeDependencies()
+	return amount.FormatWithConversions(btcCoin, isFee, ratesUpdater)
 }
 
 func isRefundedDeposit(deposit breez_sdk_spark.DepositInfo) bool {
@@ -1056,10 +1060,11 @@ func (lightning *Lightning) PrepareCloseWithdraw(
 	}
 
 	feeAmount := coin.NewAmountFromInt64(int64(fee.FeeSat))
+	ratesUpdater, btcCoin := lightning.runtimeDependencies()
 	return &closeWithdrawQuote{
-		Balance:    availableBalance.FormatWithConversions(lightning.btcCoin, false, lightning.ratesUpdater),
+		Balance:    availableBalance.FormatWithConversions(btcCoin, false, ratesUpdater),
 		BalanceSat: amountSat,
-		Fee:        feeAmount.FormatWithConversions(lightning.btcCoin, true, lightning.ratesUpdater),
+		Fee:        feeAmount.FormatWithConversions(btcCoin, true, ratesUpdater),
 		FeeSat:     fee.FeeSat,
 	}, nil
 }

--- a/frontends/android/BitBoxApp/app/src/main/res/xml/backup_rules.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/xml/backup_rules.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
     <exclude domain="file" path="cache" />
+    <exclude domain="file" path="lightning" />
     <exclude domain="file" path="lightning.json" />
     <exclude domain="sharedpref" path="lightning-encryption.xml" />
 </full-backup-content>

--- a/frontends/android/BitBoxApp/app/src/main/res/xml/data_extraction_rules.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/xml/data_extraction_rules.xml
@@ -2,11 +2,13 @@
 <data-extraction-rules>
     <cloud-backup>
         <exclude domain="file" path="cache" />
+        <exclude domain="file" path="lightning" />
         <exclude domain="file" path="lightning.json" />
         <exclude domain="sharedpref" path="lightning-encryption.xml" />
     </cloud-backup>
     <device-transfer>
         <exclude domain="file" path="cache" />
+        <exclude domain="file" path="lightning" />
         <exclude domain="file" path="lightning.json" />
         <exclude domain="sharedpref" path="lightning-encryption.xml" />
     </device-transfer>

--- a/frontends/ios/BitBoxApp/BitBoxApp/BitBoxAppApp.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/BitBoxAppApp.swift
@@ -293,6 +293,7 @@ struct BitBoxAppApp: App {
 
     private func excludeBackendPathsFromBackup(in appSupportDirectory: URL) {
         excludeFromBackup(appSupportDirectory.appendingPathComponent("lightning.json"))
+        excludeFromBackup(appSupportDirectory.appendingPathComponent("lightning", isDirectory: true))
         excludeFromBackup(appSupportDirectory.appendingPathComponent("cache", isDirectory: true))
     }
 

--- a/frontends/web/tests/clear-cache.test.ts
+++ b/frontends/web/tests/clear-cache.test.ts
@@ -12,6 +12,8 @@ let servewallet: ServeWallet | undefined;
 const cacheDir = path.join(process.cwd(), '../../appfolder.dev/cache');
 const sentinelPath = path.join(cacheDir, 'playwright-clear-cache-sentinel.txt');
 const exchangeRatesCacheDir = path.join(cacheDir, 'exchangerates');
+const lightningDir = path.join(process.cwd(), '../../appfolder.dev/lightning');
+const lightningSentinelPath = path.join(lightningDir, 'playwright-lightning-sentinel.txt');
 
 const removeCacheDir = () => {
   fs.rmSync(cacheDir, { recursive: true, force: true });
@@ -33,10 +35,14 @@ test('Clear cache removes cached files and recreates cache-backed state', async 
     await expect(page.locator('body')).toContainText('Please connect your BitBox and tap the side to continue.');
   });
 
-  await test.step('Create a cache sentinel file', async () => {
+  await test.step('Create cache and Lightning sentinel files', async () => {
     fs.mkdirSync(cacheDir, { recursive: true });
     fs.writeFileSync(sentinelPath, `clear-cache-e2e-${Date.now()}`);
     expect(fs.existsSync(sentinelPath)).toBe(true);
+
+    fs.mkdirSync(lightningDir, { recursive: true });
+    fs.writeFileSync(lightningSentinelPath, `lightning-data-${Date.now()}`);
+    expect(fs.existsSync(lightningSentinelPath)).toBe(true);
   });
 
   await test.step('Clear cache from advanced settings', async () => {
@@ -61,6 +67,7 @@ test('Clear cache removes cached files and recreates cache-backed state', async 
   await test.step('Verify backend cache was cleared and reinitialized', async () => {
     await expect.poll(() => fs.existsSync(sentinelPath)).toBe(false);
     expect(fs.existsSync(exchangeRatesCacheDir)).toBe(true);
+    expect(fs.existsSync(lightningSentinelPath)).toBe(true);
     await expect(page.getByRole('heading', { name: 'Clear cache' })).toBeHidden();
   });
 });
@@ -75,6 +82,7 @@ test.afterEach(async () => {
   await servewallet?.stop();
   servewallet = undefined;
   fs.rmSync(sentinelPath, { force: true });
+  fs.rmSync(lightningSentinelPath, { force: true });
   deleteAccountsFile();
   deleteConfigFile();
 });


### PR DESCRIPTION
This PR contains 2 commits: the first one moves the Lightning files outside of cache so that clearing the cache does not delete them; codex also found an issue such that clearing cache will recreate the rates updates and the btc coin, but Lightning still had pointers to the old ones; the second commit fixes it.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
