### PR TITLE
[wip] frontend: enable camera input switch and tap to focus

### DIFF
--- a/frontends/web/src/hooks/qrcodescanner.ts
+++ b/frontends/web/src/hooks/qrcodescanner.ts
@@ -4,12 +4,104 @@ import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
 import QrScanner from 'qr-scanner';
 import { useTranslation } from 'react-i18next';
 
+type TPoint = {
+  x: number;
+  y: number;
+};
+
+type TCameraFacingMode = 'environment' | 'user';
+
+type TCameraCapabilities = MediaTrackCapabilities & {
+  focusMode?: string[];
+};
+
+type TCameraConstraints = MediaTrackConstraintSet & {
+  focusMode?: 'single-shot' | 'continuous';
+  pointsOfInterest?: TPoint[];
+  torch?: boolean;
+};
+
+type TSupportedCameraConstraints = MediaTrackSupportedConstraints & {
+  pointsOfInterest?: boolean;
+};
+
 type TUseQRScannerOptions = {
   onStart?: () => void;
   onResult: (result: QrScanner.ScanResult) => void;
-  onError: (error: any) => void;
+  onError: (error: unknown) => void;
   scanRegionCenterY?: number;
   stopOnResult?: boolean;
+};
+
+const getVideoTrack = (video: HTMLVideoElement | null): MediaStreamTrack | undefined => {
+  const stream = video?.srcObject;
+  if (!stream || typeof (stream as MediaStream).getVideoTracks !== 'function') {
+    return undefined;
+  }
+  return (stream as MediaStream).getVideoTracks()[0];
+};
+
+const getFocusMode = (
+  track: MediaStreamTrack,
+): 'single-shot' | 'continuous' | undefined => {
+  try {
+    const capabilities = track.getCapabilities() as TCameraCapabilities;
+    if (capabilities.focusMode?.includes('single-shot')) {
+      return 'single-shot';
+    }
+    if (capabilities.focusMode?.includes('continuous')) {
+      return 'continuous';
+    }
+  } catch {
+    // Camera controls are optional; scanning still works without them.
+  }
+  return undefined;
+};
+
+const isUserFacing = (track: MediaStreamTrack): boolean => {
+  try {
+    const facingMode = track.getSettings().facingMode;
+    if (facingMode) {
+      return facingMode === 'user';
+    }
+  } catch {
+    // Fall back to the device label below.
+  }
+  return /front|user|face/i.test(track.label);
+};
+
+const applyCameraControls = async (
+  track: MediaStreamTrack,
+  controls: TCameraConstraints,
+): Promise<void> => {
+  const constraints = { ...track.getConstraints() };
+  constraints.advanced = [controls];
+  await track.applyConstraints(constraints);
+};
+
+export const cameraPointFromClient = (
+  video: HTMLVideoElement,
+  clientPoint: TPoint,
+  mirrored: boolean,
+): TPoint | undefined => {
+  const rect = video.getBoundingClientRect();
+  if (!rect.width || !rect.height || !video.videoWidth || !video.videoHeight) {
+    return undefined;
+  }
+
+  const scale = Math.max(rect.width / video.videoWidth, rect.height / video.videoHeight);
+  const renderedWidth = video.videoWidth * scale;
+  const renderedHeight = video.videoHeight * scale;
+  const croppedX = (renderedWidth - rect.width) / 2;
+  const croppedY = (renderedHeight - rect.height) / 2;
+  const elementX = Math.min(Math.max(clientPoint.x - rect.left, 0), rect.width);
+  const elementY = Math.min(Math.max(clientPoint.y - rect.top, 0), rect.height);
+  const sourceX = (elementX + croppedX) / renderedWidth;
+
+  return {
+    x: mirrored ? 1 - sourceX : sourceX,
+    y: (elementY + croppedY) / renderedHeight,
+  };
 };
 
 export const useQRScanner = (
@@ -23,8 +115,13 @@ export const useQRScanner = (
 ) => {
   const { t } = useTranslation();
   const [initErrorMessage, setInitErrorMessage] = useState<string | undefined>(undefined);
+  const [cameras, setCameras] = useState<QrScanner.Camera[]>([]);
+  const [cameraFacingMode, setCameraFacingMode] = useState<TCameraFacingMode>('environment');
+  const [selectedCameraId, setSelectedCameraId] = useState('');
+  const [isSwitchingCamera, setIsSwitchingCamera] = useState(false);
   const [hasFlash, setHasFlash] = useState(false);
   const [isFlashOn, setIsFlashOn] = useState(false);
+  const [canFocus, setCanFocus] = useState(false);
   const scanner = useRef<QrScanner | null>(null);
   // loading is set to true while the scanner is being created/started/stopped/destroyed,
   // this allows to sync across re-renders.
@@ -37,6 +134,68 @@ export const useQRScanner = (
   onResultRef.current = onResult;
   onErrorRef.current = onError;
 
+  const refreshCameras = useCallback(async (currentScanner: QrScanner) => {
+    if (scanner.current !== currentScanner) {
+      return;
+    }
+    try {
+      // Request labels because this runs after camera permission has been granted. Some
+      // Chromium-based webviews only expose non-default devices at this point.
+      const availableCameras = await QrScanner.listCameras(true);
+      if (scanner.current !== currentScanner) {
+        return;
+      }
+      setCameras(availableCameras);
+      setSelectedCameraId(
+        getVideoTrack(videoRef.current)?.getSettings().deviceId || availableCameras[0]?.id || ''
+      );
+    } catch {
+      if (scanner.current === currentScanner) {
+        setCameras([]);
+      }
+    }
+  }, [videoRef]);
+
+  const refreshCameraInfo = useCallback(async (currentScanner: QrScanner) => {
+    if (scanner.current !== currentScanner) {
+      return;
+    }
+    const track = getVideoTrack(videoRef.current);
+    setCameraFacingMode(track && isUserFacing(track) ? 'user' : 'environment');
+    setCanFocus(track ? getFocusMode(track) !== undefined : false);
+    setIsFlashOn(false);
+    await Promise.all([
+      refreshCameras(currentScanner),
+      (async () => {
+        try {
+          const flashAvailable = await currentScanner.hasFlash();
+          if (scanner.current === currentScanner) {
+            setHasFlash(flashAvailable);
+          }
+        } catch {
+          if (scanner.current === currentScanner) {
+            setHasFlash(false);
+          }
+        }
+      })(),
+    ]);
+  }, [refreshCameras, videoRef]);
+
+  useEffect(() => {
+    const mediaDevices = navigator.mediaDevices;
+    if (!mediaDevices?.addEventListener) {
+      return;
+    }
+    const handleDeviceChange = () => {
+      const currentScanner = scanner.current;
+      if (currentScanner) {
+        refreshCameras(currentScanner);
+      }
+    };
+    mediaDevices.addEventListener('devicechange', handleDeviceChange);
+    return () => mediaDevices.removeEventListener('devicechange', handleDeviceChange);
+  }, [refreshCameras]);
+
   useEffect(() => {
     (async () => {
       if (!videoRef.current) {
@@ -48,7 +207,7 @@ export const useQRScanner = (
       }
       try {
         loading.current = true;
-        scanner.current = new QrScanner(
+        const currentScanner = new QrScanner(
           videoRef.current,
           result => {
             if (stopOnResult) {
@@ -62,12 +221,12 @@ export const useQRScanner = (
                 onErrorRef.current(err);
               }
             },
-            // disabled bc we draw their own scan overlay.
+            // Disabled because the BitBoxApp draws its own scan overlay.
             highlightScanRegion: false,
             highlightCodeOutline: false,
-            calculateScanRegion: (v) => {
-              const videoWidth = v.videoWidth;
-              const videoHeight = v.videoHeight;
+            calculateScanRegion: (video) => {
+              const videoWidth = video.videoWidth;
+              const videoHeight = video.videoHeight;
               const factor = 0.5;
               const size = Math.floor(Math.min(videoWidth, videoHeight) * factor);
               const y = Math.min(
@@ -83,22 +242,19 @@ export const useQRScanner = (
             }
           }
         );
+        scanner.current = currentScanner;
         // Somehow, the new QrScanner may return before it is ready to be started.
         // We don't have a way to know when it is ready, but this 300ms wait seems
         // to work well enough.
         await new Promise(r => setTimeout(r, 300));
-        await scanner.current?.start();
+        await currentScanner.start();
         loading.current = false;
-        try {
-          setHasFlash(await scanner.current?.hasFlash() ?? false);
-        } catch {
-          setHasFlash(false);
+        await refreshCameraInfo(currentScanner);
+        if (scanner.current === currentScanner) {
+          onStartRef.current?.();
         }
-        if (onStartRef.current) {
-          onStartRef.current();
-        }
-      } catch (error: any) {
-        const stringifiedError = error.toString();
+      } catch (error) {
+        const stringifiedError = String(error);
         loading.current = false;
         const cameraNotFound = stringifiedError === 'Camera not found.';
         setInitErrorMessage(cameraNotFound ? t('send.scanQRNoCameraMessage') : stringifiedError);
@@ -113,33 +269,89 @@ export const useQRScanner = (
         }
         if (scanner.current) {
           loading.current = true;
-          await scanner.current?.pause(true);
-          await scanner.current?.stop();
-          await scanner.current?.destroy();
+          await scanner.current.pause(true);
+          scanner.current.stop();
+          scanner.current.destroy();
           scanner.current = null;
           loading.current = false;
         }
       })();
     };
-  }, [videoRef, scanRegionCenterY, stopOnResult, t]);
+  }, [refreshCameraInfo, scanRegionCenterY, stopOnResult, t, videoRef]);
 
-  const toggleFlash = useCallback(async () => {
-    const stream = videoRef.current?.srcObject;
-    if (!(stream instanceof MediaStream)) {
+  const switchCamera = useCallback(async (camera: string) => {
+    const currentScanner = scanner.current;
+    if (!currentScanner || !camera) {
       return;
     }
-    const track = stream.getVideoTracks()[0];
+    setIsSwitchingCamera(true);
+    try {
+      await currentScanner.setCamera(camera);
+      if (scanner.current === currentScanner) {
+        await refreshCameraInfo(currentScanner);
+      }
+    } catch (error) {
+      onErrorRef.current(error);
+    } finally {
+      if (scanner.current === currentScanner) {
+        setIsSwitchingCamera(false);
+      }
+    }
+  }, [refreshCameraInfo]);
+
+  const toggleFlash = useCallback(async () => {
+    const track = getVideoTrack(videoRef.current);
     if (!track) {
       return;
     }
     const nextOn = !isFlashOn;
     try {
-      await track.applyConstraints({ advanced: [{ torch: nextOn }] } as unknown as MediaTrackConstraints);
+      await applyCameraControls(track, { torch: nextOn });
       setIsFlashOn(nextOn);
     } catch (error) {
-      console.error(error);
+      onErrorRef.current(error);
     }
-  }, [videoRef, isFlashOn]);
+  }, [isFlashOn, videoRef]);
 
-  return { initErrorMessage, hasFlash, isFlashOn, toggleFlash };
+  const focusAt = useCallback(async (clientPoint: TPoint): Promise<boolean> => {
+    const video = videoRef.current;
+    const track = getVideoTrack(video);
+    if (!video || !track) {
+      return false;
+    }
+    const focusMode = getFocusMode(track);
+    const point = cameraPointFromClient(video, clientPoint, isUserFacing(track));
+    if (!focusMode || !point) {
+      return false;
+    }
+
+    const supportedConstraints = navigator.mediaDevices
+      .getSupportedConstraints() as TSupportedCameraConstraints;
+    const controls: TCameraConstraints = {
+      focusMode,
+      ...(supportedConstraints.pointsOfInterest ? { pointsOfInterest: [point] } : {}),
+      ...(track.getSettings().torch ? { torch: true } : {}),
+    };
+    try {
+      await applyCameraControls(track, controls);
+      return true;
+    } catch (error) {
+      onErrorRef.current(error);
+      return false;
+    }
+  }, [videoRef]);
+
+  return {
+    cameraFacingMode,
+    cameras,
+    canFocus,
+    focusAt,
+    hasFlash,
+    initErrorMessage,
+    isFlashOn,
+    isSwitchingCamera,
+    selectedCameraId,
+    switchCamera,
+    toggleFlash,
+  };
 };

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -2264,6 +2264,8 @@
     "scanQR": "Scan QR code",
     "scanQRInstruction": "Point your camera at an address QR code",
     "scanQRNoCameraMessage": "Camera not found. Please ensure that your device supports a camera and permissions are correctly set.",
+    "scanQRSelectCamera": "Select camera",
+    "scanQRSwitchCamera": "Switch between front and back camera",
     "scanQRToggleFlash": "Toggle flashlight",
     "sendToAccount": {
       "placeholder": "Select account",

--- a/frontends/web/src/routes/account/send/components/inputs/scan-qr.module.css
+++ b/frontends/web/src/routes/account/send/components/inputs/scan-qr.module.css
@@ -51,6 +51,50 @@
   height: 100%;
   object-fit: cover;
 }
+.videoFocusable {
+  cursor: crosshair;
+  touch-action: manipulation;
+}
+
+.focusIndicator {
+  position: absolute;
+  z-index: 1;
+  width: 64px;
+  height: 64px;
+  border: 2px solid var(--scan-qr-foreground);
+  border-radius: 50%;
+  animation: focusCamera 700ms ease-out forwards;
+  pointer-events: none;
+}
+.focusIndicator::before {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--scan-qr-foreground);
+  content: '';
+  transform: translate(-50%, -50%);
+}
+
+@keyframes focusCamera {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.35);
+  }
+  20% {
+    opacity: 1;
+  }
+  70% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+}
 
 .spinnerContainer {
   position: absolute;
@@ -165,6 +209,34 @@
   z-index: 2;
   display: flex;
   gap: var(--space-quarter);
+}
+
+.cameraSelect {
+  width: min(48vw, 220px);
+  height: 44px;
+  overflow: hidden;
+  padding: 0 32px 0 14px;
+  border: none;
+  border-radius: 22px;
+  appearance: none;
+  background-color: var(--scan-qr-control-background);
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 11 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.75 0.75L5.5 5.25L10.25 0.75' stroke='%23ffffff' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: calc(100% - 12px) center;
+  background-repeat: no-repeat;
+  color: var(--scan-qr-foreground);
+  cursor: pointer;
+  font-family: var(--font-family);
+  font-size: var(--size-default);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cameraSelect:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+.cameraSelect option {
+  background-color: var(--scan-qr-background);
+  color: var(--scan-qr-foreground);
 }
 
 .controls button {

--- a/frontends/web/src/routes/account/send/components/inputs/scan-qr.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/scan-qr.tsx
@@ -1,11 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { MouseEvent, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ChangeEvent,
+  MouseEvent,
+  PointerEvent,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { useBackButton } from '@/hooks/backbutton';
 import { useQRScanner } from '@/hooks/qrcodescanner';
-import { CloseXWhite, FlashWhite, FlashYellow } from '@/components/icon';
+import { CloseXWhite, FlashWhite, FlashYellow, SyncLight } from '@/components/icon';
 import { SpinnerRingAnimated } from '@/components/spinner/SpinnerAnimation';
+import { runningOnMobile } from '@/utils/env';
 import { triggerHapticFeedback, triggerLongHapticFeedback } from '@/utils/transport-mobile';
 import style from './scan-qr.module.css';
 
@@ -15,6 +25,12 @@ const FULLSCREEN_SCAN_REGION_CENTER_Y = 0.35;
 
 type TRequestClose = (onClosed?: () => void) => void;
 type TResetLastResult = () => void;
+
+type TFocusIndicator = {
+  id: number;
+  x: number;
+  y: number;
+};
 
 type TProps = {
   onResult: (result: string) => void | boolean | Promise<void | boolean>;
@@ -43,10 +59,12 @@ export const ScanQR = ({
   const [open, setOpen] = useState(false);
   const [cameraReady, setCameraReady] = useState(false);
   const [processing, setProcessing] = useState(false);
+  const [focusIndicator, setFocusIndicator] = useState<TFocusIndicator | null>(null);
   const closingRef = useRef(false);
   const busyRef = useRef(false);
   const processedRef = useRef<string | null>(null);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const focusIndicatorId = useRef(0);
 
   useEffect(() => {
     const raf = requestAnimationFrame(() => setOpen(true));
@@ -99,7 +117,19 @@ export const ScanQR = ({
     }
   }, [onResult, requestClose]);
 
-  const { initErrorMessage, hasFlash, isFlashOn, toggleFlash } = useQRScanner(videoRef, {
+  const {
+    cameraFacingMode,
+    cameras,
+    canFocus,
+    focusAt,
+    hasFlash,
+    initErrorMessage,
+    isFlashOn,
+    isSwitchingCamera,
+    selectedCameraId,
+    switchCamera,
+    toggleFlash,
+  } = useQRScanner(videoRef, {
     onStart: () => setCameraReady(true),
     onResult: result => handleValue(result.data),
     onError: err => console.error(err),
@@ -110,6 +140,34 @@ export const ScanQR = ({
   const handleToggleFlash = () => {
     triggerHapticFeedback();
     toggleFlash();
+  };
+
+  const handleCameraChange = async (event: ChangeEvent<HTMLSelectElement>) => {
+    triggerHapticFeedback();
+    await switchCamera(event.target.value);
+  };
+
+  const handleCameraToggle = async () => {
+    triggerHapticFeedback();
+    await switchCamera(cameraFacingMode === 'user' ? 'environment' : 'user');
+  };
+
+  const handleFocus = async (event: PointerEvent<HTMLVideoElement>) => {
+    if (!canFocus || !event.isPrimary || (event.pointerType === 'mouse' && event.button !== 0)) {
+      return;
+    }
+    const rect = event.currentTarget.getBoundingClientRect();
+    focusIndicatorId.current++;
+    const indicator = {
+      id: focusIndicatorId.current,
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+    setFocusIndicator(indicator);
+    triggerHapticFeedback();
+    if (!await focusAt({ x: event.clientX, y: event.clientY })) {
+      setFocusIndicator(current => current?.id === indicator.id ? null : current);
+    }
   };
 
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
@@ -124,6 +182,7 @@ export const ScanQR = ({
 
   const fullscreenClass = fullscreen ? style.fullscreen || '' : '';
   const content = typeof children === 'function' ? children(requestClose, resetLastResult) : children;
+  const isMobile = runningOnMobile();
 
   return (
     <div
@@ -139,10 +198,26 @@ export const ScanQR = ({
         )}
 
         <video
-          className={style.video}
+          autoPlay
+          className={`${style.video || ''} ${canFocus ? style.videoFocusable || '' : ''}`}
+          disablePictureInPicture
+          muted
+          onPointerDown={handleFocus}
+          playsInline
           ref={videoRef}
           poster="data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%3E%20width=%2264%22%20height=%2248%22%3C/svg%3E"
         />
+
+        {focusIndicator && (
+          <span
+            key={focusIndicator.id}
+            className={style.focusIndicator}
+            onAnimationEnd={() => setFocusIndicator(current => (
+              current?.id === focusIndicator.id ? null : current
+            ))}
+            style={{ left: focusIndicator.x, top: focusIndicator.y }}
+          />
+        )}
 
         <div className={style.overlay}>
           <div className={`${style.focus || ''} ${guideHidden ? style.focusHidden || '' : ''}`}>
@@ -167,15 +242,40 @@ export const ScanQR = ({
           <CloseXWhite />
         </button>
 
-        {hasFlash && (
+        {(cameras.length > 1 || hasFlash) && (
           <div className={style.controls}>
-            <button
-              type="button"
-              onClick={handleToggleFlash}
-              aria-label={t('send.scanQRToggleFlash')}
-              aria-pressed={isFlashOn}>
-              {isFlashOn ? <FlashYellow /> : <FlashWhite />}
-            </button>
+            {cameras.length > 1 && !isMobile && (
+              <select
+                aria-label={t('send.scanQRSelectCamera')}
+                className={style.cameraSelect}
+                disabled={isSwitchingCamera}
+                onChange={handleCameraChange}
+                value={selectedCameraId}>
+                {cameras.map(camera => (
+                  <option key={camera.id} value={camera.id}>
+                    {camera.label}
+                  </option>
+                ))}
+              </select>
+            )}
+            {cameras.length > 1 && isMobile && (
+              <button
+                aria-label={t('send.scanQRSwitchCamera')}
+                disabled={isSwitchingCamera}
+                onClick={handleCameraToggle}
+                type="button">
+                <SyncLight />
+              </button>
+            )}
+            {hasFlash && (
+              <button
+                type="button"
+                onClick={handleToggleFlash}
+                aria-label={t('send.scanQRToggleFlash')}
+                aria-pressed={isFlashOn}>
+                {isFlashOn ? <FlashYellow /> : <FlashWhite />}
+              </button>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
WIP

- Switch to paulmillr-qr library
- Add toggle on mobile to switch between front and rear facing camera
- Add dropdown on desktop to select between camera sources if multiple are available
- On Android, allow tap to focus, helping when trying to frame a dense QR code in focus
