### PR TITLE
lightning: report close withdrawal preparation errors

### DIFF
--- a/backend/lightning/payments.go
+++ b/backend/lightning/payments.go
@@ -1053,12 +1053,29 @@ func (lightning *Lightning) PrepareCloseWithdraw(
 		return nil, err
 	}
 	amountSat := availableBalance.BigInt().Uint64()
-	_, fee, err := lightning.prepareBitcoinPayment(
+	prepareResponse, fee, err := lightning.prepareBitcoinPayment(
 		destinationAddress,
 		amountSat,
 		breez_sdk_spark.FeePolicyFeesIncluded,
 	)
 	if err != nil {
+		// Preserve the SDK's preparation reason without its binding error wrapper.
+		var invalidInput *breez_sdk_spark.SdkErrorInvalidInput
+		if errors.As(err, &invalidInput) {
+			return nil, errp.New(invalidInput.Field0)
+		}
+		return nil, err
+	}
+	// The SDK checks the cheapest fee during preparation, but closing uses the fast fee.
+	if err := lightning.validateBitcoinPaymentAmountAgainstDustLimit(
+		destinationAddress,
+		bitcoinPaymentOutputAmountSat(fee, prepareResponse.FeePolicy),
+	); err != nil {
+		var amountBelowMinimum *lightningAmountBelowMinimumError
+		if errors.As(err, &amountBelowMinimum) {
+			// The user approves the full balance, so include fees in its required minimum.
+			return nil, &lightningAmountBelowMinimumError{minAmountSat: amountBelowMinimum.minAmountSat + fee.FeeSat}
+		}
 		return nil, err
 	}
 

--- a/backend/lightning/payments_test.go
+++ b/backend/lightning/payments_test.go
@@ -1894,6 +1894,68 @@ func TestPrepareCloseWithdraw(t *testing.T) {
 	require.Equal(t, quote.IdempotencyKey, retryQuote.IdempotencyKey)
 }
 
+func TestPrepareCloseWithdrawValidatesOutputAfterFastFee(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		balanceSat uint64
+		fastFeeSat uint64
+	}{
+		{balanceSat: 500, fastFeeSat: 200},
+		{balanceSat: 529, fastFeeSat: 200},
+		{balanceSat: 530, fastFeeSat: 200},
+		{balanceSat: 500, fastFeeSat: 600},
+	} {
+		t.Run(fmt.Sprintf("balance=%d fee=%d", testCase.balanceSat, testCase.fastFeeSat), func(t *testing.T) {
+			t.Parallel()
+			sdk := &testPaymentSDK{balanceSats: testCase.balanceSat}
+			sdk.prepareSend = func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+				response := testBitcoinPrepareResponse(testCase.fastFeeSat)
+				response.Amount = new(big.Int).SetUint64(testCase.balanceSat)
+				method := response.PaymentMethod.(breez_sdk_spark.SendPaymentMethodBitcoinAddress)
+				method.FeeQuote.SpeedSlow = breez_sdk_spark.SendOnchainSpeedFeeQuote{UserFeeSat: 99, L1BroadcastFeeSat: 1}
+				response.PaymentMethod = method
+				return response, nil
+			}
+			lightning := newActivePaymentTestLightning(t, sdk)
+
+			quote, err := lightning.PrepareCloseWithdraw(testCloseWithdrawDestinationAccountCode, "")
+			minimumBalanceSat := testCase.fastFeeSat + 330
+			if testCase.balanceSat < minimumBalanceSat {
+				require.Nil(t, quote)
+				var amountBelowMinimum *lightningAmountBelowMinimumError
+				require.ErrorAs(t, err, &amountBelowMinimum)
+				require.Equal(t, minimumBalanceSat, amountBelowMinimum.minAmountSat)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, testCase.fastFeeSat, quote.FeeSat)
+			}
+			require.NotNil(t, lightning.Account())
+			require.False(t, sdk.destroyCalled)
+		})
+	}
+}
+
+func TestPrepareCloseWithdrawPreservesSDKValidationReason(t *testing.T) {
+	t.Parallel()
+
+	const reason = "Amount is below the minimum of 330 sats required for this address after lowest fees of 100 sats"
+	sdk := &testPaymentSDK{
+		balanceSats: 400,
+		prepareSend: func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+			return breez_sdk_spark.PrepareSendPaymentResponse{}, breez_sdk_spark.NewSdkErrorInvalidInput(reason)
+		},
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+
+	quote, err := lightning.PrepareCloseWithdraw(testCloseWithdrawDestinationAccountCode, "")
+	require.Nil(t, quote)
+	require.EqualError(t, err, reason)
+	require.Equal(t, reason, errorResponse(err).ErrorMessage)
+	require.NotNil(t, lightning.Account())
+	require.False(t, sdk.destroyCalled)
+}
+
 func TestCloseWithdraw(t *testing.T) {
 	t.Parallel()
 

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.test.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.test.tsx
@@ -371,7 +371,7 @@ describe('Lightning Close & Withdraw', () => {
     expect(screen.queryByText('lightning.topUp.noBitcoinAccounts')).not.toBeInTheDocument();
   });
 
-  it('keeps failure Cancel in the body and pops back to Lightning Settings', async () => {
+  it('can go back after a preparation error and pop back to Lightning Settings', async () => {
     vi.mocked(lightningApi.postPrepareCloseWithdraw).mockRejectedValue(new Error('prepare failed'));
 
     render(
@@ -396,7 +396,10 @@ describe('Lightning Close & Withdraw', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: 'dialog.cancel' }));
+    expect(await screen.findByText('Error: prepare failed')).toBeInTheDocument();
+    act(() => {
+      expect(window.onBackButtonPressed?.()).toBe(false);
+    });
     fireEvent.click(await screen.findByRole('button', { name: 'settings back' }));
 
     expect(await screen.findByText('advanced settings')).toBeInTheDocument();

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { connectAnyKeystore } from '@/api/keystores';
 import { getLightningBalance, postCloseWithdraw, postPrepareCloseWithdraw, type TCloseWithdrawQuote } from '@/api/lightning';
-import { TLightningErrorCode, TSdkError } from '@/api/lightning-errors';
+import { TLightningErrorCode, TSdkError, toLightningErrorMessage } from '@/api/lightning-errors';
 import type { AccountCode, TAccount, TAmountWithConversions } from '@/api/account';
 import { DesktopBackButton } from '@/components/backbutton/backbutton';
 import { Button } from '@/components/forms';
@@ -47,6 +47,7 @@ export const LightningCloseWithdrawFunds = ({
   const [incoming, setIncoming] = useState<TAmountWithConversions>();
   const [incomingConfirmed, setIncomingConfirmed] = useState(false);
   const [quote, setQuote] = useState<TPreparedQuote>();
+  const [prepareError, setPrepareError] = useState<string>();
   const [isClosing, setIsClosing] = useState(false);
   const [txID, setTxID] = useState<string>();
   const mounted = useMountedRef();
@@ -60,6 +61,7 @@ export const LightningCloseWithdrawFunds = ({
     && (!hasIncoming || incomingConfirmed)
     && !!quote
     && quoteMatchesDestination
+    && !prepareError
     && !isClosing
   );
 
@@ -79,6 +81,8 @@ export const LightningCloseWithdrawFunds = ({
     const currentRequest = ++quoteRequest.current;
     const quoteDestinationAccountCode = destinationAccountCode;
     setQuote(undefined);
+    setPrepareError(undefined);
+    setConfirmed(false);
 
     try {
       const lightningBalance = await getLightningBalance();
@@ -89,6 +93,7 @@ export const LightningCloseWithdrawFunds = ({
       setHasIncoming(lightningBalance.hasIncoming);
       setIncoming(lightningBalance.incoming);
       if (!lightningBalance.hasAvailable) {
+        setPrepareError(t('error.lightningInsufficientFunds'));
         return;
       }
       if (!quoteDestinationAccountCode) {
@@ -107,10 +112,10 @@ export const LightningCloseWithdrawFunds = ({
     } catch (error) {
       console.error('Failed to prepare Lightning wallet withdrawal', error);
       if (mounted.current && currentRequest === quoteRequest.current) {
-        setStep('failure');
+        setPrepareError(toLightningErrorMessage(t, error));
       }
     }
-  }, [destinationAccountCode, mounted]);
+  }, [destinationAccountCode, mounted, t]);
 
   useEffect(() => {
     if (step !== 'confirm' || isClosing || !destinationAccountCode || quoteMatchesDestination) {
@@ -206,6 +211,7 @@ export const LightningCloseWithdrawFunds = ({
           incoming={incoming}
           incomingConfirmed={incomingConfirmed}
           isClosing={isClosing}
+          prepareError={prepareError}
           onCancel={handleBack}
           onClose={closeWithdraw}
           onConfirmChange={() => setConfirmed(current => !current)}

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
@@ -23,6 +23,7 @@ type TProps = {
   incoming?: TAmountWithConversions;
   incomingConfirmed: boolean;
   isClosing: boolean;
+  prepareError?: string;
   onCancel: () => void;
   onClose: () => void;
   onConfirmChange: () => void;
@@ -61,6 +62,7 @@ export const CloseWithdrawConfirm = ({
   incoming,
   incomingConfirmed,
   isClosing,
+  prepareError,
   onCancel,
   onClose,
   onConfirmChange,
@@ -93,7 +95,7 @@ export const CloseWithdrawConfirm = ({
 
           <section className={styles.section}>
             <h2 className={styles.sectionTitle}>{t('lightning.closeWithdrawFunds.fee')}</h2>
-            <AmountRow amount={fee} />
+            {prepareError ? <Message type="error">{prepareError}</Message> : <AmountRow amount={fee} />}
           </section>
 
           {hasIncoming && (
@@ -124,7 +126,7 @@ export const CloseWithdrawConfirm = ({
             className={styles.confirm}
             id="confirmCloseWithdrawFunds"
             checked={confirmed}
-            disabled={isClosing}
+            disabled={isClosing || !!prepareError}
             onChange={onConfirmChange}
           >
             {t('lightning.closeWithdrawFunds.confirm')}


### PR DESCRIPTION
Closing a wallet with too little balance for the exit fee and dust minimum sent the user to a generic failure screen, hiding the reason preparation failed. The SDK also validates against its cheapest fee, while the app selects the fast fee, so an unusable quote could reach confirmation and fail only when submitted.

Keep preparation errors on the confirmation screen, use the shared Lightning error formatter, and allow retrying without closing the wallet. Reset approval when preparing a new quote and disable closing until preparation succeeds.

Validate the output after the selected fast fee before returning a quote and include that fee in the required minimum balance. Preserve the SDK's preparation reason without exposing its binding error wrapper.

Cover fee and dust boundaries and SDK validation messages in backend tests, and adapt the existing preparation-error navigation test.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
