### PR TITLE
lightning: handle SDK initialization failures

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -288,9 +288,9 @@ func (backend *Backend) convertToFiat(coin coinpkg.Coin, amount coinpkg.Amount, 
 }
 
 type coinFormattedAmount struct {
-	CoinCode        coinpkg.Code                           `json:"coinCode"`
-	CoinName        string                                 `json:"coinName"`
-	FormattedAmount coinpkg.FormattedAmountWithConversions `json:"formattedAmount"`
+	CoinCode        coinpkg.Code                            `json:"coinCode"`
+	CoinName        string                                  `json:"coinName"`
+	FormattedAmount *coinpkg.FormattedAmountWithConversions `json:"formattedAmount,omitempty"`
 }
 
 func (backend *Backend) formattedCoinBalance(
@@ -303,7 +303,7 @@ func (backend *Backend) formattedCoinBalance(
 	return coinFormattedAmount{
 		CoinCode: coinCode,
 		CoinName: coinName,
-		FormattedAmount: coinpkg.FormattedAmountWithConversions{
+		FormattedAmount: &coinpkg.FormattedAmountWithConversions{
 			Amount: coin.FormatAmount(coinAmount, false),
 			Unit:   coin.GetFormatUnit(false),
 			Conversions: coinpkg.Conversions(
@@ -316,7 +316,9 @@ func (backend *Backend) formattedCoinBalance(
 	}
 }
 
-// getCoinsTotalBalance returns the total balances grouped by coins.
+// coinsTotalBalance returns the total balances grouped by coins. Lightning is included on a
+// best-effort basis so that an unavailable Lightning SDK cannot prevent on-chain balances from
+// loading.
 func (backend *Backend) coinsTotalBalance() ([]coinFormattedAmount, error) {
 	coinFormattedAmounts := []coinFormattedAmount{}
 	var sortedCoins []coinpkg.Code
@@ -348,9 +350,18 @@ func (backend *Backend) coinsTotalBalance() ([]coinFormattedAmount, error) {
 		}
 	}
 
-	lightningBalance, err := backend.lightningFormattedBalance()
-	if err != nil {
-		return nil, err
+	var lightningBalance *coinFormattedAmount
+	if backend.hasLightningAccount() {
+		lightningBalance = &coinFormattedAmount{
+			CoinCode: coinCodeLightning,
+			CoinName: "Lightning",
+		}
+		formattedLightningBalance, err := backend.lightningFormattedBalance()
+		if err != nil {
+			backend.log.WithError(err).Error("Failed to load Lightning balance for account summary")
+		} else {
+			lightningBalance = formattedLightningBalance
+		}
 	}
 
 	for _, coinCode := range sortedCoins {

--- a/backend/chart.go
+++ b/backend/chart.go
@@ -175,7 +175,8 @@ func (backend *Backend) addTxsToChart(
 	return false, nil
 }
 
-// ChartData assembles chart data for all active accounts.
+// ChartData assembles chart data for all active accounts. Lightning is included on a best-effort
+// basis so that an unavailable Lightning SDK cannot prevent the on-chain chart from loading.
 func (backend *Backend) ChartData() (*Chart, error) {
 	// If true, we are missing headers or historical conversion rates necessary to compute the chart
 	// data,
@@ -258,46 +259,46 @@ func (backend *Backend) ChartData() (*Chart, error) {
 	}
 
 	if backend.hasLightningAccount() {
-		var err error
 		lightningBalance, err := backend.lightning.Balance()
 		if err != nil {
-			return nil, err
-		}
-		lightningBalanceAmount, err := backend.convertBtcAmountToFiat(lightningBalance.Available(), fiat)
-		if err != nil {
-			return nil, err
-		}
-		currentTotal.Add(currentTotal, lightningBalanceAmount)
-
-		lightningTxs, err := backend.lightning.Transactions()
-		if err != nil {
-			backend.log.WithError(err).WithField("coin", coinCodeLightning).Info("ChartDataMissing/list-payments")
-			chartDataMissing = true
-			transactionHistoryMissing = true
-			lightningTxs = nil
-		}
-		totalNumberOfTransactions += len(lightningTxs)
-
-		if !chartDataMissing {
-			btcCoin, err := backend.Coin(coin.CodeBTC)
+			backend.log.WithError(err).Error("Failed to load Lightning balance for chart")
+		} else {
+			lightningBalanceAmount, err := backend.convertBtcAmountToFiat(lightningBalance.Available(), fiat)
 			if err != nil {
 				return nil, err
 			}
-			lightningChartDataMissing, err := backend.addTxsToChart(
-				coin.CodeBTC,
-				coinCodeLightning,
-				fiat,
-				coin.DecimalsExp(btcCoin, false),
-				lightningTxs,
-				until,
-				chartEntriesDaily,
-				chartEntriesHourly,
-			)
+			currentTotal.Add(currentTotal, lightningBalanceAmount)
+
+			lightningTxs, err := backend.lightning.Transactions()
 			if err != nil {
-				return nil, err
-			}
-			if lightningChartDataMissing {
+				backend.log.WithError(err).WithField("coin", coinCodeLightning).Info("ChartDataMissing/list-payments")
 				chartDataMissing = true
+				transactionHistoryMissing = true
+				lightningTxs = nil
+			}
+			totalNumberOfTransactions += len(lightningTxs)
+
+			if !chartDataMissing {
+				btcCoin, err := backend.Coin(coin.CodeBTC)
+				if err != nil {
+					return nil, err
+				}
+				lightningChartDataMissing, err := backend.addTxsToChart(
+					coin.CodeBTC,
+					coinCodeLightning,
+					fiat,
+					coin.DecimalsExp(btcCoin, false),
+					lightningTxs,
+					until,
+					chartEntriesDaily,
+					chartEntriesHourly,
+				)
+				if err != nil {
+					return nil, err
+				}
+				if lightningChartDataMissing {
+					chartDataMissing = true
+				}
 			}
 		}
 	}

--- a/backend/lightning.go
+++ b/backend/lightning.go
@@ -13,9 +13,6 @@ func (backend *Backend) hasLightningAccount() bool {
 }
 
 func (backend *Backend) lightningFormattedBalance() (*coinFormattedAmount, error) {
-	if backend.lightning.Account() == nil {
-		return nil, nil
-	}
 	lightningBalance, err := backend.lightning.Balance()
 	if err != nil {
 		return nil, err

--- a/backend/lightning/address_test.go
+++ b/backend/lightning/address_test.go
@@ -69,6 +69,7 @@ func activateLightningAddressTest(t *testing.T, lightning *Lightning) {
 		Code:            "v0-deadbeef-ln-0",
 		Number:          0,
 	}))
+	lightning.setSDKStatus(SDKStatusReady)
 }
 
 type testBreezSDK struct {
@@ -521,6 +522,7 @@ func TestRegisterAddressCurrentUsernameIsNoop(t *testing.T) {
 			return breez_sdk_spark.LightningAddressInfo{}, nil
 		},
 	}
+	lightning.setSDKStatus(SDKStatusReady)
 
 	address, err := lightning.RegisterAddress(" Existing ")
 	require.NoError(t, err)
@@ -587,6 +589,7 @@ func TestRegisterAddressCooldown(t *testing.T) {
 			return breez_sdk_spark.LightningAddressInfo{}, nil
 		},
 	}
+	lightning.setSDKStatus(SDKStatusReady)
 
 	address, err := lightning.RegisterAddress("replacement")
 	require.Nil(t, address)
@@ -622,6 +625,7 @@ func TestRegisterAddressAfterCooldown(t *testing.T) {
 			}, nil
 		},
 	}
+	lightning.setSDKStatus(SDKStatusReady)
 
 	address, err := lightning.RegisterAddress("replacement")
 	require.NoError(t, err)

--- a/backend/lightning/event.go
+++ b/backend/lightning/event.go
@@ -17,7 +17,7 @@ func (lightning *Lightning) notifyListPaymentsReload() {
 
 // NotifyBalanceReload computes the current lightning balance and notifies observers.
 func (lightning *Lightning) NotifyBalanceReload() {
-	if !lightning.Ready() {
+	if lightning.CheckActive() != nil {
 		return
 	}
 

--- a/backend/lightning/event_test.go
+++ b/backend/lightning/event_test.go
@@ -68,6 +68,7 @@ func TestNotifyBalanceReloadLogsReadyFailure(t *testing.T) {
 			return breez_sdk_spark.GetInfoResponse{}, errors.New("get info failed")
 		},
 	}
+	lightning.setSDKStatus(SDKStatusReady)
 
 	var logOutput bytes.Buffer
 	logger := logrus.New()

--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -37,7 +37,7 @@ func NewHandlers(
 	handleNoError("/address/availability", lightning.GetAddressAvailability).Methods("GET")
 	handleNoError("/address/generate", lightning.PostGenerateAddress).Methods("POST")
 	handleNoError("/address/register", lightning.PostRegisterAddress).Methods("POST")
-	handleNoError("/ready", lightning.GetReady).Methods("GET")
+	handleNoError("/sdk-status", lightning.GetSDKStatus).Methods("GET")
 	handleNoError("/activate", lightning.PostActivate).Methods("POST")
 	handleNoError("/deactivate", lightning.PostDeactivate).Methods("POST")
 	handleNoError("/balance", lightning.GetBalance).Methods("GET")
@@ -203,9 +203,9 @@ func (lightning *Lightning) PostRegisterAddress(r *http.Request) interface{} {
 	return responseDto{Success: true, Data: address}
 }
 
-// GetReady handles the GET request to retrieve whether the lightning SDK is ready.
-func (lightning *Lightning) GetReady(_ *http.Request) interface{} {
-	return responseDto{Success: true, Data: lightning.Ready()}
+// GetSDKStatus handles the GET request to retrieve the Lightning SDK initialization status.
+func (lightning *Lightning) GetSDKStatus(_ *http.Request) interface{} {
+	return responseDto{Success: true, Data: lightning.SDKStatus()}
 }
 
 // PostActivate handles the POST request to activate lightning.

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -37,6 +37,17 @@ const (
 	lnurlDomain               = "bitbox.cash"
 )
 
+// SDKStatus describes the state of the one SDK initialization attempt.
+type SDKStatus string
+
+// SDKStatus values describe the Lightning SDK initialization lifecycle.
+const (
+	SDKStatusInactive     SDKStatus = "inactive"
+	SDKStatusInitializing SDKStatus = "initializing"
+	SDKStatusReady        SDKStatus = "ready"
+	SDKStatusFailed       SDKStatus = "failed"
+)
+
 // Keep this local to avoid importing backend.Environment and creating a package cycle.
 type environment interface {
 	CanEncryptLightningMnemonic() bool
@@ -76,12 +87,14 @@ type Lightning struct {
 	getAccount             func(types.Code) (accounts.Interface, error)
 	synced                 bool
 
-	log          *logrus.Entry
-	sdkService   breezSDK
-	sparkStatus  func() (breez_sdk_spark.SparkStatus, error)
-	httpClient   *http.Client
-	ratesUpdater *rates.RateUpdater
-	btcCoin      coin.Coin
+	log           *logrus.Entry
+	sdkService    breezSDK
+	sparkStatus   func() (breez_sdk_spark.SparkStatus, error)
+	httpClient    *http.Client
+	ratesUpdater  *rates.RateUpdater
+	btcCoin       coin.Coin
+	sdkStatus     SDKStatus
+	sdkStatusLock sync.RWMutex
 
 	runtimeDependenciesLock sync.RWMutex
 
@@ -98,7 +111,7 @@ func NewLightning(config *config.Config,
 	httpClient *http.Client,
 	ratesUpdater *rates.RateUpdater,
 	btcCoin coin.Coin) *Lightning {
-	return &Lightning{
+	lightning := &Lightning{
 		backendConfig:          config,
 		lightningDirectoryPath: lightningDirectoryPath,
 		environment:            environment,
@@ -110,7 +123,12 @@ func NewLightning(config *config.Config,
 		httpClient:             httpClient,
 		ratesUpdater:           ratesUpdater,
 		btcCoin:                btcCoin,
+		sdkStatus:              SDKStatusInactive,
 	}
+	if lightning.Account() != nil {
+		lightning.sdkStatus = SDKStatusInitializing
+	}
+	return lightning
 }
 
 // SetRuntimeDependencies updates dependencies that are recreated when the backend cache is cleared.
@@ -212,8 +230,8 @@ func (lightning *Lightning) Disconnect() {
 		lightning.sdkService.Destroy()
 		lightning.sdkService = nil
 		lightning.synced = false
-		lightning.notifyReady()
 	}
+	lightning.setSDKStatus(SDKStatusInactive)
 }
 
 // Deactivate changes the config to inactive, disconnects the instance and deletes its storage folder.
@@ -243,24 +261,36 @@ func (lightning *Lightning) Deactivate() error {
 	return nil
 }
 
-// CheckActive returns an error if the lightning service has not been activated.
+// CheckActive returns an error unless the Lightning SDK is ready for requests.
 func (lightning *Lightning) CheckActive() error {
-	if lightning.Account() == nil || lightning.sdkService == nil {
+	if lightning.SDKStatus() != SDKStatusReady {
 		return errp.New("Lightning not initialized")
 	}
 	return nil
 }
 
-// Ready returns true if the lightning account is configured and the SDK is connected.
-func (lightning *Lightning) Ready() bool {
-	return lightning.Account() != nil && lightning.sdkService != nil
+// SDKStatus returns the state of the Lightning SDK initialization attempt.
+func (lightning *Lightning) SDKStatus() SDKStatus {
+	lightning.sdkStatusLock.RLock()
+	defer lightning.sdkStatusLock.RUnlock()
+	if lightning.sdkStatus == "" {
+		return SDKStatusInactive
+	}
+	return lightning.sdkStatus
 }
 
-func (lightning *Lightning) notifyReady() {
+func (lightning *Lightning) setSDKStatus(status SDKStatus) {
+	lightning.sdkStatusLock.Lock()
+	if lightning.sdkStatus == status {
+		lightning.sdkStatusLock.Unlock()
+		return
+	}
+	lightning.sdkStatus = status
+	lightning.sdkStatusLock.Unlock()
 	lightning.Notify(observable.Event{
-		Subject: "lightning/ready",
+		Subject: "lightning/sdk-status",
 		Action:  action.Replace,
-		Object:  lightning.Ready(),
+		Object:  status,
 	})
 }
 
@@ -370,10 +400,16 @@ func accountBreezFolder(accountCode types.Code) string {
 }
 
 // connect initializes the connection configuration and calls connect to create a Breez SDK instance.
-func (lightning *Lightning) connect() error {
+func (lightning *Lightning) connect() (returnErr error) {
 	account := lightning.Account()
 
 	if account != nil && lightning.sdkService == nil {
+		lightning.setSDKStatus(SDKStatusInitializing)
+		defer func() {
+			if returnErr != nil {
+				lightning.setSDKStatus(SDKStatusFailed)
+			}
+		}()
 		initializeLogging(lightning.log)
 
 		workingDir := path.Join(lightning.lightningDirectoryPath, accountBreezFolder(account.Code))
@@ -442,7 +478,7 @@ func (lightning *Lightning) connect() error {
 		}
 
 		lightning.sdkService = sdk
-		lightning.notifyReady()
+		lightning.setSDKStatus(SDKStatusReady)
 		lightning.NotifyBalanceReload()
 		if _, err := lightning.ensureLightningAddress(); err != nil {
 			lightning.log.WithError(err).Warn("BreezSDK: Error ensuring lightning address")
@@ -587,7 +623,14 @@ func (lightning *Lightning) SetAccount(account *config.LightningAccountConfig) e
 		Subject: "lightning/account",
 		Action:  action.Reload,
 	})
-	lightning.notifyReady()
+	switch {
+	case account == nil:
+		lightning.setSDKStatus(SDKStatusInactive)
+	case lightning.sdkService != nil:
+		lightning.setSDKStatus(SDKStatusReady)
+	default:
+		lightning.setSDKStatus(SDKStatusInitializing)
+	}
 
 	return nil
 }

--- a/backend/lightning/lightning_test.go
+++ b/backend/lightning/lightning_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/test"
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 	"github.com/stretchr/testify/require"
@@ -139,9 +140,10 @@ func TestSetAccount(t *testing.T) {
 	require.Empty(t, lightning.backendConfig.LightningConfig().Accounts)
 }
 
-func TestReady(t *testing.T) {
+func TestSDKStatusAndCheckActive(t *testing.T) {
 	lightning := newTestLightning(t, nil)
-	require.False(t, lightning.Ready())
+	require.Equal(t, SDKStatusInactive, lightning.SDKStatus())
+	require.Error(t, lightning.CheckActive())
 
 	require.NoError(t, lightning.SetAccount(&config.LightningAccountConfig{
 		Seed:            "test mnemonic",
@@ -149,13 +151,57 @@ func TestReady(t *testing.T) {
 		Code:            "v0-deadbeef-ln-0",
 		Number:          0,
 	}))
-	require.False(t, lightning.Ready())
+	require.Equal(t, SDKStatusInitializing, lightning.SDKStatus())
+	require.Error(t, lightning.CheckActive())
 
 	lightning.sdkService = &breez_sdk_spark.BreezSdk{}
-	require.True(t, lightning.Ready())
+	lightning.setSDKStatus(SDKStatusReady)
+	require.Equal(t, SDKStatusReady, lightning.SDKStatus())
+	require.NoError(t, lightning.CheckActive())
+	require.NoError(t, lightning.SetAccount(lightning.Account()))
+	require.Equal(t, SDKStatusReady, lightning.SDKStatus())
 
 	require.NoError(t, lightning.SetAccount(nil))
-	require.False(t, lightning.Ready())
+	require.Equal(t, SDKStatusInactive, lightning.SDKStatus())
+	require.Error(t, lightning.CheckActive())
+}
+
+func TestSDKStatusNotifications(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	var statuses []SDKStatus
+	lightning.Observe(func(event observable.Event) {
+		if event.Subject == "lightning/sdk-status" {
+			statuses = append(statuses, event.Object.(SDKStatus))
+		}
+	})
+
+	require.NoError(t, lightning.SetAccount(&config.LightningAccountConfig{Code: "v0-test-ln-0"}))
+	lightning.setSDKStatus(SDKStatusReady)
+	lightning.setSDKStatus(SDKStatusReady)
+	lightning.setSDKStatus(SDKStatusFailed)
+	require.NoError(t, lightning.SetAccount(nil))
+
+	require.Equal(t, []SDKStatus{
+		SDKStatusInitializing,
+		SDKStatusReady,
+		SDKStatusFailed,
+		SDKStatusInactive,
+	}, statuses)
+}
+
+func TestBalanceFailureDoesNotChangeSDKStatus(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	require.NoError(t, lightning.SetAccount(&config.LightningAccountConfig{Code: "v0-test-ln-0"}))
+	lightning.sdkService = &testBreezSDK{
+		getInfo: func(breez_sdk_spark.GetInfoRequest) (breez_sdk_spark.GetInfoResponse, error) {
+			return breez_sdk_spark.GetInfoResponse{}, errors.New("get info failed")
+		},
+	}
+	lightning.setSDKStatus(SDKStatusReady)
+
+	_, err := lightning.Balance()
+	require.Error(t, err)
+	require.Equal(t, SDKStatusReady, lightning.SDKStatus())
 }
 
 func TestAddressDomain(t *testing.T) {

--- a/backend/lightning/payments_test.go
+++ b/backend/lightning/payments_test.go
@@ -209,6 +209,7 @@ func TestTransactions(t *testing.T) {
 			}, nil
 		},
 	}
+	lightning.setSDKStatus(SDKStatusReady)
 
 	txs, err := lightning.Transactions()
 	require.NoError(t, err)
@@ -468,6 +469,7 @@ func makeActiveLightningWithSDK(t *testing.T, sdk breezSDK) *Lightning {
 		Code:            "v0-deadbeef-ln-0",
 		Number:          0,
 	}))
+	lightning.setSDKStatus(SDKStatusReady)
 	return lightning
 }
 
@@ -1222,6 +1224,7 @@ func newActivePaymentTestLightningWithConfigFilename(
 		Number:          0,
 	}))
 	lightning.sdkService = sdk
+	lightning.setSDKStatus(SDKStatusReady)
 	lightning.getAccount = func(accountCode accountsTypes.Code) (accounts.Interface, error) {
 		require.Equal(t, testCloseWithdrawDestinationAccountCode, accountCode)
 		return testCloseWithdrawAccount(), nil
@@ -2190,6 +2193,7 @@ func TestReceivePaymentAllowsAmountAboveBalanceLimit(t *testing.T) {
 	require.NoError(t, lightning.SetAccount(&config.LightningAccountConfig{Code: "v0-test-ln-0"}))
 	sdk := &receivePaymentTestSDK{}
 	lightning.sdkService = sdk
+	lightning.setSDKStatus(SDKStatusReady)
 	amountSat := uint64(lightningBalanceLimitSat + 1)
 
 	response, err := lightning.ReceivePayment(amountSat, "Over-limit invoice")

--- a/backend/lightning_test.go
+++ b/backend/lightning_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/rates"
 	"github.com/stretchr/testify/require"
 )
@@ -35,14 +36,21 @@ func TestFormattedLightningBalance(t *testing.T) {
 	require.Equal(t, "21.00", balance.FormattedAmount.Conversions["USD"])
 }
 
-func TestLightningFormattedBalanceWithoutAccount(t *testing.T) {
+func TestPortfolioDataWithInitializingLightning(t *testing.T) {
 	b := newBackend(t, testnetDisabled, regtestDisabled)
 	defer b.Close()
 
-	balance, err := b.lightningFormattedBalance()
+	require.NoError(t, b.lightning.SetAccount(&config.LightningAccountConfig{Code: "v0-test-ln-0"}))
 
+	balances, err := b.coinsTotalBalance()
 	require.NoError(t, err)
-	require.Nil(t, balance)
+	require.Equal(t, []coinFormattedAmount{{
+		CoinCode: coinCodeLightning,
+		CoinName: "Lightning",
+	}}, balances)
+
+	_, err = b.ChartData()
+	require.NoError(t, err)
 }
 
 func TestInsertLightningFormattedBalance(t *testing.T) {

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -31,6 +31,8 @@ export type TLightningAccount = {
   num: number;
 };
 
+export type TLightningSDKStatus = 'inactive' | 'initializing' | 'ready' | 'failed';
+
 export type TLightningBolt11Invoice = {
   invoice: string;
   description?: string;
@@ -296,8 +298,8 @@ export const postRegisterLightningAddress = async (username: string): Promise<st
   );
 };
 
-export const getLightningReady = async (): Promise<boolean> => {
-  return getApiResponse<boolean>('lightning/ready', 'Error calling getLightningReady');
+export const getLightningSDKStatus = async (): Promise<TLightningSDKStatus> => {
+  return getApiResponse<TLightningSDKStatus>('lightning/sdk-status', 'Error calling getLightningSDKStatus');
 };
 
 export const postActivate = async (): Promise<void> => {
@@ -411,8 +413,8 @@ export const subscribeLightningAddress = (cb: TSubscriptionCallback<string | nul
   return subscribeEndpoint('lightning/address', cb);
 };
 
-export const subscribeLightningReady = (cb: TSubscriptionCallback<boolean>): TUnsubscribe => {
-  return subscribeEndpoint('lightning/ready', cb);
+export const subscribeLightningSDKStatus = (cb: TSubscriptionCallback<TLightningSDKStatus>): TUnsubscribe => {
+  return subscribeEndpoint('lightning/sdk-status', cb);
 };
 
 export const subscribeListPayments = (cb: TSubscriptionCallback<TLightningPayment[]>) => {

--- a/frontends/web/src/components/balance/balance.tsx
+++ b/frontends/web/src/components/balance/balance.tsx
@@ -10,13 +10,27 @@ import style from './balance.module.css';
 type TProps = {
   balance?: TBalance;
   className?: string;
+  unavailable?: boolean;
 };
 
 export const Balance = ({
   balance,
   className = '',
+  unavailable,
 }: TProps) => {
   const { t } = useTranslation();
+  if (unavailable) {
+    return (
+      <header className={`${style.balanceContainer || ''} ${className}`}>
+        <SubTitle className={style.availableBalanceTitle}>
+          {t('accountSummary.availableBalance')}
+        </SubTitle>
+        <div className={style.balance} data-testid="availableBalance">
+          ---
+        </div>
+      </header>
+    );
+  }
   if (!balance) {
     return (
       <BalanceSkeleton />

--- a/frontends/web/src/contexts/LightningContext.tsx
+++ b/frontends/web/src/contexts/LightningContext.tsx
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createContext } from 'react';
-import { TLightningAccount } from '@/api/lightning';
+import { TLightningAccount, TLightningSDKStatus } from '@/api/lightning';
 
 type Props = {
   isLightningReady: boolean | undefined;
   lightningAccount: TLightningAccount | null | undefined;
+  lightningSDKStatus: TLightningSDKStatus | undefined;
 };
 
 export const LightningContext = createContext<Props>({} as Props);

--- a/frontends/web/src/contexts/LightningProvider.tsx
+++ b/frontends/web/src/contexts/LightningProvider.tsx
@@ -2,7 +2,12 @@
 
 import { ReactNode } from 'react';
 import { LightningContext } from './LightningContext';
-import { getLightningAccount, getLightningReady, subscribeLightningAccount, subscribeLightningReady } from '../api/lightning';
+import {
+  getLightningAccount,
+  getLightningSDKStatus,
+  subscribeLightningAccount,
+  subscribeLightningSDKStatus,
+} from '../api/lightning';
 import { useSync } from '../hooks/api';
 import { isLightningFeatureAvailable } from '@/utils/env';
 
@@ -16,16 +21,23 @@ export const LightningProvider = ({ children }: TProps) => {
     lightningFeatureAvailable ? getLightningAccount : null,
     lightningFeatureAvailable ? subscribeLightningAccount : null,
   );
-  const isLightningReady = useSync(
-    lightningFeatureAvailable ? getLightningReady : null,
-    lightningFeatureAvailable ? subscribeLightningReady : null,
+  const sdkStatus = useSync(
+    lightningFeatureAvailable ? getLightningSDKStatus : null,
+    lightningFeatureAvailable ? subscribeLightningSDKStatus : null,
+  );
+  const lightningSDKStatus = lightningFeatureAvailable ? sdkStatus : 'inactive';
+  const isLightningReady = (
+    lightningSDKStatus === undefined
+      ? undefined
+      : lightningSDKStatus === 'ready'
   );
 
   return (
     <LightningContext.Provider
       value={{
-        isLightningReady: lightningFeatureAvailable ? isLightningReady : false,
+        isLightningReady,
         lightningAccount: lightningFeatureAvailable ? lightningAccount : null,
+        lightningSDKStatus,
       }}>
       {children}
     </LightningContext.Provider>

--- a/frontends/web/src/hooks/lightning.ts
+++ b/frontends/web/src/hooks/lightning.ts
@@ -4,6 +4,6 @@ import { useContext } from 'react';
 import { LightningContext } from '../contexts/LightningContext';
 
 export const useLightning = () => {
-  const { isLightningReady, lightningAccount } = useContext(LightningContext);
-  return { isLightningReady, lightningAccount };
+  const { isLightningReady, lightningAccount, lightningSDKStatus } = useContext(LightningContext);
+  return { isLightningReady, lightningAccount, lightningSDKStatus };
 };

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1067,6 +1067,7 @@
     "spend_bitcoin": "Spend bitcoin",
     "spend_crypto": "Spend crypto",
     "swap": "Swap",
+    "unavailable": "Unavailable",
     "unknown": "Unknown"
   },
   "genericError": "An error occurred. If you notice any issues, please restart the application.",
@@ -1762,6 +1763,7 @@
         "title": "Trust model"
       }
     },
+    "initializationFailed": "Something went wrong while initializing Lightning. Please restart the BitBoxApp to try again.",
     "initializing": "Lightning account initializing...",
     "limit": {
       "accountWarning": "Wallet amount exceeds {{limit}} limit by {{excess}}. We recommend you move some coins to your BitBox wallet for improved security.",

--- a/frontends/web/src/routes/account/summary/accountssummary.module.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.module.css
@@ -56,6 +56,18 @@
     min-height: 46px;
 }
 
+.assetBalanceWarning {
+    height: 24px;
+    width: 24px;
+}
+
+.assetBalanceUnavailable {
+    align-items: center;
+    display: flex;
+    gap: var(--space-quarter);
+    margin: auto 0;
+}
+
 .keystoreContainer {
     display: flex;
     flex-direction: column;

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -43,7 +43,7 @@ export const AccountsSummary = ({
   const mounted = useMountedRef();
   const { hideAmounts } = useContext(AppContext);
   const { defaultCurrency } = useContext(RatesContext);
-  const { lightningAccount } = useLightning();
+  const { lightningAccount, lightningSDKStatus } = useLightning();
 
   const accountsByKeystore = getAccountsByKeystore(accounts);
   const hasActiveBitcoinAccount = accounts.some(account => account.active && isBitcoinOnly(account.coinCode));
@@ -234,6 +234,7 @@ export const AccountsSummary = ({
                 <TotalBalanceForAllKeystores
                   hideHeader={hasOnlyLightningAccount}
                   hideLightningUnitPrice={hasActiveBitcoinAccount}
+                  lightningSDKStatus={lightningSDKStatus}
                   summaryData={chartData}
                   coinsBalances={coinsTotalBalance}
                 />

--- a/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.tsx
+++ b/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.tsx
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ReactNode, useContext } from 'react';
+import { useTranslation } from 'react-i18next';
 import { CoinCode, CoinUnit, TAmountWithConversions } from '@/api/account';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
+import { StatusWarning } from '@/components/icon';
 import { Logo } from '@/components/icon/logo';
 import { Skeleton } from '@/components/skeleton/skeleton';
 import { RatesContext } from '@/contexts/RatesContext';
@@ -16,6 +18,7 @@ type TProps = {
   coinName: ReactNode;
   coinUnit?: CoinUnit;
   dataTestId?: string;
+  unavailableLabel?: string;
   showUnitPrice?: boolean;
 };
 
@@ -25,8 +28,10 @@ export const AssetBalanceWithUnitPrice = ({
   coinName,
   coinUnit,
   dataTestId,
+  unavailableLabel,
   showUnitPrice = true,
 }: TProps) => {
+  const { t } = useTranslation();
   const { defaultCurrency } = useContext(RatesContext);
   const unitPrice = useCoinUnitPrice(coinCode, amount?.unit ?? coinUnit);
   const shouldShowUnitPrice = (
@@ -64,19 +69,32 @@ export const AssetBalanceWithUnitPrice = ({
             )}
           </div>
           <div className={style.assetBalanceAmounts}>
-            {amount ? (
-              <span className={style.assetBalanceAmountFixed}>
-                <AmountWithUnit maxDecimals={9} amount={amount} />
-              </span>
+            {unavailableLabel ? (
+              <div className={style.assetBalanceUnavailable}>
+                <span>{t('generic.unavailable')}</span>
+                <StatusWarning
+                  alt={unavailableLabel}
+                  className={style.assetBalanceWarning}
+                  title={unavailableLabel}
+                />
+              </div>
             ) : (
-              <Skeleton minWidth="60px" />
-            )}
-            {amount ? (
-              <span className={style.assetBalanceAmountFixed} data-testid="fiat-balance">
-                <AmountWithUnit amount={amount} convertToFiat />
-              </span>
-            ) : (
-              <Skeleton minWidth="60px" />
+              <>
+                {amount ? (
+                  <span className={style.assetBalanceAmountFixed}>
+                    <AmountWithUnit maxDecimals={9} amount={amount} />
+                  </span>
+                ) : (
+                  <Skeleton minWidth="60px" />
+                )}
+                {amount ? (
+                  <span className={style.assetBalanceAmountFixed} data-testid="fiat-balance">
+                    <AmountWithUnit amount={amount} convertToFiat />
+                  </span>
+                ) : (
+                  <Skeleton minWidth="60px" />
+                )}
+              </>
             )}
           </div>
         </div>

--- a/frontends/web/src/routes/account/summary/total-balance-for-all-keystores.test.tsx
+++ b/frontends/web/src/routes/account/summary/total-balance-for-all-keystores.test.tsx
@@ -39,7 +39,7 @@ const chartData = (chartFiat: Fiat): TChartData => ({
   lastTimestamp: 0,
 });
 
-const btcBalance: CoinFormattedAmount = {
+const btcBalance = {
   coinCode: 'btc',
   coinName: 'Bitcoin',
   formattedAmount: {
@@ -52,7 +52,7 @@ const btcBalance: CoinFormattedAmount = {
     },
     estimated: false,
   },
-};
+} satisfies CoinFormattedAmount;
 
 const bitcoinBalance = (
   coinCode: CoinCode,

--- a/frontends/web/src/routes/account/summary/total-balance-for-all-keystores.tsx
+++ b/frontends/web/src/routes/account/summary/total-balance-for-all-keystores.tsx
@@ -4,6 +4,7 @@ import type { KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import * as accountApi from '@/api/account';
+import type { TLightningSDKStatus } from '@/api/lightning';
 import { Skeleton } from '@/components/skeleton/skeleton';
 import { BalanceSection } from './balance-section';
 import { AssetBalanceWithUnitPrice } from './asset-balance-with-unit-price';
@@ -16,6 +17,7 @@ type TCoinBalance = accountApi.CoinFormattedOptionalAmount & {
 type TProps = {
   hideHeader?: boolean;
   hideLightningUnitPrice?: boolean;
+  lightningSDKStatus?: TLightningSDKStatus;
   summaryData?: accountApi.TChartData;
   coinsBalances?: TCoinBalance[];
 };
@@ -23,6 +25,7 @@ type TProps = {
 export const TotalBalanceForAllKeystores = ({
   hideHeader,
   hideLightningUnitPrice,
+  lightningSDKStatus,
   summaryData,
   coinsBalances,
 }: TProps) => {
@@ -66,6 +69,9 @@ export const TotalBalanceForAllKeystores = ({
               coinName={balance.coinName}
               coinUnit={balance.coinUnit}
               showUnitPrice={!isLightning || !hideLightningUnitPrice}
+              unavailableLabel={isLightning && lightningSDKStatus === 'failed'
+                ? t('lightning.initializationFailed')
+                : undefined}
             />
           </div>
         );

--- a/frontends/web/src/routes/lightning/lightning.test.tsx
+++ b/frontends/web/src/routes/lightning/lightning.test.tsx
@@ -21,6 +21,7 @@ type TLightningState = {
     num: number;
     rootFingerprint: string;
   } | null | undefined;
+  lightningSDKStatus: lightningApi.TLightningSDKStatus | undefined;
 };
 
 const useLightningMock = vi.hoisted(() => vi.fn<() => TLightningState>());
@@ -101,6 +102,7 @@ describe('Lightning funding limit', () => {
     useLightningMock.mockReturnValue({
       isLightningReady: true,
       lightningAccount: { code: 'v0-test-ln-0', num: 0, rootFingerprint: 'f23ab988' },
+      lightningSDKStatus: 'ready',
     });
     vi.spyOn(devicesApi, 'getDeviceList').mockResolvedValue({});
     vi.spyOn(lightningApi, 'getBlockExplorerTxPrefix').mockResolvedValue('https://example.com/tx/');
@@ -126,6 +128,7 @@ describe('Lightning funding limit', () => {
     useLightningMock.mockReturnValue({
       isLightningReady: undefined,
       lightningAccount: undefined,
+      lightningSDKStatus: undefined,
     });
     const pendingRequest = new Promise<never>(() => {});
     vi.mocked(lightningApi.getBlockExplorerTxPrefix).mockReturnValue(pendingRequest);

--- a/frontends/web/src/routes/lightning/lightning.tsx
+++ b/frontends/web/src/routes/lightning/lightning.tsx
@@ -26,7 +26,7 @@ import { Status } from '../../components/status/status';
 import { HideAmountsButton } from '../../components/hideamountsbutton/hideamountsbutton';
 import { PaymentDetails } from './components/payment-details';
 import { RatesContext } from '@/contexts/RatesContext';
-import { useLoad, useSync } from '@/hooks/api';
+import { useLoad, useSubscribe } from '@/hooks/api';
 import { useMountedRef } from '@/hooks/mount';
 import { useLightning } from '@/hooks/lightning';
 import { Link } from 'react-router-dom';
@@ -67,14 +67,16 @@ const bitcoinDepositTransactionStatus = (
 type TLightningPageLayoutProps = {
   accountDataLoaded: boolean;
   balance?: TLightningBalance;
+  balanceUnavailable?: boolean;
   canSend?: boolean;
-  children: ReactNode;
+  children?: ReactNode;
   statusBanners: ReactNode;
 };
 
 const LightningPageLayout = ({
   accountDataLoaded,
   balance,
+  balanceUnavailable,
   canSend,
   children,
   statusBanners,
@@ -110,7 +112,11 @@ const LightningPageLayout = ({
           <View>
             <ViewHeader>
               <div className={accountStyle.balanceHeader}>
-                <Balance balance={balance} className={style.fadeIn} />
+                <Balance
+                  balance={balance}
+                  className={style.fadeIn}
+                  unavailable={balanceUnavailable}
+                />
                 <ActionButtons
                   accountDataLoaded={accountDataLoaded}
                   canSend={canSend}
@@ -118,9 +124,11 @@ const LightningPageLayout = ({
                 />
               </div>
             </ViewHeader>
-            <ViewContent>
-              {children}
-            </ViewContent>
+            {children !== undefined && (
+              <ViewContent>
+                {children}
+              </ViewContent>
+            )}
           </View>
         </Main>
       </GuidedContent>
@@ -297,8 +305,21 @@ const LightningInner = ({
 export const Lightning = () => {
   const { t } = useTranslation();
   const { btcUnit } = useContext(RatesContext);
-  const { isLightningReady, lightningAccount } = useLightning();
-  const balance = useSync(getLightningBalance, subscribeLightningBalance);
+  const { isLightningReady, lightningAccount, lightningSDKStatus } = useLightning();
+  const loadLightningBalance = useCallback(async () => {
+    try {
+      return await getLightningBalance();
+    } catch (err) {
+      console.error(err);
+      return undefined;
+    }
+  }, []);
+  const loadedBalance = useLoad(
+    isLightningReady ? loadLightningBalance : null,
+    [isLightningReady, loadLightningBalance]
+  );
+  const subscribedBalance = useSubscribe(subscribeLightningBalance);
+  const balance = isLightningReady ? subscribedBalance ?? loadedBalance : undefined;
   const [syncedAddressesCount] = useState<number>();
   const [payments, setPayments] = useState<TLightningPayment[]>();
   const [sparkStatus, setSparkStatus] = useState<TSparkStatus>();
@@ -366,6 +387,12 @@ export const Lightning = () => {
         {t('lightning.betaWarning')}
       </Status>
       <Status
+        hidden={lightningSDKStatus !== 'failed'}
+        dismissibleKey=""
+        type="warning">
+        {t('lightning.initializationFailed')}
+      </Status>
+      <Status
         hidden={sparkStatus === undefined || sparkStatus.status === 'operational'}
         dismissibleKey=""
         type={sparkStatus?.status === 'major' ? 'error' : 'warning'}>
@@ -393,8 +420,8 @@ export const Lightning = () => {
   }
   if (
     lightningAccount === undefined
-    || isLightningReady === undefined
-    || (lightningAccount && !isLightningReady)
+    || lightningSDKStatus === undefined
+    || (lightningAccount && lightningSDKStatus === 'initializing')
   ) {
     return (
       <LightningPageLayout
@@ -403,6 +430,15 @@ export const Lightning = () => {
       >
         <Spinner text={t('lightning.initializing')} />
       </LightningPageLayout>
+    );
+  }
+  if (lightningSDKStatus === 'failed') {
+    return (
+      <LightningPageLayout
+        accountDataLoaded={false}
+        balanceUnavailable
+        statusBanners={statusBanners}
+      />
     );
   }
 


### PR DESCRIPTION
Keep shared portfolio and chart requests usable when Lightning initialization or balance loading fails. Expose SDK status so the UI can warn the user and recommend restarting without blocking the rest of the app.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
