### PR TITLE
eth: handle missing fees in pending transactions

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -437,7 +437,7 @@ func pendingTxsAmount(outgoingTransactionsData []*accounts.TransactionData, isEr
 			if tx.Type == accounts.TxTypeSend {
 				pendingTxAmount = pendingTxAmount.Add(pendingTxAmount, tx.Amount.BigInt())
 			}
-			if !isErc20 {
+			if !isErc20 && tx.Fee != nil {
 				// tx Fee is considered only for ETH transactions. For ERC20 tokens it should
 				// be subtracted to the balance of the related ETH account. This is not done at
 				// the moment, could be possibly fixed in the future migrating to BlockBook.

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -446,6 +446,26 @@ func TestUpdateOutgoingTransactionsStillChecksPendingTransactions(t *testing.T) 
 	require.Equal(t, 0, sendCalls)
 }
 
+func TestPendingTxsAmountWithInternalTransfer(t *testing.T) {
+	fee := coin.NewAmountFromInt64(2)
+	transactions := []*accounts.TransactionData{
+		{
+			Type:   accounts.TxTypeSend,
+			Status: accounts.TxStatusPending,
+			Amount: coin.NewAmountFromInt64(10),
+			Fee:    &fee,
+		},
+		{
+			// Internal ETH transfers have no separate fee.
+			Type:   accounts.TxTypeReceive,
+			Status: accounts.TxStatusPending,
+			Amount: coin.NewAmountFromInt64(20),
+		},
+	}
+
+	require.Equal(t, big.NewInt(12), pendingTxsAmount(transactions, false))
+}
+
 func TestMatchesAddress(t *testing.T) {
 	acct := newAccount(t)
 	defer acct.Close()


### PR DESCRIPTION
Internal ETH transfers have no separate fee, so Etherscan represents their fee as nil.
Successful transfers remain pending until 12 confirmations. Account updates include these
transfers in pendingTxsAmount(), which dereferences the fee unconditionally for ETH accounts.

Refreshing an account with a recent internal transfer can therefore panic in a background
goroutine and terminate the app. This can happen after sending, during startup, or during
periodic synchronization, including for incoming internal transfers. The amount is irrelevant.

Restarting can encounter the same transfer until it reaches 12 confirmations. Clearing the
cache does not directly resolve this condition; time spent clearing it and rebooting may
allow the transfer to reach the confirmation threshold.

Skip absent fees when computing the pending amount.
