### PR TITLE
frontend: show connect keystore prompt on top-up

### DIFF
--- a/frontends/web/src/routes/lightning/topup/topup-result.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup-result.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { connectAnyKeystore } from '@/api/keystores';
 import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
 import { GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
@@ -51,17 +52,15 @@ export const TopUpSuccess = () => {
 export const TopUpNoBitcoinAccounts = ({ hasAccounts }: TTopUpNoBitcoinAccountsProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const primaryAction = (
-    hasAccounts
-      ? {
-        label: t('manageAccounts.title'),
-        route: '/settings/manage-accounts',
-      }
-      : {
-        label: t('welcome.connect'),
-        route: '/',
-      }
-  );
+
+  const handlePrimaryAction = async () => {
+    // This happens only when accounts exist, but none are Bitcoin accounts.
+    if (hasAccounts) {
+      navigate('/settings/manage-accounts');
+      return;
+    }
+    await connectAnyKeystore();
+  };
 
   return (
     <GuideWrapper>
@@ -81,8 +80,8 @@ export const TopUpNoBitcoinAccounts = ({ hasAccounts }: TTopUpNoBitcoinAccountsP
               <p>{t('lightning.topUp.noBitcoinAccounts')}</p>
             </ViewContent>
             <ViewButtons>
-              <Button primary onClick={() => navigate(primaryAction.route)}>
-                {primaryAction.label}
+              <Button primary onClick={handlePrimaryAction}>
+                {hasAccounts ? t('manageAccounts.title') : t('welcome.connect')}
               </Button>
               <DesktopBackButton onClick={() => navigate('/lightning')}>
                 {t('button.back')}

--- a/frontends/web/src/routes/lightning/topup/topup.test.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup.test.tsx
@@ -3,13 +3,14 @@
 import '../../../../__mocks__/i18n';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as accountApi from '@/api/account';
 import * as coinsApi from '@/api/coins';
 import * as keystoresApi from '@/api/keystores';
 import * as lightningApi from '@/api/lightning';
 import { TLightningErrorCode } from '@/api/lightning-errors';
+import { BackButtonProvider } from '@/contexts/BackButtonContext';
 import { RatesContext } from '@/contexts/RatesContext';
 import { LightningTopUp } from './topup';
 
@@ -89,20 +90,28 @@ const lightningBalance = (marginSat = 150000): lightningApi.TLightningBalance =>
   incoming: amount('0'),
 });
 
-const renderTopUp = (activeAccounts = [account]) => render(
-  <MemoryRouter>
-    <RatesContext.Provider value={{
-      defaultCurrency: 'USD',
-      activeCurrencies: ['USD'],
-      btcUnit: 'sat',
-      rotateDefaultCurrency: vi.fn(),
-      rotateBtcUnit: vi.fn(),
-      addToActiveCurrencies: vi.fn(),
-      updateDefaultCurrency: vi.fn(),
-      removeFromActiveCurrencies: vi.fn(),
-    }}>
-      <LightningTopUp activeAccounts={activeAccounts} hasAccounts />
-    </RatesContext.Provider>
+const CurrentPath = () => {
+  const { pathname } = useLocation();
+  return <span data-testid="current-path">{pathname}</span>;
+};
+
+const renderTopUp = (activeAccounts = [account], hasAccounts = true) => render(
+  <MemoryRouter initialEntries={['/lightning/topup']}>
+    <BackButtonProvider>
+      <RatesContext.Provider value={{
+        defaultCurrency: 'USD',
+        activeCurrencies: ['USD'],
+        btcUnit: 'sat',
+        rotateDefaultCurrency: vi.fn(),
+        rotateBtcUnit: vi.fn(),
+        addToActiveCurrencies: vi.fn(),
+        updateDefaultCurrency: vi.fn(),
+        removeFromActiveCurrencies: vi.fn(),
+      }}>
+        <LightningTopUp activeAccounts={activeAccounts} hasAccounts={hasAccounts} />
+        <CurrentPath />
+      </RatesContext.Provider>
+    </BackButtonProvider>
   </MemoryRouter>
 );
 
@@ -110,6 +119,31 @@ describe('LightningTopUp', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(lightningApi, 'subscribeLightningBalance').mockReturnValue(vi.fn());
+  });
+
+  it('prompts to connect a BitBox without leaving Top up when there are no accounts', async () => {
+    vi.spyOn(lightningApi, 'getLightningBalance').mockResolvedValue(lightningBalance());
+    const connectAnyKeystore = vi.spyOn(keystoresApi, 'connectAnyKeystore').mockResolvedValue({
+      success: false,
+      errorCode: 'userAbort',
+    });
+
+    renderTopUp([], false);
+    fireEvent.click(await screen.findByRole('button', { name: /connect/i }));
+
+    await waitFor(() => expect(connectAnyKeystore).toHaveBeenCalledOnce());
+    expect(screen.getByTestId('current-path')).toHaveTextContent('/lightning/topup');
+  });
+
+  it('opens Manage accounts when accounts exist but no Bitcoin account is active', async () => {
+    vi.spyOn(lightningApi, 'getLightningBalance').mockResolvedValue(lightningBalance());
+    const connectAnyKeystore = vi.spyOn(keystoresApi, 'connectAnyKeystore');
+
+    renderTopUp([], true);
+    fireEvent.click(await screen.findByRole('button', { name: /manage/i }));
+
+    expect(screen.getByTestId('current-path')).toHaveTextContent('/settings/manage-accounts');
+    expect(connectAnyKeystore).not.toHaveBeenCalled();
   });
 
   it('shows every Bitcoin account without loading its balance', async () => {


### PR DESCRIPTION
If the user tries to top-up but no keystore is connected, instead of redirecting them to the home page, show the connectAnyKeystore prompt.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
