### PR TITLE
frontend: restore scrolling above bottom navigation on iOS

### DIFF
--- a/frontends/web/src/app.module.css
+++ b/frontends/web/src/app.module.css
@@ -40,8 +40,11 @@
        max-height: 100dvh;
     }
 
-    .appContent.hasBottomNavigation main {
-        padding-bottom: var(--bottom-navigation-scroll-space);
+    .appContent.hasBottomNavigation main::after {
+        /* WebKit can omit flex container padding from scrollable overflow.
+           https://bugs.webkit.org/show_bug.cgi?id=316902 */
+        content: '';
+        flex: 0 0 var(--bottom-navigation-scroll-space);
     }
 
     .tabTransition {


### PR DESCRIPTION
WebKit 26.4 can omit flex container padding from scrollable overflow, leaving the LNURL send button behind the bottom navigation with no room to scroll. Replace the mobile bottom padding with a non-shrinking flex spacer to preserve that scroll space.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
