### PR TITLE
lightning: show connect keystore on whitdraw

### DIFF
--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.test.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.test.tsx
@@ -6,6 +6,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TAccount, TAmountWithConversions } from '@/api/account';
+import * as keystoresApi from '@/api/keystores';
 import * as lightningApi from '@/api/lightning';
 import { BackButtonProvider } from '@/contexts/BackButtonContext';
 import { LightningCloseWithdrawFunds } from './close-withdraw-funds';
@@ -69,8 +70,9 @@ const SettingsPage = () => {
   return <button onClick={() => navigate(-1)}>settings back</button>;
 };
 
-describe('Lightning Close & Withdraw back navigation', () => {
+describe('Lightning Close & Withdraw', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
     setMobileViewport();
     vi.mocked(lightningApi.getLightningBalance).mockResolvedValue({
@@ -89,6 +91,56 @@ describe('Lightning Close & Withdraw back navigation', () => {
       fee: amount('100'),
       feeSat: 100,
     });
+  });
+
+  it('prompts to connect a BitBox without leaving close and withdraw when there are no accounts', async () => {
+    const connectAnyKeystore = vi.spyOn(keystoresApi, 'connectAnyKeystore').mockResolvedValue({
+      success: false,
+      errorCode: 'userAbort',
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/lightning/close-withdraw-funds']}>
+        <BackButtonProvider>
+          <Routes>
+            <Route path="/" element={<span>portfolio</span>} />
+            <Route
+              path="/lightning/close-withdraw-funds"
+              element={<LightningCloseWithdrawFunds activeAccounts={[]} hasAccounts={false} />}
+            />
+          </Routes>
+        </BackButtonProvider>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /connect/i }));
+
+    await waitFor(() => expect(connectAnyKeystore).toHaveBeenCalledOnce());
+    expect(screen.getByText('lightning.topUp.noBitcoinAccounts')).toBeInTheDocument();
+    expect(screen.queryByText('portfolio')).not.toBeInTheDocument();
+  });
+
+  it('opens Manage accounts when accounts exist but no Bitcoin account is active', async () => {
+    const connectAnyKeystore = vi.spyOn(keystoresApi, 'connectAnyKeystore');
+
+    render(
+      <MemoryRouter initialEntries={['/lightning/close-withdraw-funds']}>
+        <BackButtonProvider>
+          <Routes>
+            <Route
+              path="/lightning/close-withdraw-funds"
+              element={<LightningCloseWithdrawFunds activeAccounts={[]} hasAccounts />}
+            />
+            <Route path="/settings/manage-accounts" element={<span>manage accounts page</span>} />
+          </Routes>
+        </BackButtonProvider>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /manage/i }));
+
+    expect(await screen.findByText('manage accounts page')).toBeInTheDocument();
+    expect(connectAnyKeystore).not.toHaveBeenCalled();
   });
 
   it('blocks Android back while closing', async () => {

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { connectAnyKeystore } from '@/api/keystores';
 import { getLightningBalance, postCloseWithdraw, postPrepareCloseWithdraw, type TCloseWithdrawQuote } from '@/api/lightning';
 import type { AccountCode, TAccount, TAmountWithConversions } from '@/api/account';
 import { DesktopBackButton } from '@/components/backbutton/backbutton';
@@ -146,6 +147,13 @@ export const LightningCloseWithdrawFunds = ({
   }, [destinationAccountCode, mounted, quote]);
 
   const handleBack = () => navigate(-1);
+  const handleNoBitcoinAccountAction = async () => {
+    if (hasAccounts) {
+      navigate('/settings/manage-accounts');
+      return;
+    }
+    await connectAnyKeystore();
+  };
 
   const headerBackEnabled = (
     !btcAccounts.length
@@ -154,25 +162,14 @@ export const LightningCloseWithdrawFunds = ({
 
   const renderStep = () => {
     if (!btcAccounts.length) {
-      const primaryAction = (
-        hasAccounts
-          ? {
-            label: t('manageAccounts.title'),
-            route: '/settings/manage-accounts',
-          }
-          : {
-            label: t('welcome.connect'),
-            route: '/',
-          }
-      );
       return (
         <View textCenter verticallyCentered>
           <ViewContent>
             <p>{t('lightning.topUp.noBitcoinAccounts')}</p>
           </ViewContent>
           <ViewButtons>
-            <Button primary onClick={() => navigate(primaryAction.route)}>
-              {primaryAction.label}
+            <Button primary onClick={handleNoBitcoinAccountAction}>
+              {hasAccounts ? t('manageAccounts.title') : t('welcome.connect')}
             </Button>
             <DesktopBackButton onClick={handleBack}>
               {t('button.back')}


### PR DESCRIPTION
If the user has no keystore connected, after clicking "connect your bitbox", show the "connectAnyKeystore" popup.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
