### PR TITLE
frontend: fix lightning send autocomplete

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1834,7 +1834,7 @@
       "enterInvoice": "Enter address or invoice",
       "invoice": {
         "label": "Enter payment details",
-        "placeholder": "Address or invoice"
+        "placeholder": "Payment info"
       },
       "lnurlPay": {
         "invalidAmount": "Enter an amount between {{minAmount}} and {{maxAmount}} sats."


### PR DESCRIPTION
Somehow the placeholder 'Address or invoice' caused autocompletition.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
