### PR TITLE
frontend: do not override window app icon on macos

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -318,7 +318,9 @@ int main(int argc, char *argv[])
     a.setApplicationName(APPNAME);
     a.setOrganizationDomain("shiftcrypto.ch");
     a.setOrganizationName("Shift Crypto");
+#if !defined(Q_OS_MACOS)
     a.setWindowIcon(QIcon(QCoreApplication::applicationDirPath() + "/bitbox.png"));
+#endif
 
     if(a.isSecondary()) {
         // The application is already running. If there is exactly one positional argument, we send


### PR DESCRIPTION
https://github.com/BitBoxSwiss/bitbox-wallet-app/pull/4050 introduced native macOS Tahoe icons, but they are overridden when the app launches i.e. the icon changes whenever you close/open the app. Fixed by skipping this override on macOS.