### PR TITLE
frontend: always use 256px for lightning receive qr code

### DIFF
--- a/frontends/web/src/components/qrcode/qrcode.module.css
+++ b/frontends/web/src/components/qrcode/qrcode.module.css
@@ -54,6 +54,10 @@
 
 .qrImage {
   border-radius: var(--radius-xl);
+  height: auto;
+  max-width: 100%;
+  max-height: 100vh;
+  width: auto;
 }
 
 .show {

--- a/frontends/web/src/routes/lightning/receive/receive.module.css
+++ b/frontends/web/src/routes/lightning/receive/receive.module.css
@@ -73,6 +73,7 @@
 
 .invoiceQRCode {
     margin-bottom: var(--space-half);
+    max-width: 100%;
 }
 
 .invoiceAmount {

--- a/frontends/web/src/routes/lightning/receive/receive.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.tsx
@@ -169,7 +169,10 @@ export function Receive() {
             <div className={styles.addressContent}>
               <p className={styles.qrInstruction}>{t('lightning.receive.address.scanQRCode')}</p>
               <div className={styles.addressQRCode}>
-                <QRCode data={lightningAddress || undefined} size={168} tapToCopy={false} />
+                <QRCode
+                  data={lightningAddress || undefined}
+                  size={216}
+                  tapToCopy={false} />
               </div>
               {lightningAddress && (
                 <>
@@ -266,7 +269,10 @@ export function Receive() {
             <div className={styles.invoiceContent}>
               <p className={styles.qrInstruction}>{t('lightning.receive.invoice.title')}</p>
               <div className={styles.invoiceQRCode}>
-                <QRCode data={receivePaymentResponse?.invoice} size={216} tapToCopy={false} />
+                <QRCode
+                  data={receivePaymentResponse?.invoice}
+                  size={256}
+                  tapToCopy={false} />
               </div>
               <p className={styles.invoiceAmount}>
                 <span>{inputSatsText} sats</span>


### PR DESCRIPTION
This could be larger, but the backend currently sends an image that is 256px so anything larger would currently look blurry.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
