### PR TITLE
frontend: remove expert section in lighthing settings

### DIFF
--- a/frontends/web/src/routes/settings/lightning-settings.tsx
+++ b/frontends/web/src/routes/settings/lightning-settings.tsx
@@ -6,7 +6,6 @@ import { getLightningBalance, subscribeLightningBalance } from '@/api/lightning'
 import { Header, Main } from '@/components/layout';
 import { View, ViewContent } from '@/components/view/view';
 import { Checked } from '@/components/icon';
-import { SubTitle } from '@/components/title';
 import { getKeystoreName } from '@/api/keystores';
 import { useLoad, useSubscribe } from '@/hooks/api';
 import { useLightning } from '@/hooks/lightning';
@@ -87,7 +86,6 @@ export const LightningSettings = () => {
           settingName={<span>{t('lightning.settings.disableWallet')}</span>}
           onClick={() => navigate('/lightning/deactivate/')}
         />
-        <SubTitle className={styles.sectionTitle}>{t('lightning.settings.expert')}</SubTitle>
         <SettingsItem
           disabled={!lightningBalance?.hasAvailable}
           settingName={<span className={styles.danger}>{t('lightning.settings.closeAndWithdrawFunds')}</span>}


### PR DESCRIPTION
Lightning is already an advanced feature so it does not need to have its own expert setting for closing the wallet.

Closing the wallet should not be an expert feature.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
