### PR TITLE
lightning: show disclaimer on Lightning on testnet

### DIFF
--- a/frontends/web/src/components/banners/testing.tsx
+++ b/frontends/web/src/components/banners/testing.tsx
@@ -2,14 +2,17 @@
 
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 import { AppContext } from '@/contexts/AppContext';
 import { SessionStatus } from '@/components/status/status-session';
+import { isLightningRoute } from '@/utils/route';
 
 export const Testing = () => {
   const { t } = useTranslation();
   const { isTesting } = useContext(AppContext);
+  const { pathname } = useLocation();
 
-  if (!isTesting) {
+  if (!isTesting || isLightningRoute(pathname)) {
     return null;
   }
 

--- a/frontends/web/src/contexts/AppContext.tsx
+++ b/frontends/web/src/contexts/AppContext.tsx
@@ -13,7 +13,7 @@ type AppContextProps = {
   guideShown: boolean;
   guideExists: boolean;
   hideAmounts: boolean;
-  isTesting: boolean;
+  isTesting: boolean | undefined;
   isDevServers: boolean;
   vendorIframeActive: boolean;
   isOnline?: boolean;

--- a/frontends/web/src/contexts/AppProvider.tsx
+++ b/frontends/web/src/contexts/AppProvider.tsx
@@ -21,7 +21,7 @@ type TProps = {
 export const AppProvider = ({ children }: TProps) => {
   const { config, setConfig } = useConfig();
   const nativeLocale = i18nextFormat(useDefault(useLoad(getNativeLocale), 'de-CH'));
-  const isTesting = useDefault(useLoad(getTesting), false);
+  const isTesting = useLoad(getTesting);
   const isOnline = useSync(getOnline, subscribeOnline);
   const isDevServers = useDefault(useLoad(getDevServers), false);
   const [guideShown, setGuideShown] = useState(false);

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1875,6 +1875,11 @@
       "partial": "The Spark network is partially unavailable. Lightning payments may be unavailable.",
       "unknown": "The Spark network status is unknown. Lightning payments may be unavailable."
     },
+    "testnetWarning": {
+      "checkboxLabel": "I have read the information above",
+      "message": "Lightning coins have real value, even when using the app in testnet mode. Proceed?",
+      "title": "Warning"
+    },
     "topUp": {
       "action": "Top up",
       "available": "Available",

--- a/frontends/web/src/routes/lightning/testnet-warning.module.css
+++ b/frontends/web/src/routes/lightning/testnet-warning.module.css
@@ -1,0 +1,3 @@
+.acknowledgement {
+    margin: var(--space-default) 0;
+}

--- a/frontends/web/src/routes/lightning/testnet-warning.test.tsx
+++ b/frontends/web/src/routes/lightning/testnet-warning.test.tsx
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../__mocks__/i18n';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
+import { Link, MemoryRouter, useLocation } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getTesting } from '@/api/backend';
+import { Testing } from '@/components/banners/testing';
+import { AppProvider } from '@/contexts/AppProvider';
+import { BackButtonProvider } from '@/contexts/BackButtonContext';
+import translations from '@/locales/en/app.json';
+import { AppRouter } from '../router';
+
+const mocks = vi.hoisted(() => ({
+  lightningPage: vi.fn((): JSX.Element => <p>Lightning page</p>),
+  setConfig: vi.fn(),
+}));
+
+vi.mock('@/i18n/i18n');
+vi.mock('@/api/backend', () => ({
+  getTesting: vi.fn(),
+  getDevServers: () => Promise.resolve(false),
+}));
+vi.mock('@/api/nativelocale', () => ({
+  getNativeLocale: () => Promise.resolve('en'),
+}));
+vi.mock('@/api/online', () => ({
+  getOnline: () => Promise.resolve(true),
+  subscribeOnline: () => () => {},
+}));
+vi.mock('@/contexts/ConfigProvider', () => ({
+  useConfig: () => ({ config: undefined, setConfig: mocks.setConfig }),
+}));
+vi.mock('@/hooks/lightning', () => ({
+  useLightning: () => ({ isLightningAvailable: true }),
+}));
+vi.mock('./lightning', () => ({ Lightning: mocks.lightningPage }));
+vi.mock('./send/send', () => ({ Send: mocks.lightningPage }));
+vi.mock('./activate', () => ({ LightningActivate: mocks.lightningPage }));
+vi.mock('../settings/lightning-settings', () => ({ LightningSettings: mocks.lightningPage }));
+vi.mock('../device/deviceswitch', () => ({ DeviceSwitch: () => <p>Home page</p> }));
+vi.mock('../settings/advanced-settings', () => ({ AdvancedSettings: () => <p>Advanced settings</p> }));
+
+const Navigation = (): JSX.Element => {
+  const { pathname, search } = useLocation();
+  return (
+    <nav>
+      <Link to="/settings/advanced-settings">Leave Lightning</Link>
+      <Link to="/lightning">Open Lightning</Link>
+      <Link to="/settings/lightning-settings">Open Lightning settings</Link>
+      <output aria-label="Current location">{pathname}{search}</output>
+    </nav>
+  );
+};
+
+const renderApp = (path = '/lightning', previousPath?: string) => render(
+  <MemoryRouter initialEntries={previousPath ? [previousPath, path] : [path]}>
+    <AppProvider>
+      <BackButtonProvider>
+        <Navigation />
+        <Testing />
+        <AppRouter
+          accounts={[]}
+          activeAccounts={[]}
+          devices={{}}
+          devicesKey={prefix => prefix}
+          showBottomNavigation={false}
+        />
+      </BackButtonProvider>
+    </AppProvider>
+  </MemoryRouter>,
+);
+
+const warning = () => screen.findByText(translations.lightning.testnetWarning.title);
+const acknowledge = async () => {
+  await userEvent.click(await screen.findByRole('checkbox', { name: translations.lightning.testnetWarning.checkboxLabel }));
+  await userEvent.click(screen.getByRole('button', { name: translations.button.done }));
+};
+
+describe('Lightning in testnet mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getTesting).mockResolvedValue(true);
+  });
+
+  it.each([
+    '/lightning',
+    '/lightning/',
+    '/lightning/activate/',
+    '/lightning/disclaimer',
+    '/lightning/deactivate',
+    '/lightning/set-lnurl-address',
+    '/lightning/claim-top-up',
+    '/lightning/close-withdraw-funds',
+    '/lightning/send',
+    '/lightning/receive',
+    '/lightning/topup',
+    '/LIGHTNING/send',
+    '/light%6eing',
+  ])('warns before opening %s and hides the testnet banner', async path => {
+    renderApp(path);
+
+    expect(await warning()).toBeInTheDocument();
+    expect(screen.getByText(translations.lightning.testnetWarning.message)).toBeInTheDocument();
+    expect(mocks.lightningPage).not.toHaveBeenCalled();
+    expect(screen.queryByText(translations.warning.testnet)).not.toBeInTheDocument();
+  });
+
+  it('keeps the requested destination and remembers acceptance across navigation', async () => {
+    const path = '/lightning/send?paymentRequest=demo';
+    renderApp(path);
+    await acknowledge();
+
+    expect(screen.getByText('Lightning page')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Current location' })).toHaveTextContent(path);
+    expect(screen.queryByText(translations.warning.testnet)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('link', { name: 'Leave Lightning' }));
+    expect(await screen.findByText(translations.warning.testnet)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('link', { name: 'Open Lightning settings' }));
+    expect(screen.getByText('Lightning page')).toBeInTheDocument();
+    expect(screen.queryByText(translations.lightning.testnetWarning.title)).not.toBeInTheDocument();
+    expect(screen.getByText(translations.warning.testnet)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('link', { name: 'Open Lightning' }));
+    expect(screen.getByText('Lightning page')).toBeInTheDocument();
+    expect(screen.queryByText(translations.lightning.testnetWarning.title)).not.toBeInTheDocument();
+    expect(mocks.setConfig).not.toHaveBeenCalled();
+  });
+
+  it('warns again in a new app session', async () => {
+    const { unmount } = renderApp();
+    await acknowledge();
+    expect(screen.getByText('Lightning page')).toBeInTheDocument();
+    unmount();
+
+    renderApp();
+    expect(await warning()).toBeInTheDocument();
+    expect(screen.queryByText('Lightning page')).not.toBeInTheDocument();
+    expect(mocks.setConfig).not.toHaveBeenCalled();
+  });
+
+  it('requires the checkbox before allowing Done', async () => {
+    renderApp();
+    const checkbox = await screen.findByRole('checkbox', { name: translations.lightning.testnetWarning.checkboxLabel });
+    const done = screen.getByRole('button', { name: translations.button.done });
+
+    expect(checkbox).not.toBeChecked();
+    expect(done).toBeDisabled();
+    await userEvent.click(done);
+    expect(mocks.lightningPage).not.toHaveBeenCalled();
+
+    await userEvent.click(checkbox);
+    expect(done).toBeEnabled();
+    await userEvent.click(checkbox);
+    expect(done).toBeDisabled();
+  });
+
+  it('returns to the previous page on X without accepting the warning', async () => {
+    const previousPath = '/settings/advanced-settings?search=lightning';
+    renderApp('/lightning', previousPath);
+    await userEvent.click(await screen.findByRole('checkbox', { name: translations.lightning.testnetWarning.checkboxLabel }));
+    await userEvent.click(screen.getByTestId('close-button'));
+
+    expect(await screen.findByText('Advanced settings')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Current location' })).toHaveTextContent(previousPath);
+    expect(mocks.lightningPage).not.toHaveBeenCalled();
+    expect(await screen.findByText(translations.warning.testnet)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('link', { name: 'Open Lightning' }));
+    expect(await warning()).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    expect(screen.getByRole('button', { name: translations.button.done })).toBeDisabled();
+  });
+
+  it('returns home on X when opened directly without an earlier page', async () => {
+    renderApp();
+    await userEvent.click(await screen.findByTestId('close-button'));
+
+    expect(await screen.findByText('Home page')).toBeInTheDocument();
+    expect(mocks.lightningPage).not.toHaveBeenCalled();
+  });
+
+  it('treats the system back button as cancellation', async () => {
+    renderApp('/lightning', '/settings/advanced-settings');
+    await warning();
+
+    act(() => {
+      window.onBackButtonPressed?.();
+    });
+
+    expect(await screen.findByText('Advanced settings')).toBeInTheDocument();
+    expect(mocks.lightningPage).not.toHaveBeenCalled();
+  });
+
+  it('waits for the network mode before mounting a Lightning page', async () => {
+    let resolveTesting: (testing: boolean) => void = () => {};
+    vi.mocked(getTesting).mockReturnValue(new Promise(resolve => {
+      resolveTesting = resolve;
+    }));
+    renderApp();
+
+    expect(mocks.lightningPage).not.toHaveBeenCalled();
+    expect(screen.queryByText(translations.lightning.testnetWarning.title)).not.toBeInTheDocument();
+
+    await act(async () => resolveTesting(true));
+    expect(await warning()).toBeInTheDocument();
+    expect(mocks.lightningPage).not.toHaveBeenCalled();
+  });
+
+  it('does not show a warning or testnet banner on mainnet', async () => {
+    vi.mocked(getTesting).mockResolvedValue(false);
+    renderApp();
+
+    expect(await screen.findByText('Lightning page')).toBeInTheDocument();
+    expect(screen.queryByText(translations.lightning.testnetWarning.title)).not.toBeInTheDocument();
+    expect(screen.queryByText(translations.warning.testnet)).not.toBeInTheDocument();
+  });
+
+  it.each([
+    '/settings/advanced-settings',
+    '/settings/lightning-settings',
+    '/settings/lightning-settings/',
+  ])('keeps the testnet banner on %s without showing the Lightning warning', async path => {
+    renderApp(path);
+
+    expect(await screen.findByText(translations.warning.testnet)).toBeInTheDocument();
+    expect(screen.queryByText(translations.lightning.testnetWarning.title)).not.toBeInTheDocument();
+  });
+
+  it('still warns on entering the account after visiting Lightning settings', async () => {
+    renderApp('/settings/lightning-settings');
+    expect(await screen.findByText('Lightning page')).toBeInTheDocument();
+    expect(screen.queryByText(translations.lightning.testnetWarning.title)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('link', { name: 'Open Lightning' }));
+    expect(await warning()).toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/routes/lightning/testnet-warning.tsx
+++ b/frontends/web/src/routes/lightning/testnet-warning.tsx
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ReactNode, useContext, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Dialog, DialogButtons, DialogScrollContent } from '@/components/dialog/dialog';
+import { Button, Checkbox } from '@/components/forms';
+import { Header, Main } from '@/components/layout';
+import { Message } from '@/components/message/message';
+import { AppContext } from '@/contexts/AppContext';
+import styles from './testnet-warning.module.css';
+
+type TWarningProps = {
+  onAccept: () => void;
+  onCancel: () => void;
+};
+
+const LightningTestnetWarning = ({ onAccept, onCancel }: TWarningProps) => {
+  const { t } = useTranslation();
+  const [understood, setUnderstood] = useState(false);
+
+  return (
+    <Main>
+      <Header title={<h2>{t('lightning.accountLabel')}</h2>} />
+      <Dialog open title={t('lightning.accountLabel')} onClose={onCancel}>
+        <DialogScrollContent>
+          <Message type="warning">
+            <strong>{t('lightning.testnetWarning.title')}</strong>
+            <p>{t('lightning.testnetWarning.message')}</p>
+          </Message>
+          <div className={styles.acknowledgement}>
+            <Checkbox
+              id="lightning-testnet-warning-understood"
+              checked={understood}
+              onChange={event => setUnderstood(event.target.checked)}
+              label={t('lightning.testnetWarning.checkboxLabel')}
+            />
+          </div>
+        </DialogScrollContent>
+        <DialogButtons>
+          <Button primary disabled={!understood} onClick={onAccept}>
+            {t('button.done')}
+          </Button>
+        </DialogButtons>
+      </Dialog>
+    </Main>
+  );
+};
+
+type TProps = {
+  active: boolean;
+  children: ReactNode;
+};
+
+export const LightningTestnetGuard = ({ active, children }: TProps) => {
+  const { isTesting, sessionConfig, updateSessionConfig } = useContext(AppContext);
+  const { key } = useLocation();
+  const navigate = useNavigate();
+
+  if (!active) {
+    return children;
+  }
+  if (isTesting === undefined) {
+    return null;
+  }
+  if (!isTesting || sessionConfig.lightningTestnetWarningAccepted) {
+    return children;
+  }
+
+  const cancel = () => {
+    if (key === 'default') {
+      navigate('/', { replace: true });
+    } else {
+      navigate(-1);
+    }
+  };
+
+  return (
+    <LightningTestnetWarning
+      onAccept={() => updateSessionConfig({ lightningTestnetWarningAccepted: true })}
+      onCancel={cancel}
+    />
+  );
+};

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactChild } from 'react';
-import { Navigate, Route, Routes, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { TAccount } from '@/api/account';
 import { TDevices } from '@/api/devices';
 import { AddAccount } from './account/add/add-account';
@@ -54,6 +54,8 @@ import { LightningTopUp } from './lightning/topup/topup';
 import { LightningClaimTopUp } from './lightning/claim-top-up/claim-top-up';
 import { LightningCloseWithdrawFunds } from './lightning/close-and-withdraw-funds/close-withdraw-funds';
 import { isLightningFeatureAvailable } from '@/utils/env';
+import { isLightningRoute } from '@/utils/route';
+import { LightningTestnetGuard } from './lightning/testnet-warning';
 
 type TAppRouterProps = {
   devices: TDevices;
@@ -81,6 +83,7 @@ export const AppRouter = ({
 }: TAppRouterProps) => {
   const hasAccounts = accounts.length > 0;
   const lightningFeatureAvailable = isLightningFeatureAvailable();
+  const { pathname } = useLocation();
   const Homepage = (<DeviceSwitch
     key={devicesKey('device-switch-default')}
     deviceID={null}
@@ -304,7 +307,7 @@ export const AppRouter = ({
 
   const AllAccountsEl = <InjectParams><AllAccounts accounts={activeAccounts} /></InjectParams>;
 
-  return (
+  const routes = (
     <Routes>
       <Route path="/">
         <Route index element={Homepage} />
@@ -408,5 +411,11 @@ export const AppRouter = ({
         </Route>
       </Route>
     </Routes>
+  );
+
+  return (
+    <LightningTestnetGuard active={lightningFeatureAvailable && isLightningRoute(pathname)}>
+      {routes}
+    </LightningTestnetGuard>
   );
 };

--- a/frontends/web/src/routes/settings/settings-availability.ts
+++ b/frontends/web/src/routes/settings/settings-availability.ts
@@ -6,7 +6,7 @@ import { debug, isLightningFeatureAvailable, runningInAndroid, runningInIOS } fr
 
 type TTestWalletVisibilityArgs = {
   deviceIDs: string[];
-  isTesting: boolean;
+  isTesting: boolean | undefined;
 };
 
 type TDeviceInfoWithBluetooth = DeviceInfo & {
@@ -36,4 +36,4 @@ export const isExportLogsSettingVisible = () => !debug;
 export const isTestWalletSettingVisible = ({
   deviceIDs,
   isTesting,
-}: TTestWalletVisibilityArgs) => isTesting && deviceIDs.length === 0;
+}: TTestWalletVisibilityArgs) => isTesting === true && deviceIDs.length === 0;

--- a/frontends/web/src/routes/settings/settings-search.test.ts
+++ b/frontends/web/src/routes/settings/settings-search.test.ts
@@ -19,6 +19,8 @@ vi.mock('@/utils/env', () => ({
 const translations: Record<string, string> = {
   'lightning.settings.enableWallet': 'Enable lightning wallet',
   'lightning.settings.title': 'Lightning settings',
+  'testnet.activate.title': 'Activate testnet',
+  'testnet.deactivate.title': 'Deactivate testnet',
   'testWallet.connect.title': 'Test wallet',
   'testWallet.disconnect.title': 'Disconnect test wallet',
 };
@@ -40,6 +42,27 @@ const getItems = (
 describe('settings search', () => {
   beforeEach(() => {
     isLightningFeatureAvailableMock.mockReturnValue(true);
+  });
+
+  it.each([
+    { isTesting: undefined, title: undefined },
+    { isTesting: false, title: 'Activate testnet' },
+    { isTesting: true, title: 'Deactivate testnet' },
+  ])('shows the correct testnet setting for isTesting=$isTesting', ({ isTesting, title }) => {
+    const items = getSettingsSearchItems({
+      devices: {},
+      hasAccounts: true,
+      hasSoftwareKeystore: false,
+      isLightningEnabled: true,
+      isTesting,
+      t,
+    });
+
+    expect(items.find(item => item.id === 'testnet-mode')).toEqual(title === undefined ? undefined : {
+      id: 'testnet-mode',
+      page: 'advanced',
+      title,
+    });
   });
 
   it('uses the connect title for the test wallet setting when no software wallet exists', () => {

--- a/frontends/web/src/routes/settings/settings-search.ts
+++ b/frontends/web/src/routes/settings/settings-search.ts
@@ -26,7 +26,7 @@ type TGetSettingsSearchItemsArgs = {
   hasAccounts: boolean;
   isLightningEnabled: boolean | undefined;
   hasSoftwareKeystore: boolean;
-  isTesting: boolean;
+  isTesting: boolean | undefined;
   t: TFunction;
 };
 
@@ -90,6 +90,7 @@ const SETTINGS_SEARCH_DESCRIPTORS: TSettingsSearchDescriptor[] = [
   },
   {
     id: 'testnet-mode',
+    isAvailable: ({ isTesting }) => isTesting !== undefined,
     getTitle: ({ isTesting, t }) => isTesting ? t('testnet.deactivate.title') : t('testnet.activate.title'),
     page: 'advanced',
   },

--- a/frontends/web/src/utils/route.tsx
+++ b/frontends/web/src/utils/route.tsx
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useContext, useEffect } from 'react';
-import { NavigateFunction, useLocation, useNavigate } from 'react-router-dom';
+import { matchRoutes, NavigateFunction, useLocation, useNavigate } from 'react-router-dom';
 import { AppContext } from '@/contexts/AppContext';
 
 let navigate: NavigateFunction | undefined;
+
+export const isLightningRoute = (pathname: string) => matchRoutes([
+  { path: '/lightning/*' },
+], pathname) !== null;
 
 /**
  * @deprecated preact-router like. Use `useNavigate` hook if possible


### PR DESCRIPTION
When an user tries to access their lightning account while on testnet, show them a warning to tell them that LN works on mainnet and that they have real funds there.

Also don't show the testnet banner when on lightning, as that would be confusing for users.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
