### PR TITLE
tests: add v9.27.1 simulator

### DIFF
--- a/backend/devices/bitbox02/testdata/simulators.json
+++ b/backend/devices/bitbox02/testdata/simulators.json
@@ -38,5 +38,9 @@
     {
         "url": "https://github.com/BitBoxSwiss/bitbox02-firmware/releases/download/firmware%2Fv9.26.5/bitbox02-multi-v9.26.5-simulator1.0.0-linux-amd64",
         "sha256": "21a394c3d7642e0a251b340fba9b601742ae98c3790e439b6258b55e1a4585bf"
+    },
+    {
+        "url": "https://github.com/BitBoxSwiss/bitbox02-firmware/releases/download/firmware%2Fv9.27.1/bitbox02-multi-v9.27.1-simulator1.0.0-linux-amd64",
+        "sha256": "0b049efb21dcf8a447e9f46c660c731e38fb83101023d4f80f1f423ddaa4126b"
     }
 ]


### PR DESCRIPTION
Add the v9.27.1 firmware simulator to the test matrix using the
SHA-256 digest published with the release asset.

Related PRs:

- [bitbox-api-rs #131](https://github.com/BitBoxSwiss/bitbox-api-rs/pull/131)
- [bitbox-api-ts #12](https://github.com/BitBoxSwiss/bitbox-api-ts/pull/12)
- [bitbox02-api-go #185](https://github.com/BitBoxSwiss/bitbox02-api-go/pull/185)
