### PR TITLE
backend: use slices.SortFunc for chart ordering

### DIFF
--- a/backend/chart.go
+++ b/backend/chart.go
@@ -3,9 +3,9 @@
 package backend
 
 import (
+	"cmp"
 	"math/big"
 	"slices"
-	"sort"
 	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
@@ -315,7 +315,9 @@ func (backend *Backend) ChartData() (*Chart, error) {
 			}
 			i++
 		}
-		sort.Slice(result, func(i, j int) bool { return result[i].Time < result[j].Time })
+		slices.SortFunc(result, func(a, b ChartEntry) int {
+			return cmp.Compare(a.Time, b.Time)
+		})
 
 		// Manually add the last point with the current total, to make the last point match.
 		// The last point might not match the account total otherwise because:


### PR DESCRIPTION
Replace the index-based chart-entry sort with a typed `slices.SortFunc` comparator.

The ordering remains unchanged, while the comparison logic no longer captures the backing slice by index.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [x] having an AI review your changes